### PR TITLE
cli: an apt 404 from the pool is diagnosed as stale lists, with the remedy

### DIFF
--- a/.venv
+++ b/.venv
@@ -1,0 +1,1 @@
+/home/chiefgyk3d/src/hammunition/.venv

--- a/docs/QUESTIONS.md
+++ b/docs/QUESTIONS.md
@@ -886,3 +886,56 @@ is installed *now*, not at what the same transaction installs) and was fixed
 as one the same night, not deferred: the plan now asks `apt-get --simulate`
 and refuses the pairing by name, and the profile no longer lists
 `wsjtx-improved`.
+
+---
+
+## Q-018 🟡 — Should `install` refresh the apt lists by default?
+
+**Raised 2026-09-04**, from the whole-profile campaign on Parrot
+(`~/.local/state/hammunition-campaigns/profiles-parrot-2026-09-03.md`, the
+first run; the rerun with fresh lists is in the morning report). The
+guest's `clean-baseline` was four days old. Its lists named
+`glib2.0 2.84.4-3~deb13u3`; the pool had moved to the next revision; and
+**six of fifteen profiles** — `digital-modes`, `electronics`, `listening`,
+`logging`, `packet`, `propagation` — passed the plan and died four
+commands in:
+
+```
+E: Failed to fetch https://deb.parrot.sh/parrot/pool/main/g/glib2.0/libglib2.0-dev_2.84.4-3%7edeb13u3_amd64.deb  404  Not Found
+E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
+```
+
+The catalog was right and the machine was unchanged (apt fetches every
+archive before it unpacks any). Four days is not an unusual age for an
+operator's lists; a laptop that last ran `apt update` before a trip will
+hit this on its first `hammunition install` home. AHRL and 73Linux both run
+`apt update` unconditionally before anything else, which is why neither
+has ever reported this failure.
+
+What the engine does today: `--refresh` puts `apt-get update` at the head
+of the transaction, disclosed in the plan, and the plan refuses outright
+when there are *no* lists. Nothing handles lists that exist and are stale,
+because nothing can measure it: the list files carry the archive's
+`Last-Modified` as their mtime and an `apt-get update` that hits unchanged
+indexes touches nothing, so "when did this machine last update" is not
+on disk on Debian at all (Ubuntu writes `/var/lib/apt/periodic/update-success-stamp`
+via a conf.d snippet Debian does not ship). The failure is now
+*diagnosed* — the message names the files, says nothing was installed,
+and gives the remedy — but a diagnosis is a consolation, not a fix.
+
+| Option | For | Against |
+|---|---|---|
+| **A. Refresh by default; `--no-refresh` to opt out** ⭐ | Matches what every operator does by hand and what both inventory sources do. The command is already disclosed in the plan when `--refresh` is passed; making it the default changes nothing about what `--dry-run` shows, only when. A plan with nothing to install skips it, so an idempotent re-run stays a no-op. | Every install starts with a privileged network operation. A field station with no uplink fails before its first package unless it remembers `--no-refresh` (the local-mirror case). The plan's candidate check still resolves against the *old* lists — the refresh runs after the plan is shown — so a package the fresh lists would newly offer is still refused, and one they would newly lack still fails at fetch, one step later. Every documented example gains a first line. |
+| B. Refresh when the lists look old | No cost on a fresh machine. | Not measurable on Debian, as above. A heuristic on file mtimes would read the archive's own timestamps and be wrong in both directions. Rejected on the evidence, not the taste. |
+| C. On a 404, run `apt-get update` and retry the same `apt-get install` once | Self-healing, contained, no default changes; D-038 is the precedent for one automatic retry. | D-038 retries the *plan*; this would run a command `--dry-run` never printed, which CLAUDE.md forbids — the dry run must be complete. And a retry after a partial fetch is exactly the moment an operator wants to be asked. |
+| D. Leave it: diagnosis plus `--refresh` | No change; the message now says what to do. | The operator learns the flag by failing once. That is the AHRL install-once-and-rot pattern (D-010) at the level of a single run. |
+
+**Recommendation: A.** The plan-time weakness is real but bounded — it
+produces one clean failure with the diagnosis, never a partial install —
+and the alternative is that every operator's first run after a few days
+away fails. If the field-station case matters more than it looks, `B`'s
+measurement problem does not go away and `C` is ruled out by the dry-run
+rule, so A with the opt-out is the only shape that survives. Whether the
+refresh also re-runs the candidate check against the fresh lists (a second,
+better plan, disclosed as such) is a follow-on, and worth doing if A is
+taken.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -625,6 +625,18 @@ Hammunition does not roll back. It tells you what it did (**D-004**). On a
 failure the run stops at that command, and the count that completed is printed
 along with the log's location.
 
+One failure is diagnosed rather than merely printed. When an `apt-get install`
+fails with `404 Not Found` on files in the pool, the package lists on the
+machine are older than the archive: the plan resolved against those lists,
+so the catalog is not at fault, and apt downloads every archive before it
+unpacks any, so the command installed nothing. The message says so, names
+the files by version, and gives the remedy — `sudo apt-get update`, or
+`--refresh` on the same run. Six of fifteen profiles on a four-day-old Parrot
+guest died this way (2026-09-03), each report ending in seven URLs and
+apt's own hint under them. A `5xx` or a timeout is a mirror problem and gets
+no such diagnosis; sending an operator to refresh lists that are fine would
+be a wrong answer with a confident tone.
+
 ## What is not here yet
 
 `uninstall` reverses apt, venv and binary installs, copied binaries,

--- a/src/hammunition/backends/apt.py
+++ b/src/hammunition/backends/apt.py
@@ -49,6 +49,7 @@ import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import unquote
 
 from .base import BackendError, Command, CommandRunner
 
@@ -60,6 +61,7 @@ __all__ = [
     "downgrades_refused",
     "parse_policy",
     "parse_simulation",
+    "stale_fetches",
 ]
 
 APT_LISTS = Path("/var/lib/apt/lists")
@@ -212,6 +214,37 @@ def downgrades_refused(error: str) -> list[str]:
         if match is not None and match["name"] not in names:
             names.append(match["name"])
     return names
+
+
+_FETCH_404_LINE = re.compile(r"^E: Failed to fetch (?P<url>\S+)\s+404\s+Not Found\b")
+
+
+def stale_fetches(error: str) -> list[str]:
+    """The ``.deb`` files a failed ``apt-get install`` asked the archive for
+    and was told no longer exist, from its transcript.
+
+    A Parrot 7.3 guest whose lists were four days old (2026-09-03)::
+
+        E: Failed to fetch https://deb.parrot.sh/parrot/pool/main/g/glib2.0/libglib2.0-dev_2.84.4-3%7edeb13u3_amd64.deb  404  Not Found [IP: 108.62.48.7 443]
+        E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
+
+    The lists named a glib2.0 the pool had since replaced. Nothing about the
+    catalog was wrong, the plan's candidate check had passed against those
+    same lists, and the transaction died four commands in with apt's own
+    hint buried under seven URLs. The file names are returned decoded
+    (``%7e`` is ``~``) so the message can name the versions. Any other
+    failure, and any other status than 404, yields an empty list: a mirror
+    that is down (a 5xx, a timeout) is not stale lists, and saying so would
+    send the operator to refresh lists that are fine.
+    """
+    files: list[str] = []
+    for line in error.splitlines():
+        match = _FETCH_404_LINE.match(line)
+        if match is not None:
+            name = unquote(match["url"].rsplit("/", 1)[-1])
+            if name not in files:
+                files.append(name)
+    return files
 
 
 @dataclass(frozen=True)

--- a/src/hammunition/cli/main.py
+++ b/src/hammunition/cli/main.py
@@ -38,6 +38,7 @@ from importlib import metadata
 from pathlib import Path
 
 from hammunition.backends import (
+    Action,
     AptBackend,
     AptRepoBackend,
     BackendError,
@@ -49,6 +50,7 @@ from hammunition.backends import (
     SubprocessRunner,
     VenvBackend,
 )
+from hammunition.backends.apt import stale_fetches
 from hammunition.backends.source import DEFAULT_PREFIX
 from hammunition.consent import (
     ConsentDeclined,
@@ -881,6 +883,9 @@ def cmd_install(args: argparse.Namespace) -> int:
         f"\nFailed: {report.failed.display(euid=euid)}\n{report.stderr.strip()}",
         file=sys.stderr,
     )
+    stale = stale_lists_diagnosis(report.failed, report.stderr)
+    if stale:
+        print(f"\n{stale}", file=sys.stderr)
     print(
         f"{len(report.completed)} command(s) completed before the failure and are "
         f"recorded in {log.path}. Hammunition does not roll back; it tells you what "
@@ -888,6 +893,34 @@ def cmd_install(args: argparse.Namespace) -> int:
         file=sys.stderr,
     )
     return EXIT_FAILED
+
+
+def stale_lists_diagnosis(failed: Command | Action, stderr: str) -> str | None:
+    """What a 404 from ``apt-get install`` means, in the operator's terms.
+
+    The plan's candidate check passed against the package lists on disk;
+    the archive has since replaced a version those lists name; apt asked for
+    the old file and was told it is gone. The catalog was right and the
+    machine is unchanged -- apt fetches every archive before it unpacks
+    any, so a fetch failure leaves nothing half-installed -- and the fix is
+    the one apt itself hints at under the URLs. Six of fifteen profiles on
+    a four-day-old Parrot guest failed exactly this way (2026-09-03), each
+    report ending in seven ``Failed to fetch`` lines and no diagnosis.
+    """
+    if isinstance(failed, Action) or "apt-get" not in failed.argv or "install" not in failed.argv:
+        return None
+    missing = stale_fetches(stderr)
+    if not missing:
+        return None
+    shown = ", ".join(missing[:3]) + (f" and {len(missing) - 3} more" if len(missing) > 3 else "")
+    return (
+        f"The package lists on this machine are older than the archive: apt asked for "
+        f"{len(missing)} file(s) the mirror no longer has ({shown}). The plan resolved "
+        f"against those lists, so the catalog is not at fault, and apt downloads every "
+        f"archive before unpacking any, so this command installed nothing. Refresh the "
+        f"lists and run the same install again: `sudo apt-get update`, or add --refresh "
+        f"to do it as the first step of the run."
+    )
 
 
 def cmd_uninstall(args: argparse.Namespace) -> int:

--- a/tests/test_target_release.py
+++ b/tests/test_target_release.py
@@ -207,3 +207,56 @@ def test_the_plan_prints_what_comes_from_the_release(tmp_path: Path) -> None:
     assert "libcurl4-openssl-dev" in text
     assert "libnghttp3-dev" in text
     assert "D-038" in text
+
+
+PARROT_STALE_LISTS = """\
+E: Failed to fetch https://deb.parrot.sh/parrot/pool/main/g/glib2.0/gir1.2-glib-2.0-dev_2.84.4-3%7edeb13u3_amd64.deb  404  Not Found [IP: 108.62.48.7 443]
+E: Failed to fetch https://deb.parrot.sh/parrot/pool/main/g/glib2.0/libgirepository-2.0-0_2.84.4-3%7edeb13u3_amd64.deb  404  Not Found [IP: 108.62.48.7 443]
+E: Failed to fetch https://deb.parrot.sh/parrot/pool/main/g/glib2.0/girepository-tools_2.84.4-3%7edeb13u3_amd64.deb  404  Not Found [IP: 108.62.48.7 443]
+E: Failed to fetch https://deb.parrot.sh/parrot/pool/main/g/glib2.0/libglib2.0-dev_2.84.4-3%7edeb13u3_amd64.deb  404  Not Found [IP: 108.62.48.7 443]
+E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
+"""
+
+
+def test_a_404_from_the_pool_is_read_as_stale_lists_and_named_by_version() -> None:
+    """Six of fifteen profiles on a four-day-old Parrot guest failed at their
+    first apt-get install with this transcript (2026-09-03): the lists named
+    a glib2.0 the pool had replaced. The catalog was right, the plan had
+    passed against those lists, and the report ended in seven URLs with no
+    diagnosis. A 5xx or a timeout is a mirror problem, not stale lists, and
+    must not send the operator to refresh lists that are fine."""
+    from hammunition.backends.apt import stale_fetches
+
+    assert stale_fetches(PARROT_STALE_LISTS) == [
+        "gir1.2-glib-2.0-dev_2.84.4-3~deb13u3_amd64.deb",
+        "libgirepository-2.0-0_2.84.4-3~deb13u3_amd64.deb",
+        "girepository-tools_2.84.4-3~deb13u3_amd64.deb",
+        "libglib2.0-dev_2.84.4-3~deb13u3_amd64.deb",
+    ]
+    down = "E: Failed to fetch https://deb.debian.org/debian/pool/main/f/foo/foo_1_amd64.deb  503  Service Unavailable\n"
+    assert stale_fetches(down) == []
+    assert stale_fetches(PARROT_REFUSAL) == []
+
+
+def test_the_install_failure_says_stale_lists_installed_nothing_and_names_the_fix() -> None:
+    from hammunition.backends import Action, Command
+    from hammunition.cli.main import stale_lists_diagnosis
+
+    install = Command(
+        argv=("apt-get", "install", "--yes", "--", "libglib2.0-dev"),
+        description="",
+        requires_root=True,
+    )
+    text = stale_lists_diagnosis(install, PARROT_STALE_LISTS)
+    assert text is not None
+    assert "4 file(s) the mirror no longer has" in text
+    assert "girepository-tools_2.84.4-3~deb13u3_amd64.deb" in text and "and 1 more" in text
+    assert "libglib2.0-dev_2.84.4-3~deb13u3_amd64.deb" not in text  # the elided fourth
+    assert "installed nothing" in text
+    assert "sudo apt-get update" in text and "--refresh" in text
+    # Not every apt-get failure is this one, and not every 404 is apt's.
+    assert stale_lists_diagnosis(install, PARROT_REFUSAL) is None
+    remove = Command(argv=("apt-get", "remove", "--yes", "foo"), description="")
+    assert stale_lists_diagnosis(remove, PARROT_STALE_LISTS) is None
+    unpack = Action(kind="unpack", description="unpack", detail="", perform=lambda: "")
+    assert stale_lists_diagnosis(unpack, PARROT_STALE_LISTS) is None


### PR DESCRIPTION
The engine half of the finding behind #19.

Six of fifteen profiles on a four-day-old Parrot guest passed the plan and died four commands in (2026-09-03): the lists named `glib2.0 2.84.4-3~deb13u3`, the pool had moved on, and each report ended in seven `Failed to fetch … 404` lines with apt's own hint buried under them. The catalog was right and the machine was unchanged — apt fetches every archive before it unpacks any.

- `stale_fetches()` in the apt backend reads the 404 lines out of the transcript, file names decoded so the message can name versions. A 5xx or a timeout yields nothing: a mirror that is down is not stale lists, and saying so would send the operator to refresh lists that are fine.
- The install failure path prints the diagnosis — what happened, that nothing was installed, and the remedy (`sudo apt-get update`, or `--refresh` on the same run).
- `docs/reference/cli.md` documents it.
- **Q-018** asks whether `--refresh` should be the default, with a recommendation (A, with `--no-refresh`) and the measurement of why "refresh when the lists look old" is not an option: list file mtimes are the archive's `Last-Modified`, an all-Hit update touches nothing, and only Ubuntu writes `update-success-stamp` (verified on the 24.04 VM; Parrot has neither the stamp nor the conf.d snippet).

Tests drive both from the real Parrot transcript, including the not-this-failure cases (a 503, apt's downgrade refusal, `apt-get remove`, an in-process `Action`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)