### PR TITLE
scripts: campaign prepare refreshes apt lists, keeps failure text, writes the report as it goes

### DIFF
--- a/docs/contributing/vm-testing.md
+++ b/docs/contributing/vm-testing.md
@@ -250,7 +250,23 @@ default of 1800 s covers every compile measured so far; a no-swap VM that
 No reset between units, deliberately: a campaign is one accumulating
 machine-state, like a real operator's machine. This is the mechanism the M5
 report will be generated from — one campaign per target, every unit, and
-the exit-criterion fraction falls out as arithmetic.
+the exit-criterion fraction falls out as arithmetic. `--reset-first DOMAIN`
+restores `clean-baseline` and prepares the guest once before the first unit,
+so a whole-catalog campaign starts from the known state without a separate
+`reset` and a by-hand sync.
+
+**Prepare refreshes the apt lists.** A snapshot freezes them at the day it
+was taken and the archive moves on: Parrot's `clean-baseline` was four days
+old when its lists still named `glib2.0 2.84.4-3~deb13u3`, the pool no
+longer had it, and six of fifteen profiles failed at their first fetch with
+a 404 — four commands into a transaction, on a catalog that was fine
+(2026-09-03). Every prepare now runs `apt-get update` before building the
+venv, which is also why a guest without passwordless sudo fails at prepare
+rather than at unit 1. A prepare that fails prints the guest's output and is
+retried once, because the Kali campaign died at profile 5 of 15 with a bare
+`CalledProcessError` and no text — a PyPI hiccup and a broken guest were
+the same verdict. The report file is rewritten after every unit, so a
+campaign that dies keeps what it measured.
 
 **Then install the profiles whole.** Per-unit success does not prove
 profile success: twenty of `digital-modes`' twenty-one members were

--- a/docs/contributing/vm-testing.md
+++ b/docs/contributing/vm-testing.md
@@ -262,7 +262,12 @@ longer had it, and six of fifteen profiles failed at their first fetch with
 a 404 — four commands into a transaction, on a catalog that was fine
 (2026-09-03). Every prepare now runs `apt-get update` before building the
 venv, which is also why a guest without passwordless sudo fails at prepare
-rather than at unit 1. A prepare that fails prints the guest's output and is
+rather than at unit 1. The update is retried for up to five minutes,
+because Pop!_OS 24.04 runs its own `apt-get` at boot and held the lists
+lock against a prepare that started 30 s after the restore (2026-09-04);
+`DPkg::Lock::Timeout` looks like the fix and is not — measured at a 0 s
+wait against a held lists lock on apt 3.0.3, it covers the dpkg frontend
+lock only. A prepare that fails prints the guest's output and is
 retried once, because the Kali campaign died at profile 5 of 15 with a bare
 `CalledProcessError` and no text — a PyPI hiccup and a broken guest were
 the same verdict. The report file is rewritten after every unit, so a

--- a/scripts/vm_campaign.py
+++ b/scripts/vm_campaign.py
@@ -21,6 +21,9 @@ operator's machine behaves, and per-unit resets would turn a night into a
 week. Reset to `clean-baseline` before a campaign when you want isolation
 (`scripts/vm-snapshot.sh reset DOMAIN`).
 
+``--reset-first DOMAIN`` does that restore, and the prepare (repository
+synced, apt lists refreshed, venv built), once before the first unit.
+
 The exception is ``--whole-profiles``: each name is a profile installed as
 one transaction, and ``--reset-each DOMAIN`` restores the VM to
 `clean-baseline` and re-prepares it before every one. Per-unit success does
@@ -81,6 +84,44 @@ class UnitResult:
         return OUTCOMES.get(self.exit_code, f"exit {self.exit_code}")
 
 
+# The runbook's "prepared" includes updated (vm-testing.md, baseline prep
+# step 1), and a snapshot freezes the apt lists at the day it was taken. The
+# archive does not wait: Parrot's clean-baseline was four days old when its
+# lists still named glib2.0 2.84.4-3~deb13u3 and the pool had moved on, and
+# six of fifteen profiles failed at the first fetch with a 404 (2026-09-03).
+# So the lists are refreshed here, once per prepare, before anything is
+# measured -- the engine's own ``--refresh`` would do it per unit, and the
+# campaign is measuring the catalog, not the age of a snapshot.
+PREPARE_REMOTE = (
+    "cd hammunition && sudo -n apt-get update -q "
+    "&& python3 -m venv .venv && .venv/bin/pip install -q -e . "
+    "&& .venv/bin/hammunition --version"
+)
+
+
+def prepare(ssh: list[str], host: str, *, attempts: int = 2) -> None:
+    """The venv and the engine on the guest, with the failure text kept.
+
+    ``check=True`` with ``capture_output=True`` and nothing printed is how the
+    Kali campaign died at profile 5 of 15 with a bare ``CalledProcessError``
+    and no way to tell a PyPI hiccup from a broken guest (2026-09-03). The
+    output is printed on every failure, and one retry covers the transient
+    kind -- the same command succeeded by hand a minute later.
+    """
+    for attempt in range(1, attempts + 1):
+        proc = subprocess.run(
+            [*ssh, host, PREPARE_REMOTE], capture_output=True, text=True, check=False
+        )
+        if proc.returncode == 0:
+            return
+        tail = "\n".join((proc.stdout + proc.stderr).splitlines()[-15:])
+        print(
+            f"prepare attempt {attempt}/{attempts} failed (exit {proc.returncode}):\n{tail}",
+            flush=True,
+        )
+    sys.exit(f"{host} could not be prepared after {attempts} attempts; nothing was measured")
+
+
 def reset_and_prepare(domain: str, host: str, identity: str | None) -> None:
     """Back to `clean-baseline`, then the runbook's prepare steps.
 
@@ -114,16 +155,7 @@ def reset_and_prepare(domain: str, host: str, identity: str | None) -> None:
     )
     if tar.wait() != 0:
         sys.exit("tar of the repository failed")
-    subprocess.run(
-        [
-            *ssh,
-            host,
-            "cd hammunition && python3 -m venv .venv && .venv/bin/pip install -q -e . "
-            "&& .venv/bin/hammunition --version",
-        ],
-        check=True,
-        capture_output=True,
-    )
+    prepare(ssh, host)
 
 
 def run_unit(host: str, identity: str | None, unit: str, timeout: int) -> UnitResult:
@@ -252,7 +284,15 @@ def main() -> int:
         default=None,
         help="libvirt domain to restore to clean-baseline and re-prepare before every unit",
     )
+    parser.add_argument(
+        "--reset-first",
+        metavar="DOMAIN",
+        default=None,
+        help="libvirt domain to restore to clean-baseline and prepare once, before the campaign",
+    )
     args = parser.parse_args()
+    if args.reset_each and args.reset_first:
+        parser.error("--reset-each already resets before the first unit; drop --reset-first")
 
     catalog = load_catalog(REPO_ROOT / "catalog" / "packages")
     profiles = load_profiles(REPO_ROOT / "catalog" / "profiles", catalog)
@@ -277,6 +317,9 @@ def main() -> int:
         check=False,
     ).stdout.strip()
 
+    if args.reset_first:
+        reset_and_prepare(args.reset_first, args.host, args.identity)
+
     target_probe = (
         subprocess.run(
             [
@@ -291,6 +334,12 @@ def main() -> int:
         ).stdout.strip()
         or args.host
     )
+    noun = "Profiles (whole, from clean-baseline)" if args.whole_profiles else "Units"
+
+    def report_so_far(results: list[UnitResult]) -> str:
+        return render_report(
+            target_line=target_probe, engine_commit=commit, results=results, noun=noun
+        )
 
     results: list[UnitResult] = []
     for unit in units:
@@ -300,18 +349,16 @@ def main() -> int:
         result = run_unit(args.host, args.identity, unit, args.timeout)
         print(f"    {result.outcome} ({result.seconds:.0f}s)", flush=True)
         results.append(result)
+        # The report is rewritten after every unit, so a campaign that dies
+        # at unit 5 of 15 leaves the four results it had, and a failure's
+        # tail is readable while the next unit builds instead of hours later.
+        if args.out:
+            args.out.write_text(report_so_far(results))
 
-    report = render_report(
-        target_line=target_probe,
-        engine_commit=commit,
-        results=results,
-        noun="Profiles (whole, from clean-baseline)" if args.whole_profiles else "Units",
-    )
     if args.out:
-        args.out.write_text(report)
         print(f"wrote {args.out}")
     else:
-        print(report)
+        print(report_so_far(results))
     return 0
 
 

--- a/scripts/vm_campaign.py
+++ b/scripts/vm_campaign.py
@@ -91,10 +91,16 @@ class UnitResult:
 # six of fifteen profiles failed at the first fetch with a 404 (2026-09-03).
 # So the lists are refreshed here, once per prepare, before anything is
 # measured -- the engine's own ``--refresh`` would do it per unit, and the
-# campaign is measuring the catalog, not the age of a snapshot.
+# campaign is measuring the catalog, not the age of a snapshot. The retry
+# loop is for a guest that runs its own apt at boot: Pop!_OS 24.04's did,
+# and a prepare that started 30 s after the restore lost the lists lock to
+# it (2026-09-04). ``DPkg::Lock::Timeout`` was the obvious fix and does not
+# apply to the lists lock -- measured at 0 s against a held lock, apt 3.0.3
+# -- so the wait is this loop, bounded at five minutes.
 PREPARE_REMOTE = (
-    "cd hammunition && sudo -n apt-get update -q "
-    "&& python3 -m venv .venv && .venv/bin/pip install -q -e . "
+    "cd hammunition || exit 1; n=0; until sudo -n apt-get update -q; do "
+    "n=$((n+1)); [ $n -ge 30 ] && exit 100; sleep 10; done; "
+    "python3 -m venv .venv && .venv/bin/pip install -q -e . "
     "&& .venv/bin/hammunition --version"
 )
 

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -195,6 +195,11 @@ def test_campaign_prepare_refreshes_apt_lists_and_keeps_its_failure_text(
     remote = mod.PREPARE_REMOTE
     assert "sudo -n apt-get update" in remote
     assert remote.index("apt-get update") < remote.index("python3 -m venv")
+    # Pop!_OS 24.04 runs its own apt-get at boot and held the lists lock
+    # against the first prepare (2026-09-04). DPkg::Lock::Timeout does not
+    # cover that lock (measured: 0 s wait, apt 3.0.3), so the update is
+    # retried in a bounded loop instead.
+    assert "until sudo -n apt-get update" in remote and "-ge 30" in remote
 
     calls: list[list[str]] = []
     outcomes = iter(

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -6,8 +6,11 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 from hammunition.launchers import desktop_entry, launcher_steps, wrapper_body
 from hammunition.manifest.schema import PackageManifest
@@ -166,3 +169,56 @@ def test_campaign_files_a_declined_consent_gate_as_neither_failure_nor_refusal()
     assert "| `rf-research` | consent declined |" in report
     assert "## Failures" not in report
     assert "## Consent gates presented" in report and "Do you affirm" in report
+
+
+def test_campaign_prepare_refreshes_apt_lists_and_keeps_its_failure_text(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Two things the Parrot and Kali campaigns of 2026-09-03 proved. Parrot:
+    a clean-baseline four days old still named glib2.0 2.84.4-3~deb13u3 and
+    the pool had moved on, so six of fifteen profiles failed at the first
+    fetch with a 404 — the prepare must refresh the lists, before the venv
+    (so a guest whose sudo is not passwordless fails prepare, not unit 1).
+    Kali: prepare failed at profile 5 with a bare CalledProcessError and
+    nothing captured, so a PyPI hiccup and a broken guest were the same
+    verdict — the failure text is printed and the transient kind is retried."""
+    import importlib.util
+    from pathlib import Path as P
+
+    spec = importlib.util.spec_from_file_location(
+        "vm_campaign", P(__file__).resolve().parent.parent / "scripts" / "vm_campaign.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    remote = mod.PREPARE_REMOTE
+    assert "sudo -n apt-get update" in remote
+    assert remote.index("apt-get update") < remote.index("python3 -m venv")
+
+    calls: list[list[str]] = []
+    outcomes = iter(
+        [
+            subprocess.CompletedProcess(
+                [], 1, stdout="", stderr="ERROR: Could not fetch URL https://pypi.org/simple/"
+            ),
+            subprocess.CompletedProcess([], 0, stdout="hammunition 0.7.0\n", stderr=""),
+        ]
+    )
+
+    def fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return next(outcomes)
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    mod.prepare(["ssh"], "user@guest")
+    assert len(calls) == 2 and calls[0][-1] == remote
+    out = capsys.readouterr().out
+    assert "prepare attempt 1/2 failed (exit 1)" in out
+    assert "Could not fetch URL https://pypi.org/simple/" in out
+
+    always = subprocess.CompletedProcess([], 1, stdout="", stderr="venv: command not found")
+    monkeypatch.setattr(mod.subprocess, "run", lambda argv, **kw: always)
+    with pytest.raises(SystemExit, match="could not be prepared after 2 attempts"):
+        mod.prepare(["ssh"], "user@guest")
+    assert "venv: command not found" in capsys.readouterr().out


### PR DESCRIPTION
Three harness defects, each found by the 2026-09-03 overnight campaigns, plus one the fix itself found on the new Pop!_OS VM.

- **Parrot** — the `clean-baseline` snapshot was four days old, its lists named `glib2.0 2.84.4-3~deb13u3`, the pool had moved on, and six of fifteen profiles failed four commands in with a 404. The catalog was fine; the snapshot's lists were stale. Prepare now runs `apt-get update` before building the venv, once per prepare.
- **Kali** — prepare failed at profile 5 of 15 with a bare `CalledProcessError` and nothing captured, so a PyPI hiccup and a broken guest were the same verdict. `prepare()` prints the guest's output on failure and retries once.
- **Ubuntu 24.04** — `digital-modes` FAILED at 663 s and the reason was unreadable until the campaign ended hours later. The report is rewritten after every unit.
- **Pop!_OS 24.04** — runs its own `apt-get` at boot and held the lists lock against the first prepare after a restore. `DPkg::Lock::Timeout` looks like the fix and is not: measured against a held fcntl lock in the Debian 13 container, apt 3.0.3 fails in 0 s with it set. The update is retried in a bounded loop, measured through a 25 s hold (3 retries, 31 s) and at the bound (exit 100).

`--reset-first DOMAIN` restores `clean-baseline` and prepares once before the first unit, for whole-catalog campaigns.

Test: drives `prepare()` with a fake ssh that fails once with PyPI text, and was made to fail by removing the `apt-get update`. Runbook updated (`docs/contributing/vm-testing.md`).

Evidence: the Parrot rerun, Kali and Pop!_OS profile campaigns launched tonight run on this branch; results land in the morning report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)