### PR TITLE
execute: fetch and verify every download first; simulate a .deb with the apt step before either installs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -336,7 +336,18 @@ Resolution is a distinct phase that finishes before anything is executed
    `depends` or `build_depends`, a retired status, and a profile with every
    member deferred all still refuse the transaction.
 8. **Print the plan**, in full, for every run and not only for `--dry-run`.
-9. **Present any consent gate**, then confirm, then execute.
+9. **Present any consent gate**, then confirm, then execute — in this order:
+   **every download first**, fetched into the cache and verified against the
+   manifest's sha256 (**D-018**), so a wrong hash or a dead URL refuses on a
+   machine nothing has touched; then, when the plan holds a vendor `.deb`,
+   one more `apt-get install --simulate` over the apt packages and the
+   downloaded file together, because apt can only resolve a `.deb` from its
+   file and the plan-time simulate in step 6 could not include one; then
+   `apt-get update` if `--refresh`, debconf preseeds, the apt step, the
+   builds and installs in catalog order, configuration files, launchers,
+   and group membership last (several groups are created by the package
+   being installed). A `git` clone is a command that needs `git` from apt,
+   so it stays in build order rather than moving up with the fetches.
 
 If anything in steps 2–7 fails, **every** failure is printed together and
 nothing is changed. Reporting only the first would have the same shape as the

--- a/docs/reference/vm-campaign-ubuntu.md
+++ b/docs/reference/vm-campaign-ubuntu.md
@@ -150,7 +150,9 @@ execution. **Fetching and verifying every artefact, and simulating every
 `.deb` against the post-apt state, before the first system modification**
 would make "the plan passed" mean what an operator reads it to mean. It is
 a reordering of `execute.py`, not a new backend, and it is recorded here so
-it is built on evidence and not forgotten.
+it is built on evidence and not forgotten. **Built 2026-09-03:** every
+fetch now runs first, and a plan holding a `.deb` simulates it together with
+the apt step after the fetch and before either installs.
 
 ## Left with the maintainer
 

--- a/src/hammunition/backends/apt.py
+++ b/src/hammunition/backends/apt.py
@@ -310,17 +310,9 @@ class AptBackend:
         A failed simulation is a result, not an exception: the plan reads
         apt's account and decides what it means.
         """
-        ordered = sorted(set(packages))
-        if not ordered:
+        if not set(packages):
             return AptSimulation(ok=True, release=release)
-        target = ("--target-release", release) if release is not None else ()
-        command = Command(
-            argv=("apt-get", "install", "--simulate", "--yes", *target, "--", *ordered),
-            description=f"Ask apt how it would install {len(ordered)} package(s)",
-            requires_root=False,
-            env=dict(NONINTERACTIVE),
-        )
-        result = self.runner.run(command)
+        result = self.runner.run(self.simulate_command(packages, release=release))
         if not result.ok:
             # apt puts the E: lines and the solver's explanation on stderr;
             # stdout is "Reading package lists..." and worth nothing to a
@@ -328,6 +320,23 @@ class AptBackend:
             error = result.stderr.strip() or result.stdout.strip()
             return AptSimulation(ok=False, error=error, release=release)
         return AptSimulation(ok=True, installs=parse_simulation(result.stdout), release=release)
+
+    def simulate_command(
+        self, packages: Sequence[str], *, release: str | None = None, description: str = ""
+    ) -> Command:
+        """The ``--simulate`` invocation itself, for :meth:`simulate` and for a
+        plan that wants it as a step. A local ``.deb`` may be among *packages*
+        by path -- apt resolves a file the same way, which is how a downloaded
+        vendor package is checked against the apt step it will follow before
+        either has touched the machine."""
+        ordered = sorted(set(packages))
+        target = ("--target-release", release) if release is not None else ()
+        return Command(
+            argv=("apt-get", "install", "--simulate", "--yes", *target, "--", *ordered),
+            description=description or f"Ask apt how it would install {len(ordered)} package(s)",
+            requires_root=False,
+            env=dict(NONINTERACTIVE),
+        )
 
     def would_install(self, packages: Sequence[str]) -> set[str]:
         """Every package apt would unpack to install *packages* -- the named

--- a/src/hammunition/execute.py
+++ b/src/hammunition/execute.py
@@ -265,7 +265,16 @@ def commands_for(
 ) -> list[Step]:
     """Every step this plan implies, in the order it will run.
 
-    The order is not cosmetic. apt runs first because a source build needs its
+    The order is not cosmetic. Every download runs first, before anything
+    that changes the machine: a fetch is verified against the manifest's
+    sha256 (D-018), so a wrong hash or a dead URL refuses on an untouched
+    system rather than after apt has installed a toolchain for a build that
+    will never start; and a vendor .deb, which apt can only resolve from
+    its file, is simulated against the apt step once fetched and before
+    either runs -- the half of the "plan passed, machine touched, then it
+    failed" shape that D-038's plan-time simulate could not reach
+    (`docs/reference/vm-campaign-ubuntu.md`, 2026-09-02). apt runs next
+    because a source build needs its
     ``build_depends`` — its compiler, its headers — present before ``./configure``
     can succeed. Group membership comes last because several of these groups are
     created by the package being installed (Debian's ``wireshark-common`` creates
@@ -276,9 +285,87 @@ def commands_for(
     and an absence is an error rather than a silent skip — a plan that quietly dropped the one
     step that installs the software would report success having done nothing.
     """
-    commands: list[Step] = []
+    # Each backend's steps in build order; the fetches are lifted out below.
+    builds: list[Step] = []
+    for planned in plan.packages:
+        block = planned.block.install
+        if isinstance(block, SourceInstall):
+            if source is None:
+                raise BackendError(
+                    f"{planned.name} is a source build and no source backend was supplied. "
+                    f"Skipping it would report a successful run that installed nothing."
+                )
+            builds.extend(source.steps(planned.manifest, block))
+        elif isinstance(block, GitInstall):
+            if git is None:
+                raise BackendError(
+                    f"{planned.name} builds from git and no git backend was supplied. "
+                    f"Skipping it would report a successful run that installed nothing."
+                )
+            builds.extend(git.steps(planned.manifest, block))
+        elif isinstance(block, BinaryInstall):
+            if binary is None:
+                raise BackendError(
+                    f"{planned.name} installs a prebuilt artifact and no binary backend "
+                    f"was supplied. Skipping it would report a successful run that "
+                    f"installed nothing."
+                )
+            builds.extend(binary.steps(planned.manifest, block))
+        elif isinstance(block, VenvInstall):
+            if venv is None:
+                raise BackendError(
+                    f"{planned.name} installs into a virtualenv and no venv backend "
+                    f"was supplied. Skipping it would report a successful run that "
+                    f"installed nothing."
+                )
+            builds.extend(venv.steps(planned.manifest, block))
+        elif isinstance(block, NodeInstall):
+            if node is None:
+                raise BackendError(
+                    f"{planned.name} is a Node.js application and no node backend "
+                    f"was supplied. Skipping it would report a successful run that "
+                    f"installed nothing."
+                )
+            builds.extend(node.steps(planned.manifest, block))
+
+    # A `fetch` is an in-process download into the cache, verified before it
+    # is kept; it needs nothing apt installs and touches nothing outside the
+    # cache, so every one of them can go first. A git clone is a Command
+    # that needs git from apt and stays where its backend put it.
+    commands: list[Step] = [
+        step for step in builds if isinstance(step, Action) and step.kind == "fetch"
+    ]
+    builds = [step for step in builds if not (isinstance(step, Action) and step.kind == "fetch")]
+
     if refresh:
         commands.append(apt.refresh_command())
+
+    # A vendor .deb is resolved by apt from its file, and the file does not
+    # exist until its fetch has run -- so the plan's own simulate (D-038)
+    # could not include it. This one can: it runs after every fetch and
+    # before the apt step, over the apt packages and the downloaded .debs
+    # together, and a refusal here is a refusal on an untouched machine.
+    # `apt-get install ./file.deb` is what the binary backend runs later;
+    # asking the same resolver the same question first is the whole idea.
+    debs = [
+        str(binary.fetcher.path_for(planned.block.install.artifact))
+        for planned in plan.packages
+        if binary is not None
+        and isinstance(planned.block.install, BinaryInstall)
+        and planned.block.install.format == "deb"
+    ]
+    if debs:
+        commands.append(
+            apt.simulate_command(
+                (*plan.apt_to_install, *debs),
+                release=plan.apt_release,
+                description=(
+                    f"Ask apt whether the {len(debs)} downloaded .deb file(s) resolve "
+                    f"together with the apt step, before anything is installed"
+                ),
+            )
+        )
+
     if plan.debconf_selections and plan.apt_to_install:
         # Before the apt install, never after: a package's postinst reads its
         # preseeded answers as it configures, so wireshark-common creates the
@@ -309,46 +396,7 @@ def commands_for(
                 )
             )
 
-    for planned in plan.packages:
-        block = planned.block.install
-        if isinstance(block, SourceInstall):
-            if source is None:
-                raise BackendError(
-                    f"{planned.name} is a source build and no source backend was supplied. "
-                    f"Skipping it would report a successful run that installed nothing."
-                )
-            commands.extend(source.steps(planned.manifest, block))
-        elif isinstance(block, GitInstall):
-            if git is None:
-                raise BackendError(
-                    f"{planned.name} builds from git and no git backend was supplied. "
-                    f"Skipping it would report a successful run that installed nothing."
-                )
-            commands.extend(git.steps(planned.manifest, block))
-        elif isinstance(block, BinaryInstall):
-            if binary is None:
-                raise BackendError(
-                    f"{planned.name} installs a prebuilt artifact and no binary backend "
-                    f"was supplied. Skipping it would report a successful run that "
-                    f"installed nothing."
-                )
-            commands.extend(binary.steps(planned.manifest, block))
-        elif isinstance(block, VenvInstall):
-            if venv is None:
-                raise BackendError(
-                    f"{planned.name} installs into a virtualenv and no venv backend "
-                    f"was supplied. Skipping it would report a successful run that "
-                    f"installed nothing."
-                )
-            commands.extend(venv.steps(planned.manifest, block))
-        elif isinstance(block, NodeInstall):
-            if node is None:
-                raise BackendError(
-                    f"{planned.name} is a Node.js application and no node backend "
-                    f"was supplied. Skipping it would report a successful run that "
-                    f"installed nothing."
-                )
-            commands.extend(node.steps(planned.manifest, block))
+    commands.extend(builds)
 
     # Configuration is written after the software that reads it exists, so a
     # package's own postinst cannot overwrite what we put down, and before

--- a/tests/test_binary_backend.py
+++ b/tests/test_binary_backend.py
@@ -208,6 +208,48 @@ def test_a_deb_goes_through_apt_and_not_dpkg(tmp_path: Path) -> None:
     assert str(fetched["path"]) in argv
 
 
+def test_a_deb_is_simulated_with_the_apt_step_after_its_fetch_and_before_apt_installs(
+    tmp_path: Path,
+) -> None:
+    """The plan's own simulate (D-038) cannot include a file that has not
+    been downloaded. So the transaction fetches first, then asks apt about
+    the apt packages and the .deb *together*, then installs -- a vendor
+    package built for another release is refused with nothing changed."""
+    from hammunition.backends import AptBackend
+    from hammunition.execute import commands_for
+
+    manifest = _manifest("https://example.invalid/x.deb", "0" * 64, "deb", binaries=[])
+    backend = _backend(tmp_path)
+    plan = InstallPlan(
+        target=TARGET,
+        packages=(
+            PlannedPackage(manifest=manifest, block=manifest.install[0], apt_packages=("libdep",)),
+        ),
+        apt_release="stable",
+    )
+    steps = commands_for(plan, AptBackend(RecordingRunner()), binary=backend)
+    labels = [s.kind if isinstance(s, Action) else s.argv[0] for s in steps]
+    assert labels == ["fetch", "apt-get", "apt-get", "install-deb"]
+    simulate = steps[1]
+    assert isinstance(simulate, Command)
+    block = manifest.install[0].install
+    assert isinstance(block, BinaryInstall)
+    deb = str(backend.fetcher.path_for(block.artifact))
+    assert simulate.argv == (
+        "apt-get",
+        "install",
+        "--simulate",
+        "--yes",
+        "--target-release",
+        "stable",
+        "--",
+        deb,
+        "libdep",
+    )
+    assert not simulate.requires_root
+    assert ".deb" in simulate.description
+
+
 def test_apt_refusing_a_deb_is_an_error_not_a_pass(tmp_path: Path) -> None:
     """A vendor .deb built for a different release is the usual cause, and apt
     refusing it is the correct outcome."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -890,16 +890,36 @@ def _source_backend(tmp_path: Path) -> SourceBackend:
     return SourceBackend(Fetcher(tmp_path / "cache"), build_root=tmp_path / "build", jobs=2)
 
 
-def test_apt_runs_before_a_source_build_needs_its_toolchain(tmp_path: Path) -> None:
-    """Order is not cosmetic: ./configure cannot succeed before build_depends
-    are installed."""
+def test_every_fetch_runs_before_apt_and_apt_before_a_build(tmp_path: Path) -> None:
+    """Order is not cosmetic, twice over. Every download is fetched and
+    verified before the first thing that changes the machine, so a wrong
+    sha256 or a dead URL (D-018) is a refusal on an untouched system rather
+    than a failure after apt has installed a toolchain for a build that will
+    never start. Then apt, because ./configure cannot succeed before
+    build_depends are installed."""
     steps = commands_for(
         _source_plan(tmp_path),
         AptBackend(RecordingRunner()),
         source=_source_backend(tmp_path),
+        refresh=True,
     )
     labels = [s.kind if isinstance(s, Action) else s.argv[0] for s in steps]
-    assert labels == ["apt-get", "fetch", "extract", "./configure", "make", "make"]
+    assert labels == ["fetch", "apt-get", "apt-get", "extract", "./configure", "make", "make"]
+    assert _argv(steps[1]) == ("apt-get", "update")
+
+
+def test_a_fetch_that_fails_leaves_apt_unrun(tmp_path: Path) -> None:
+    """The property the order buys: nothing has been installed when a
+    download fails verification, so there is nothing to explain or undo."""
+    runner = RecordingRunner()
+    apt = AptBackend(runner)
+    steps = commands_for(_source_plan(tmp_path), apt, source=_source_backend(tmp_path))
+    log = TransactionLog(tmp_path / "log.jsonl")
+    # The URL is example.invalid: the fetch fails, which is the point.
+    report = execute(steps, runner, log=log, plan=_source_plan(tmp_path))
+    assert not report.ok
+    assert isinstance(report.failed, Action) and report.failed.kind == "fetch"
+    assert runner.commands == []
 
 
 def test_a_source_build_without_a_backend_is_an_error_not_a_skip(tmp_path: Path) -> None:


### PR DESCRIPTION
Stacked on #14 (`defer-unavailable`). Merge that first; this PR then shows only its own commit.

## What

Every `fetch` Action is hoisted to the head of the command list. A download is verified against the manifest's sha256 and touches nothing outside the cache, so a wrong hash or a dead URL now refuses on a machine nothing has modified — not after apt has installed a toolchain for a build that will never start. A `git` clone needs `git` from apt and stays in build order.

A plan holding a vendor `.deb` gets one more step after the fetches and before the apt step: `apt-get install --simulate` over the outstanding apt packages and the downloaded file together. The plan-time simulate (D-038) cannot include a `.deb` because apt resolves one from its file, and the file does not exist until its fetch has run — the gap `docs/reference/vm-campaign-ubuntu.md` recorded on 2026-09-02. `AptBackend.simulate_command` is shared with the plan-time path so the two cannot drift.

## Measured

Debian 13, `install wsjtx-improved --yes`: fetch first (67.7 MB from SourceForge), then `apt-get install --simulate --yes -- <cached .deb>` (exit 0), then `install-deb`; `wsjtx 3.2.0` installed, three steps confirmed. The transaction record from that run also exposed a D-031 gap (`verified: true` with `checks: []` for a `.deb` unit); the fix and the measurement paragraph live in the next PR in the chain (`apt-repos`), because that branch was already carrying the doc edits.

## Gates

ruff, ruff format, `mypy --strict`, pytest, `check_doc_links.py`, `audit_gitignore.py`, commit-claims hook — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
