### PR TITLE
Record the standing rule: CI and tests are not optional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,48 @@ a defect.
 required doc fields, CLI examples that no longer match actual output, and
 capability-matrix claims not backed by a passing container test.
 
+## CI and tests are not optional
+
+**Every project here gets working CI and a real test suite, and their absence is
+a defect to fix rather than a state to work around.** A maintainer preference,
+recorded once and applying from here on — it does not need asking about again.
+
+This repository already largely does this: eight CI jobs, `mypy --strict` as a
+gate, container-based target tests, and a docs link checker. What follows is
+the reasoning behind the rule, learned the hard way in the sibling project
+[hammunition-hill](https://github.com/ChiefGyk3D/hammunition-hill), so that it
+survives contact with the next repository rather than living in one person's
+head.
+
+- **Put checks in the test suite; let CI run the test suite.** A CI-only script
+  rots, because nobody can run it locally and nobody notices when it stops
+  meaning anything.
+- **A check must be falsifiable.** Break the thing it watches on purpose and
+  confirm it goes red with a message naming the fix, before trusting it. One
+  check in the sibling project was silently passing on the exact input it
+  existed to catch — a comment-stripping regex ate the `//` in `https://`.
+- **Test the matrix, not your machine.** An ElementTree truthiness bug there
+  passed on the dev venv's Python 3.11 and failed on 3.12+. It was a real bug,
+  not a warning to silence.
+- **A check nobody trusts is worse than none.** Two were deliberately left out
+  for that reason: a formatter that would reflow 36 hand-formatted files for no
+  defect caught, and whole-environment dependency auditing that would report
+  advisories against the runner's own pip.
+- **Prove properties, not just behaviour.** That project's test suite blocks
+  every socket to anywhere but loopback, so it cannot quietly depend on the real
+  internet; and it asserts the feature counts in its README against the code,
+  because the README claimed twelve panels for months after there were nineteen.
+- **Run it and look at it.** Three separate visual bugs there passed every test
+  and were found by rendering the page.
+- **Measure before claiming.** An importer's first version needed ~620 MB of RAM
+  at real scale, more than a Pi Zero has, while its docstring claimed the
+  opposite.
+- **Never pin an action from memory; resolve it.** Every pin in that project's
+  first workflow was a real commit and two major versions stale, and one failed
+  outright against the runner's newer CLI. `git ls-remote --tags` is the check.
+  Worth a look here too: this repository's `actions/checkout@v4` is three majors
+  behind current.
+
 ## Conventions
 
 - Idempotent: every operation safe to re-run


### PR DESCRIPTION
A maintainer preference, stated once and applying from here on rather than needing to be asked for per project. Documentation only — one new section in `CLAUDE.md`.

**This repository already largely does it**: eight CI jobs, `mypy --strict` as a gate, container-based target tests, a docs link checker. What's added is the *reasoning*, so the rule survives contact with the next repository instead of living in one person's head.

Each bullet carries the specific failure that taught it, all from the sibling project [hammunition-hill](https://github.com/ChiefGyk3D/hammunition-hill) where CI was built from scratch this week:

- **Checks belong in the test suite** — a CI-only script rots because nobody can run it locally.
- **A check must be falsifiable** — one there was silently passing on the exact input it existed to catch, because a comment-stripping regex ate the `//` in `https://`.
- **Test the matrix** — an ElementTree truthiness bug passed on the dev venv's 3.11 and failed on 3.12+.
- **A check nobody trusts is worse than none** — two were deliberately left out for this reason.
- **Prove properties, not behaviour** — that suite blocks every non-loopback socket, and asserts its README's feature counts against the code.
- **Run it and look at it** — three visual bugs passed every test.
- **Measure before claiming** — an importer needed ~620 MB at real scale while its docstring said otherwise.
- **Never pin an action from memory** — every pin in that first workflow was real and two majors stale; one failed outright against the runner's newer CLI.

## One observation, deliberately not acted on

That last bullet applies here: `actions/checkout@v4` is three majors behind current (v7.0.1), and `setup-python@v5` behind v7.

I have **not** changed them. Floating major tags are a different and defensible choice from SHA pinning — they pick up patches automatically, at the cost of not advancing across majors — and which this project wants is your call, not a drive-by edit in a docs PR. Happy to do it either way if you want it.

## Verification

`scripts/check_doc_links.py`: 153 internal references, none broken.

Opened as a draft since this is the first change I've made to this repository — say the word and I'll merge it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRuecujkLKs3NbDdLTdhNg)_