### PR TITLE
plan: defer a profile member the target does not offer (D-039, resolves Q-017)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ Do not re-litigate these without being asked:
 | Node builds | Allowed when disclosed as a requirement; refused at plan time when Node is absent or too old; Node only from the distribution | openhamclock is the Q-006 default and publishes no binary (**D-037**) |
 | Node builds | Disclosed as a requirement; refused at plan time when Node is absent or too old; never fetched | openhamclock is a Vite app and `curl | bash` for Node is the habit we refuse (**D-037**) |
 | Mixed-release targets | Resolve from the release the machine already installs from, disclosed by name; never downgrade, never guess a release | Parrot's baseline takes 197 packages from backports and five profiles died at the first apt command (**D-038**) |
+| Profile members a target lacks | Deferred by name, the rest installs; a name the operator typed, an engine gap or a manifest defect still refuses | `listening` withheld nineteen units on Ubuntu 24.04 over four the archive lacks (**D-039**) |
 
 Full reasoning and evidence in `docs/DECISIONS.md`, which is authoritative.
 
@@ -447,11 +448,14 @@ longer a design question in the abstract; a shipped manifest depends on it. See
 `ohb.works` as the backend; SuperSDR is carried under **D-033**; cellular
 tooling is staged under **D-034**.
 
-**Q-017 is open** (raised 2026-09-02): whether a profile member the target's
-archive does not carry withholds the whole profile (D-016) or is deferred by
-name (D-035). Five of fifteen profiles do not install whole on Ubuntu 24.04
-over it; `docs/reference/vm-campaign-ubuntu.md` is the evidence. It does not
-block work — every unit still installs by name.
+**Q-017 is resolved as D-039** (2026-09-03): a profile member the target does
+not offer — no install block, no apt candidate for its *own* packages, Node
+below its floor — is deferred by name and the rest of the profile installs.
+A name the operator typed, an engine gap (`code`/`codium` need apt_repos), a
+missing `depends`/`build_depends`, a retired status, and a profile with every
+member deferred all still refuse. Deferrals are logged (`transaction_begin`
+version 2) and shown by `status`. `docs/reference/vm-campaign-ubuntu.md` is
+the evidence it was decided on.
 
 ## Roadmap — 1.0 is the five-source union
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2405,3 +2405,80 @@ neither judges nor changes it. And whether a release-specific plan should
 be recorded in the transaction log beyond the argv it already carries; the
 `--target-release` flag is in the printed and logged command, which is the
 disclosure D-031 asks for.
+
+## D-039 — A profile member the target does not offer is deferred by name and the rest of the profile installs; a member the operator named, an engine gap, or a manifest defect still refuses the transaction
+
+**Date:** 2026-09-03. **Status:** accepted; resolves Q-017.
+**Depends on:** D-016 (refuse at plan time, never partway), D-035 (a
+missing value defers one file, never the transaction), D-037 (Node only from
+the distribution), D-031 (verify the effect, not the exit status).
+**Amends:** D-016, which held that a transaction resolves whole or not at
+all. It still does, for everything the operator asked for by name. The
+exception is drawn around one thing: a *profile* member that the *target*
+does not offer.
+
+**What was measured.** The full-catalog campaigns on Ubuntu 24.04 and 26.04
+(`docs/reference/vm-campaign-ubuntu.md`, 2026-09-02): every unit planned
+and installed by name, and then **five of fifteen profiles refused whole on
+24.04, two on 26.04**, each over members refused for a reason true of the
+target — `listening` withheld nineteen installable units because the 24.04
+archive carries neither `readsb`, `rtl-ais`, `satdump` nor
+`mlat-client-adsbfi`; `propagation` withheld everything because Node 18.19
+is below openhamclock's 20.19 floor and 24.04 carries no `voacapl`. The
+operator's remedy was to install the nineteen by name, which is the
+fix-one-re-run loop D-016 exists to end, arriving from the other side.
+
+**The rule.** A package that reached the plan only through a profile, or as
+a catalog dependency of one, is **deferred** rather than refused when the
+reason is one of exactly three, each a fact about the target:
+
+1. the catalog declares no install block matching this distro, version and
+   architecture (D-002's selector, honestly negative);
+2. apt on this release has no candidate for **the unit's own packages** —
+   the `packages:` of its apt block, and only those;
+3. the distribution's `nodejs` is absent or below the manifest's floor
+   (D-037).
+
+A deferred member's catalog dependents defer with it, each naming the
+dependency it lost. Deferrals are printed under *Will NOT happen*, written
+to the transaction log (`transaction_begin` version 2, `deferred`), and
+reported by `hammunition status` for as long as that transaction is the most
+recent one.
+
+**What still refuses, by name.** Everything that is not one of those three:
+
+- **A name the operator typed.** `hammunition install satdump` on 24.04 is
+  a request to see the refusal, and it sees it in full. A unit named both
+  directly and through a profile is a named request.
+- **An engine gap.** `code` and `codium` are refused on every target because
+  the engine has no `apt_repos` backend yet, not because any archive lacks
+  them; deferring them would make the missing backend invisible.
+  `workstation` refuses whole until that backend exists, which is the test
+  Q-017 set for the classification.
+- **A missing `depends` or `build_depends`.** Those are the manifest's, not
+  the target's: D-016 names four AHRL dependency lines that went stale
+  exactly this way, and a deferral that swallowed them would hide the defect
+  the check was written to find.
+- **A retired or broken status**, a declined consent gate (D-021), a
+  verification failure (D-018), a declared package conflict (D-022), and an
+  apt simulation that cannot resolve (D-038). None is a fact about what the
+  archive offers.
+- **A profile whose every member is deferred.** Installing nothing and
+  reporting success is the shape D-031 exists to catch; it refuses naming
+  the profile and each member's reason.
+
+**Why the line is here and not wider.** Q-017's three options were: defer
+(this), fix each gap in the catalog with `when:` selectors, or a
+`--defer-unavailable` flag. The selectors would freeze one evening's
+`apt-cache policy` into data meant to describe software, and would still
+produce the same partial install, made silently in the catalog instead of
+reported by the engine. The flag is `--yes` for consent gates over again:
+the option everyone passes, at which point it is the default with a worse
+name (D-021). What makes deferral safe is not the mechanism but the
+classification, so the classification is the decision.
+
+**Rejected while building it:** deferring on any no-candidate result. A
+unit's `depends` line naming a package the archive lacks is indistinguishable
+from its own package being absent unless the plan checks which list the
+name came from — so it checks, and defers only when every missing name is
+in the unit's own `packages:`.

--- a/docs/QUESTIONS.md
+++ b/docs/QUESTIONS.md
@@ -810,7 +810,19 @@ pinned artefact or left to the built-in model.
 
 ---
 
-## Q-017 🟡 — A per-target gap in one profile member: refuse the profile (D-016), or defer the member (D-035)?
+## Q-017 ✅ — A per-target gap in one profile member: refuse the profile (D-016), or defer the member (D-035)? — **RESOLVED 2026-09-03**
+
+**A, as recommended, recorded as D-039.** A profile member is deferred when
+the reason is one of three facts about the target (no install block, no apt
+candidate for the unit's *own* packages, Node below the floor); its catalog
+dependents defer with it; a name the operator typed, an engine gap, a
+missing `depends`/`build_depends`, a retired status, and a profile with
+every member deferred all still refuse. Deferrals are logged
+(`transaction_begin` version 2) and shown by `status`. `workstation` still
+refuses whole over `code`/`codium` until the apt_repos backend exists, which
+was the test. Tests: `tests/test_profile_deferral.py`.
+
+The original question, as raised:
 
 **Raised 2026-09-02**, from the full-catalog campaigns on Ubuntu 24.04 and
 26.04 (`docs/reference/vm-campaign-ubuntu.md`). Every unit was planned and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -324,10 +324,21 @@ Resolution is a distinct phase that finishes before anything is executed
    one release, the question is asked a third time with `--target-release`
    naming it; a yes is carried into the apt command and the plan lists what
    that release supplies (**D-038**). Any other refusal is the plan's.
-7. **Print the plan**, in full, for every run and not only for `--dry-run`.
-8. **Present any consent gate**, then confirm, then execute.
+7. **Defer what the target does not offer** — but only for a member that
+   reached the plan through a *profile*, and only for one of three reasons
+   that are facts about the target: no install block matches this
+   distro/version/arch, apt on this release has no candidate for the unit's
+   *own* packages, or the distribution's Node is below the manifest's floor.
+   The member and its catalog dependents are listed under *Will NOT happen*
+   with the reason, and the rest of the profile installs (**D-039**). A
+   name you typed is never deferred: `hammunition install satdump` on
+   Ubuntu 24.04 shows the refusal in full. An engine gap, a missing
+   `depends` or `build_depends`, a retired status, and a profile with every
+   member deferred all still refuse the transaction.
+8. **Print the plan**, in full, for every run and not only for `--dry-run`.
+9. **Present any consent gate**, then confirm, then execute.
 
-If anything in steps 2–6 fails, **every** failure is printed together and
+If anything in steps 2–7 fails, **every** failure is printed together and
 nothing is changed. Reporting only the first would have the same shape as the
 defect this is built against: fix one, re-run, meet the next.
 
@@ -349,7 +360,8 @@ capability matrix that reports coverage the engine does not have is the shim
 | An apt transaction apt itself **cannot resolve** as one `apt-get install` — the packages all exist, and the set of them still does not install | `apt: cannot resolve this transaction as one apt-get install`, then apt's own words, indented, and the simulate command that reproduces it. When the reason is that an installed package would be downgraded and it is installed from one other release, the plan is first retried from that release (**D-038**) and this row is reached only if that fails too. Five Parrot profiles passed the plan and died at the first apt command before this row existed (2026-09-02) |
 | A `system_modifications` kind other than `group_membership` | the kind, by name |
 | A package whose status is `broken` or `retired` | the recorded reason, verdict and date |
-| A dependency apt has no candidate for | which name, and whether it came from `install` or `depends` |
+| A dependency apt has no candidate for | which name, and whether it came from `install` or `depends`. A *profile* member whose own `install` packages are the ones missing is deferred instead (**D-039**), and the row above still applies to its `depends` |
+| A profile every member of which this target cannot install | the profile by name, with each member's reason — installing nothing and reporting success is not an outcome (**D-039**) |
 | No apt package lists at all | that this is a stale-lists problem, with `--refresh` as the remedy |
 | A group membership with no identifiable operator | that `--user` is needed |
 
@@ -560,7 +572,12 @@ its log entry carries `verified: false`.
 transaction ended** — completed, failed after N commands, or interrupted with
 no ending recorded — never just what it set out to do, and for a completed run
 whether its effects were **confirmed afterwards** or came back unverified. A run
-that died partway is not reported as if it finished.
+that died partway is not reported as if it finished. What that run **deferred
+by design** — a profile member the target does not offer (**D-039**), a
+configuration file a station value was missing for (**D-035**) — is listed
+after the packages it intended, from the `deferred` entry the log has carried
+since `transaction_begin` version 2, so a profile that landed eighteen of
+twenty-two still reads that way a week later.
 
 Hammunition does not roll back. It tells you what it did (**D-004**). On a
 failure the run stops at that command, and the count that completed is printed

--- a/docs/reference/transaction-log.md
+++ b/docs/reference/transaction-log.md
@@ -54,7 +54,7 @@ exit does.
 
 | `event` | Written | Carries |
 |---|---|---|
-| `transaction_begin` | Once, first | `target`, the manifest `packages` requested, the `apt_packages` the whole set resolved to. |
+| `transaction_begin` | Once, first | `target`, the manifest `packages` requested, the `apt_packages` the whole set resolved to. **Version 2** (2026-09-03) adds `deferred`: one `{kind, subject, what, why}` per thing the plan chose not to do — `kind: package` for a profile member the target does not offer (**D-039**), `kind: config` for a file a station value was missing for (**D-035**). `status` prints them; a version 1 entry has no key and nothing is inferred from its absence. |
 | `command_begin` | Before each command | `argv`, `requires_root`, `description`. |
 | `command_end` | After each command that ran | `argv`, `returncode`. |
 | `action_begin` | Before each in-process step | `kind` (`fetch`, `extract`, `config`, `requirements`, `wrapper`, `desktop-entry`, `patch`, `prepare`, `install-binary`, `verify-pin`, `remove-venv`, `remove-wrapper`, `remove-desktop-entry`), `detail`, `description`. |

--- a/docs/reference/vm-campaign-ubuntu.md
+++ b/docs/reference/vm-campaign-ubuntu.md
@@ -81,6 +81,25 @@ members are refused for an engine gap, not an archive gap — and stays refused
 until the apt_repos backend exists. Whether this table now installs whole on
 the VMs is the next campaign's measurement, not this one's claim.
 
+**Measured 2026-09-03, Ubuntu 24.04, engine at `05f3db0`, each profile
+from the clean-baseline snapshot** (`~/.local/state/hammunition-campaigns/
+ubuntu2404-deferral-2026-09-03.md`):
+
+| Profile | Outcome | Deferred, by the plan's own words | Seconds |
+|---|---|---|---:|
+| `satellite` | **installed+confirmed** | `satdump` — no candidate | 101 |
+| `electronics` | **installed+confirmed** | `m2kcli` — no candidate | 177 |
+| `propagation` | **installed+confirmed** | `openhamclock` — nodejs 18.19.1 below the 20.19 floor; `pythonprop`, `voacapl` — no candidate | 819 |
+| `listening` | **installed+confirmed** | `mlat-client-adsbfi`, `readsb`, `rtl-ais`, `satdump` — no candidate | 233 |
+| `workstation` | refused (plan) | — `code`, `codium`: engine gap, as the classification requires | 1 |
+
+Four of the five that refused whole on 2026-09-02 now install whole, with
+every deferral printed under *Will NOT happen* naming the member, the
+reason and the by-name command that shows the refusal in full. The fifth
+refused for the reason D-039 says it must. The deferred names are from a
+`--dry-run` of each profile on the same VM after the campaign, because the
+campaign report records outcomes and seconds, not plans.
+
 ## What the whole-profile runs found, and what was fixed
 
 **`digital-modes` on Kali planned clean and failed after forty-four

--- a/docs/reference/vm-campaign-ubuntu.md
+++ b/docs/reference/vm-campaign-ubuntu.md
@@ -72,8 +72,14 @@ member withholds the profile:
 
 Five of fifteen on 24.04, two on 26.04, one on Debian and Parrot. Whether
 a member the archive does not carry should withhold the profile (D-016) or
-be deferred by name the way a config file is (D-035) is **Q-017**, and it
-is the maintainer's; the table is its evidence.
+be deferred by name the way a config file is (D-035) was **Q-017**; the
+table is its evidence, and it was resolved on 2026-09-03 as **D-039**: the
+`m2kcli`, `readsb`, `rtl-ais`, `satdump`, `mlat-client-adsbfi`,
+`openhamclock`, `voacapl`, `pythonprop` and `gr-gsm` rows now defer by name
+and the rest of each profile installs. The `workstation` row does not — its
+members are refused for an engine gap, not an archive gap — and stays refused
+until the apt_repos backend exists. Whether this table now installs whole on
+the VMs is the next campaign's measurement, not this one's claim.
 
 ## What the whole-profile runs found, and what was fixed
 
@@ -129,7 +135,7 @@ it is built on evidence and not forgotten.
 
 ## Left with the maintainer
 
-- Q-017, above.
+- ~~Q-017, above.~~ Resolved as D-039, 2026-09-03.
 - The third-party-repository backend (`code`, `codium` on every target).
 - Ubuntu 24.04 as a declared target in `containers/targets.yaml` and the
   capability matrix, now that it is measured — or Linux Mint 22.3 as its

--- a/src/hammunition/cli/main.py
+++ b/src/hammunition/cli/main.py
@@ -443,6 +443,17 @@ def cmd_status(args: argparse.Namespace) -> int:
         )
     for name in intended:
         print(f"    {name}")
+    # transaction_begin version 2 records what the plan deferred (D-039): a
+    # profile member this target's archive does not carry, or a station value
+    # a config file needed and did not have. A version 1 entry has no key and
+    # nothing is inferred from its absence.
+    deferred = begin.get("deferred", [])
+    if deferred:
+        print(f"  deferred in that transaction, by design ({len(deferred)}):")
+        for entry in deferred:
+            print(
+                f"    {entry.get('subject', '?')}: {entry.get('what', '')} -- {entry.get('why', '')}"
+            )
     return EXIT_OK
 
 

--- a/src/hammunition/execute.py
+++ b/src/hammunition/execute.py
@@ -601,11 +601,15 @@ def execute(
     log.append(
         {
             "event": "transaction_begin",
-            "version": 1,
+            # Version 2 adds `deferred` (Q-017 / D-039): what the plan chose
+            # NOT to do, so a `status` read later knows the run installed
+            # eighteen of a profile's twenty-two on purpose, not by accident.
+            "version": 2,
             "timestamp": datetime.now(UTC).isoformat(),
             "target": plan.target.to_log_entry(),
             "packages": [p.name for p in plan.packages],
             "apt_packages": list(plan.apt_to_install),
+            "deferred": [d.to_log_entry() for d in plan.deferrals],
         }
     )
 

--- a/src/hammunition/plan.py
+++ b/src/hammunition/plan.py
@@ -49,6 +49,7 @@ from hammunition.backends.apt import downgrades_refused
 from hammunition.backends.source import IMPLEMENTED_BUILD_SYSTEMS
 from hammunition.distro import Target
 from hammunition.manifest.schema import (
+    AptInstall,
     BinaryInstall,
     ConfigFile,
     ConsentGate,
@@ -108,6 +109,11 @@ class Deferral:
     `linbpq` did not know a callsign. Nineteen packages installed and one file
     not written is a better outcome than nothing installed, and it is only
     honest if the unwritten file is reported rather than skipped.
+
+    Q-017 extended it to a *profile member the target does not offer*: on
+    Ubuntu 24.04 `listening` withheld nineteen installable units over four the
+    archive does not carry. Same shape, same rule -- most of what was asked
+    for happens, the part that does not is named, and `status` keeps naming it.
     """
 
     subject: str
@@ -117,9 +123,16 @@ class Deferral:
     """What is missing."""
     remedy: str
     """What the operator can do about it."""
+    kind: str = "config"
+    """``config`` (D-035: a file not written) or ``package`` (Q-017: a profile
+    member not installed). Recorded in the transaction log so `status` can
+    tell them apart."""
 
     def render(self) -> str:
         return f"{self.subject}: {self.what}\n    why: {self.why}\n    → {self.remedy}"
+
+    def to_log_entry(self) -> dict[str, str]:
+        return {"kind": self.kind, "subject": self.subject, "what": self.what, "why": self.why}
 
 
 class PlanError(Exception):
@@ -611,8 +624,8 @@ def _check_node_floor(
             subject=manifest.name,
             reason=(
                 f"is a Node.js application needing Node {floor} or newer, and this "
-                f"distribution's nodejs is {version} ({source}) — "
-                f"{found[0]}.{found[1]}"
+                f"distribution's nodejs is {version} ({source}): "
+                f"{found[0]}.{found[1]} is below the floor"
             ),
             remedy=(
                 "Node is only ever taken from the distribution, never fetched (D-037); "
@@ -678,6 +691,28 @@ def _indent(text: str, prefix: str = "      ") -> str:
     return "\n".join(prefix + line for line in text.splitlines())
 
 
+def _target_deferral(name: str, wanted: Mapping[str, Sequence[str]], why: str) -> Deferral:
+    """Q-017: a profile member this target does not offer, deferred by name.
+
+    Only for a member the operator did not ask for by name -- ``wanted`` says
+    who asked -- and only for a reason true of the *target*: no candidate on
+    this release for the unit's own packages, no install block for this
+    distro or architecture, a Node floor the distribution's package is below.
+    The caller decides the reason qualifies; this only phrases it.
+    """
+    via = ", ".join(w for w in wanted[name] if w != REQUESTED_DIRECTLY)
+    return Deferral(
+        subject=name,
+        what=f"will not be installed ({via})",
+        why=why,
+        remedy=(
+            f"the rest installs without it; `hammunition install {name}` shows the "
+            f"refusal in full, and a release that carries it needs no change here"
+        ),
+        kind="package",
+    )
+
+
 def resolve(
     names: Sequence[str],
     *,
@@ -711,6 +746,14 @@ def resolve(
 
     ordered = _order(wanted, catalog, blockers)
 
+    # Q-017: a member that reached the request only through a profile (or as a
+    # dependency of one) may be deferred when the target does not offer it. A
+    # name the operator typed is never deferred -- asking for it by name is
+    # asking to see the refusal.
+    deferrable = {name for name in ordered if REQUESTED_DIRECTLY not in wanted[name]}
+    deferred: dict[str, Deferral] = {}
+    target_name = target.pretty_name or f"{target.distro} {target.version}".strip()
+
     # (manifest, block, every apt package it needs, which of those are build-only)
     resolved: list[tuple[PackageManifest, InstallBlock, tuple[str, ...], tuple[str, ...]]] = []
     for name in ordered:
@@ -723,13 +766,16 @@ def resolve(
 
         block = manifest.resolve(target.distro, target.version, target.arch)
         if block is None:
+            where = f"{target.distro} {target.version or '(no version)'} on {target.arch}"
+            if name in deferrable:
+                deferred[name] = _target_deferral(
+                    name, wanted, f"the catalog declares no install block matching {where}"
+                )
+                continue
             blockers.append(
                 Blocker(
                     subject=name,
-                    reason=(
-                        f"declares no install block matching {target.distro} "
-                        f"{target.version or '(no version)'} on {target.arch}"
-                    ),
+                    reason=f"declares no install block matching {where}",
                     remedy=(
                         "this target is genuinely unsupported for this package; the catalog "
                         "says so rather than pretending otherwise"
@@ -743,9 +789,9 @@ def resolve(
             blockers.extend(capability)
             continue
 
-        writable, deferred = _plan_config(manifest, station)
+        writable, unwritable = _plan_config(manifest, station)
         config_files.extend(writable)
-        deferrals.extend(deferred)
+        deferrals.extend(unwritable)
 
         # apt and source reach here; _check_engine_capability rejects the rest.
         # A source build needs its `build_depends` from apt before it can start,
@@ -834,12 +880,28 @@ def resolve(
                 )
         else:
             states = apt.probe(sorted({*all_apt, *all_conflicts}))
-            for manifest, _, packages, _ in resolved:
+            for manifest, block, packages, _ in resolved:
                 missing = [p for p in packages if p not in states or not states[p].known]
                 if missing:
                     origin = {p: "depends" for p in manifest.depends if p not in catalog}
                     origin.update({p: "build_depends" for p in _build_depends_of(manifest)})
                     detail = ", ".join(f"{p} ({origin.get(p, 'install')})" for p in sorted(missing))
+                    # Q-017: the unit's OWN apt packages absent from this
+                    # release is the target's gap. A missing `depends` or
+                    # `build_depends` is the manifest's, and stays a blocker
+                    # -- deferral drawn wider than that swallows defects.
+                    own = (
+                        set(block.install.packages)
+                        if isinstance(block.install, AptInstall)
+                        else set()
+                    )
+                    if manifest.name in deferrable and set(missing) <= own:
+                        deferred[manifest.name] = _target_deferral(
+                            manifest.name,
+                            wanted,
+                            f"apt on {target_name} has no candidate for {', '.join(sorted(missing))}",
+                        )
+                        continue
                     blockers.append(
                         Blocker(
                             subject=manifest.name,
@@ -869,9 +931,81 @@ def resolve(
             continue
         outcome = _check_node_floor(manifest, block.install, states.get("nodejs"))
         if isinstance(outcome, Blocker):
-            blockers.append(outcome)
+            # Q-017: the distribution's Node being absent or below the floor
+            # is true of the target, so a profile member defers on it.
+            if manifest.name in deferrable:
+                # The blocker's reason reads on from its subject; the deferral
+                # prints `why:` on its own line, so name the subject again.
+                deferred[manifest.name] = _target_deferral(
+                    manifest.name, wanted, f"{manifest.name} {outcome.reason}"
+                )
+            else:
+                blockers.append(outcome)
         else:
             notes.append(outcome)
+
+    # -- Q-017: the deferred set closes over catalog dependencies -----------
+    # pythonprop depends on voacapl; a target that lacks voacapl cannot have
+    # pythonprop either, however present its own package is. A dependent the
+    # operator asked for by name is refused, naming the dependency.
+    changed = True
+    while changed:
+        changed = False
+        for manifest, _, _, _ in resolved:
+            if manifest.name in deferred:
+                continue
+            gone = sorted(d for d in manifest.depends if d in deferred)
+            if not gone:
+                continue
+            why = f"depends on {', '.join(gone)}, which this target does not offer"
+            if manifest.name in deferrable:
+                deferred[manifest.name] = _target_deferral(manifest.name, wanted, why)
+                changed = True
+            else:
+                blockers.append(
+                    Blocker(
+                        subject=manifest.name,
+                        reason=why,
+                        remedy=(
+                            f"`hammunition install {gone[0]}` shows why; there is no "
+                            f"installing the dependent without it"
+                        ),
+                    )
+                )
+                # Not `changed`: a blocker ends the plan, and its dependents
+                # would only repeat the same refusal.
+
+    # A profile whose every member is deferred is refused, not deferred: a
+    # plan that installs nothing and reports a success is the shape D-031
+    # exists to catch, one layer up.
+    for name in names:
+        profile = profiles.get(name)
+        if profile is None or name in catalog:
+            continue
+        members = [p for p in profile.packages if p in catalog]
+        if members and all(m in deferred for m in members):
+            blockers.append(
+                Blocker(
+                    subject=name,
+                    reason=(
+                        f"every member of this profile is unavailable on {target_name}: "
+                        f"{', '.join(members)}"
+                    ),
+                    remedy=(
+                        "the profile has nothing to install here; each member's own "
+                        "reason is listed by `hammunition install <member>`"
+                    ),
+                )
+            )
+
+    if deferred:
+        deferrals.extend(deferred[name] for name in ordered if name in deferred)
+        # A deferred member's configuration is neither written nor reported
+        # as unwritten: there is no package for the file to belong to.
+        config_files = [c for c in config_files if c[0] not in deferred]
+        deferrals = [d for d in deferrals if not (d.kind == "config" and d.subject in deferred)]
+        resolved = [r for r in resolved if r[0].name not in deferred]
+        all_apt = sorted({p for _, _, packages, _ in resolved for p in packages})
 
     # -- declared conflicts against what is installed now (D-022) ----------
     for manifest, block, _, _ in resolved:

--- a/tests/test_node_backend.py
+++ b/tests/test_node_backend.py
@@ -200,7 +200,7 @@ def test_a_too_old_node_is_refused_at_plan_time_naming_floor_found_and_source(
         _plan(tmp_path, AptPackageState("nodejs", installed=None, candidate="16.20.2+dfsg-1"))
     text = str(exc.value)
     assert "needing Node 20.19 or newer" in text
-    assert "16.20.2+dfsg-1" in text and "— 16.20" in text
+    assert "16.20.2+dfsg-1" in text and "16.20 is below the floor" in text
     assert "never fetched (D-037)" in text
 
 

--- a/tests/test_profile_deferral.py
+++ b/tests/test_profile_deferral.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Q-017: a profile member the *target* does not offer is deferred by name and
+the rest of the profile installs. Everything else still refuses (D-016).
+
+The line is drawn at "true of the target, not of the operator or the engine":
+no apt candidate on this release for the unit's own packages, no install
+block for this distro/arch, a Node floor the distribution's package is below.
+An engine gap (a backend that does not exist), a missing build dependency, a
+retired unit, or a member the operator asked for *by name* are all still
+blockers -- deferral that swallowed those would make them invisible.
+
+Measured on Ubuntu 24.04 (2026-09-02): `listening` withheld nineteen
+installable units over four the archive does not carry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hammunition.backends.apt import AptPackageState
+from hammunition.plan import PlanError
+from test_plan import TARGET, _apt, _manifest, _profile, _resolve
+
+
+def _unit(name: str, **overrides: Any) -> Any:
+    return _manifest(
+        name=name, install=[{"install": {"method": "apt", "packages": [name]}}], **overrides
+    )
+
+
+def _catalog(*units: Any) -> dict[str, Any]:
+    return {u.name: u for u in units}
+
+
+def _deferred_names(plan: Any) -> list[str]:
+    return [d.subject for d in plan.deferrals if d.kind == "package"]
+
+
+# ---------------------------------------------------------------------------
+# The rule
+# ---------------------------------------------------------------------------
+
+
+def test_a_profile_member_without_a_candidate_is_deferred_and_the_rest_installs(
+    tmp_path: Path,
+) -> None:
+    catalog = _catalog(_unit("present"), _unit("absent"))
+    profile = _profile(name="listening", packages=["present", "absent"])
+    plan = _resolve(
+        tmp_path,
+        ["listening"],
+        catalog=catalog,
+        profiles={"listening": profile},
+        known={"present": None},
+    )
+    assert [p.name for p in plan.packages] == ["present"]
+    assert plan.apt_to_install == ("present",)
+    assert _deferred_names(plan) == ["absent"]
+    (deferral,) = plan.deferrals
+    assert "no candidate" in deferral.why
+    assert "debian 13" in deferral.why.lower()
+    assert "listening" in deferral.what
+
+
+def test_the_same_member_requested_by_name_is_still_refused(tmp_path: Path) -> None:
+    """Nothing is hidden: asking for the unit itself gets the refusal in full."""
+    catalog = _catalog(_unit("absent"))
+    with pytest.raises(PlanError) as excinfo:
+        _resolve(tmp_path, ["absent"], catalog=catalog, known={})
+    assert "apt has no candidate for absent" in str(excinfo.value)
+
+
+def test_requested_by_name_and_by_profile_is_refused_not_deferred(tmp_path: Path) -> None:
+    catalog = _catalog(_unit("present"), _unit("absent"))
+    profile = _profile(name="listening", packages=["present", "absent"])
+    with pytest.raises(PlanError):
+        _resolve(
+            tmp_path,
+            ["listening", "absent"],
+            catalog=catalog,
+            profiles={"listening": profile},
+            known={"present": None},
+        )
+
+
+def test_a_profile_with_every_member_deferred_is_refused_naming_the_profile(
+    tmp_path: Path,
+) -> None:
+    """Deferring everything is refusing with a happier face. Say so."""
+    catalog = _catalog(_unit("absent"), _unit("gone"))
+    profile = _profile(name="satellite", packages=["absent", "gone"])
+    with pytest.raises(PlanError) as excinfo:
+        _resolve(
+            tmp_path, ["satellite"], catalog=catalog, profiles={"satellite": profile}, known={}
+        )
+    text = str(excinfo.value)
+    assert "satellite" in text
+    assert "no member" in text or "every member" in text
+
+
+# ---------------------------------------------------------------------------
+# Which gaps count as the target's
+# ---------------------------------------------------------------------------
+
+
+def test_no_install_block_for_this_target_is_a_deferral(tmp_path: Path) -> None:
+    other = _manifest(
+        name="elsewhere",
+        install=[
+            {
+                "when": {"distro": ["ubuntu"]},
+                "install": {"method": "apt", "packages": ["elsewhere"]},
+            }
+        ],
+    )
+    catalog = _catalog(_unit("present"), other)
+    profile = _profile(name="p", packages=["present", "elsewhere"])
+    plan = _resolve(
+        tmp_path, ["p"], catalog=catalog, profiles={"p": profile}, known={"present": None}
+    )
+    assert [p.name for p in plan.packages] == ["present"]
+    assert _deferred_names(plan) == ["elsewhere"]
+    assert "no install block" in plan.deferrals[0].why
+
+
+def test_a_node_floor_the_distribution_is_below_is_a_deferral(tmp_path: Path) -> None:
+    from test_node_backend import manifest as node_manifest
+
+    node = node_manifest()
+    catalog = _catalog(_unit("present"), node)
+    profile = _profile(name="propagation", packages=["present", "nodeunit"])
+
+    apt = _apt(tmp_path, {"present": None, "npm": None})
+    real_probe = apt.probe
+
+    def probe(packages: Any) -> Any:
+        states = real_probe(packages)
+        if "nodejs" in packages:
+            states["nodejs"] = AptPackageState("nodejs", installed=None, candidate="18.19.1+dfsg-6")
+        return states
+
+    apt.probe = probe  # type: ignore[method-assign]
+    plan = _resolve(
+        tmp_path, ["propagation"], catalog=catalog, profiles={"propagation": profile}, apt=apt
+    )
+    assert [p.name for p in plan.packages] == ["present"]
+    assert _deferred_names(plan) == ["nodeunit"]
+    assert "18.19" in plan.deferrals[0].why
+    # The deferred unit's tool dependencies do not ride along.
+    assert plan.apt_to_install == ("present",)
+
+
+def test_a_dependent_of_a_deferred_member_is_deferred_with_it(tmp_path: Path) -> None:
+    """pythonprop depends on voacapl; 24.04 carries neither. Both defer, and
+    the dependent says why."""
+    catalog = _catalog(_unit("present"), _unit("voacapl"), _unit("pythonprop", depends=["voacapl"]))
+    profile = _profile(name="propagation", packages=["present", "voacapl", "pythonprop"])
+    plan = _resolve(
+        tmp_path,
+        ["propagation"],
+        catalog=catalog,
+        profiles={"propagation": profile},
+        known={"present": None, "pythonprop": None},
+    )
+    assert [p.name for p in plan.packages] == ["present"]
+    assert sorted(_deferred_names(plan)) == ["pythonprop", "voacapl"]
+    dependent = next(d for d in plan.deferrals if d.subject == "pythonprop")
+    assert "voacapl" in dependent.why
+
+
+def test_a_named_request_whose_catalog_dependency_is_unavailable_is_refused(
+    tmp_path: Path,
+) -> None:
+    catalog = _catalog(_unit("voacapl"), _unit("pythonprop", depends=["voacapl"]))
+    with pytest.raises(PlanError) as excinfo:
+        _resolve(tmp_path, ["pythonprop"], catalog=catalog, known={"pythonprop": None})
+    assert "voacapl" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# What is NOT the target's gap, and still blocks
+# ---------------------------------------------------------------------------
+
+
+def test_an_engine_gap_still_blocks_the_profile(tmp_path: Path) -> None:
+    """`workstation` is the test: code and codium are refused because the
+    engine lacks a backend, not because the archive lacks them."""
+    code = _unit(
+        "code",
+        apt_repos=[
+            {
+                "name": "vscode",
+                "uri": "https://packages.example.invalid/repos/code",
+                "suites": ["stable"],
+                "components": ["main"],
+                "key_url": "https://packages.example.invalid/keys/example.asc",
+                "key_fingerprint": "0123456789ABCDEF0123456789ABCDEF01234567",
+                "rationale": "The editor is published only from the vendor's own repository, which this fixture stands in for.",
+            }
+        ],
+    )
+    catalog = _catalog(_unit("present"), code)
+    profile = _profile(name="workstation", packages=["present", "code"])
+    with pytest.raises(PlanError) as excinfo:
+        _resolve(
+            tmp_path,
+            ["workstation"],
+            catalog=catalog,
+            profiles={"workstation": profile},
+            known={"present": None, "code": None},
+        )
+    assert "third-party apt repositories" in str(excinfo.value)
+
+
+def test_a_missing_build_dependency_still_blocks(tmp_path: Path) -> None:
+    """A build dependency apt cannot find is a manifest defect, not a target gap."""
+    built = _manifest(
+        name="built",
+        install=[
+            {
+                "install": {
+                    "method": "source",
+                    "source": {
+                        "url": "https://example.invalid/built-1.0.tar.gz",
+                        "sha256": "0" * 64,
+                    },
+                    "build_system": "make",
+                },
+                "build_depends": ["libfftw2-dev"],
+            }
+        ],
+        binaries=[{"produced": "built", "install_as": "built"}],
+    )
+    catalog = _catalog(_unit("present"), built)
+    profile = _profile(name="p", packages=["present", "built"])
+    with pytest.raises(PlanError) as excinfo:
+        _resolve(tmp_path, ["p"], catalog=catalog, profiles={"p": profile}, known={"present": None})
+    assert "libfftw2-dev (build_depends)" in str(excinfo.value)
+
+
+def test_a_retired_member_still_blocks(tmp_path: Path) -> None:
+    dead = _unit(
+        "dead",
+        status="retired",
+        status_reason="gone",
+        status_date="2026-01-01",
+        status_verdict="tested",
+        retire_reason="world_changed",
+    )
+    catalog = _catalog(_unit("present"), dead)
+    profile = _profile(name="p", packages=["present", "dead"])
+    with pytest.raises(PlanError):
+        _resolve(
+            tmp_path,
+            ["p"],
+            catalog=catalog,
+            profiles={"p": profile},
+            known={"present": None, "dead": None},
+        )
+
+
+# ---------------------------------------------------------------------------
+# It is reported: plan, log, status
+# ---------------------------------------------------------------------------
+
+
+def test_the_plan_prints_the_deferred_member_under_will_not_happen(tmp_path: Path) -> None:
+    from hammunition.cli.main import render_plan
+
+    catalog = _catalog(_unit("present"), _unit("absent"))
+    profile = _profile(name="listening", packages=["present", "absent"])
+    plan = _resolve(
+        tmp_path,
+        ["listening"],
+        catalog=catalog,
+        profiles={"listening": profile},
+        known={"present": None},
+    )
+    text = "\n".join(render_plan(plan, [], euid=1000))
+    assert "Will NOT happen" in text
+    assert "absent: " in text
+    assert "no candidate" in text
+
+
+def test_the_transaction_log_records_the_deferral(tmp_path: Path) -> None:
+    from hammunition.execute import commands_for, execute
+    from hammunition.state.log import TransactionLog
+
+    catalog = _catalog(_unit("present"), _unit("absent"))
+    profile = _profile(name="listening", packages=["present", "absent"])
+    apt = _apt(tmp_path, {"present": None})
+    plan = _resolve(
+        tmp_path, ["listening"], catalog=catalog, profiles={"listening": profile}, apt=apt
+    )
+    log = TransactionLog(tmp_path / "t.jsonl")
+    execute(commands_for(plan, apt=apt, refresh=False), apt.runner, log=log, plan=plan)
+    begin = next(e for e in log.read() if e["event"] == "transaction_begin")
+    assert begin["deferred"] == [
+        {
+            "kind": "package",
+            "subject": "absent",
+            "what": plan.deferrals[0].what,
+            "why": plan.deferrals[0].why,
+        }
+    ]
+
+
+def test_status_reports_what_the_last_transaction_deferred(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import argparse
+
+    from hammunition.cli.main import cmd_status
+    from hammunition.distro import Target
+    from hammunition.state import TransactionLog, log_path
+
+    monkeypatch.setattr(Target, "detect", classmethod(lambda cls: TARGET))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.delenv("SUDO_USER", raising=False)
+    monkeypatch.setenv("USER", "root")  # operator() -> "root": falsy owner, XDG path
+    log = TransactionLog(log_path())
+    log.append(
+        {
+            "event": "transaction_begin",
+            "version": 2,
+            "packages": ["present"],
+            "apt_packages": ["present"],
+            "deferred": [
+                {
+                    "kind": "package",
+                    "subject": "absent",
+                    "what": "will not be installed (profile listening)",
+                    "why": "apt on Debian 13 has no candidate for absent",
+                }
+            ],
+        }
+    )
+    log.append({"event": "transaction_end", "version": 2, "completed": 1})
+    rc = cmd_status(argparse.Namespace(catalog=None, user=None))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "deferred" in out.lower()
+    assert "absent" in out
+    assert "no candidate" in out


### PR DESCRIPTION
## What

Q-017, decided as **A** on 2026-09-03: a profile member the target does not offer is deferred by name and the rest of the profile installs. Recorded as **D-039**.

**Deferred** (only for a member that reached the plan through a profile, or as a catalog dependency of one), when the reason is a fact about the target:
- no install block matches this distro/version/arch
- apt on this release has no candidate for the unit's **own** `packages:`
- the distribution's `nodejs` is below the manifest's floor (D-037)

Catalog dependents defer with the dependency, naming it (pythonprop → voacapl).

**Still refuses**, by name: a name the operator typed (also when it is in a profile), an engine gap (`code`/`codium` need apt_repos — `workstation` stays refused until that backend exists), a missing `depends`/`build_depends`, a retired status, and a profile whose every member is deferred.

Deferred units and their tool deps leave the transaction before simulate. `transaction_begin` is version 2 with `deferred`; `status` prints it.

## Measured (Ubuntu 24.04 VM, dry run)

- `listening`: plans 20, defers `mlat-client-adsbfi`, `readsb`, `rtl-ais`, `satdump` under *Will NOT happen*
- `propagation`: plans 9, defers `openhamclock` (Node 18.19 < 20.19), `pythonprop`, `voacapl`
- `hammunition install satdump`: still refused in full
- `workstation`: still refused over `code`/`codium`

Whole-profile installs on 24.04 with the deferral in effect are the next campaign; this PR claims the plan, not the install.

## Docs

D-039 in DECISIONS.md, Q-017 marked resolved, CLAUDE.md row + paragraph, `cli.md` (step 7, two refusal rows, `status`), `transaction-log.md` (version 2), `vm-campaign-ubuntu.md`.

## Tests

`tests/test_profile_deferral.py` — 14 tests, written red first. One assertion in `test_node_backend.py` follows the reworded Node-floor reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
