### PR TITLE
fix: a cmake build pulls cmake into the apt set — wsjtx worked by accident

### DIFF
--- a/docs/contributing/manifests.md
+++ b/docs/contributing/manifests.md
@@ -83,15 +83,21 @@ Where the reason is real, say it in the install block's `note`, with what was
 measured and when.
 
 `build_depends` lists what the *software* needs to build — libraries, headers,
-Qt. The engine's own tools are not the manifest's job: a `git` block pulls in
-`git`, `autoreconf: true` pulls in autoconf/automake/libtool, a `node` block
-pulls in `nodejs` and `npm`, and `build_system: cmake` pulls in `cmake`. That
-last one was learned the hard way — `wsjtx` never listed cmake and built on
-five targets anyway because `js8call` in the same profile did, until Pop!_OS
-resolved `js8call` from apt and `digital-modes` died at command 27 with
-`'cmake' is not on PATH`. A manifest that relies on its neighbours for a tool
-is a manifest that works by accident. Listing `cmake` yourself is harmless (it
-is de-duplicated), just unnecessary.
+Qt. The toolchain is not the manifest's job: every `source` or `git` block
+pulls in `build-essential`, a `build_system: cmake` block pulls in `cmake`, a
+`git` block pulls in `git`, `autoreconf: true` pulls in
+autoconf/automake/libtool, and a `node` block pulls in `nodejs` and `npm`.
+This was learned the hard way — `wsjtx` never listed cmake or a compiler and
+built on five targets anyway because `js8call` in the same profile did, until
+Pop!_OS resolved `js8call` from apt and `digital-modes` died at command 27
+with `'cmake' is not on PATH`. Measured the same day: the Debian 13 baseline
+ships no gcc, 33 of 39 compiled manifests listed `build-essential` by hand,
+and four (`fldigi`, `glfer`, `mshv`, `wsjtx`) relied on a neighbour — `mshv`'s
+own note already records that order-dependence for a header. A manifest that
+relies on its neighbours for a tool works by accident. Listing
+`build-essential` or `cmake` yourself is harmless (de-duplicated), just
+unnecessary. `qmake` is the exception: every qmake manifest names `qt5-qmake`
+or `qt6-base-dev` itself and the engine does not add one.
 
 ## Categories come from the vocabulary
 

--- a/docs/contributing/manifests.md
+++ b/docs/contributing/manifests.md
@@ -82,6 +82,17 @@ worth six `-Wno-*` flags and a build that a future GCC will break.
 Where the reason is real, say it in the install block's `note`, with what was
 measured and when.
 
+`build_depends` lists what the *software* needs to build — libraries, headers,
+Qt. The engine's own tools are not the manifest's job: a `git` block pulls in
+`git`, `autoreconf: true` pulls in autoconf/automake/libtool, a `node` block
+pulls in `nodejs` and `npm`, and `build_system: cmake` pulls in `cmake`. That
+last one was learned the hard way — `wsjtx` never listed cmake and built on
+five targets anyway because `js8call` in the same profile did, until Pop!_OS
+resolved `js8call` from apt and `digital-modes` died at command 27 with
+`'cmake' is not on PATH`. A manifest that relies on its neighbours for a tool
+is a manifest that works by accident. Listing `cmake` yourself is harmless (it
+is de-duplicated), just unnecessary.
+
 ## Categories come from the vocabulary
 
 `catalog/categories.yaml` is the controlled list. Adding a tag means adding it

--- a/src/hammunition/plan.py
+++ b/src/hammunition/plan.py
@@ -944,16 +944,22 @@ def resolve(
                 tool_depends = (*tool_depends, "patch")
         if getattr(block.install, "autoreconf", False):
             tool_depends = (*tool_depends, "autoconf", "automake", "libtool")
-        # The build system is the engine's tool as much as git is. wsjtx never
-        # declared cmake and built on five targets anyway, because js8call in
-        # the same profile is a git build there and declares it; on Pop!_OS
-        # 24.04 js8call comes from apt, nothing else asked for cmake, and
-        # digital-modes died at command 27 with 'cmake' not on PATH
-        # (2026-09-04). The other build systems are not injected here yet:
-        # every qmake manifest declares qt5-qmake itself, and what
-        # autotools and make builds get a compiler from is unmeasured.
-        if getattr(block.install, "build_system", None) == "cmake":
-            tool_depends = (*tool_depends, "cmake")
+        # The toolchain is the engine's tool as much as git is. wsjtx never
+        # declared cmake or a compiler and built on five targets anyway,
+        # because js8call in the same profile is a git build there and
+        # declares both; on Pop!_OS 24.04 js8call comes from apt, nothing
+        # else asked for cmake, and digital-modes died at command 27 with
+        # 'cmake' not on PATH (2026-09-04). Measured the same day on the
+        # Debian 13 baseline, which ships no gcc: 33 of the catalog's 39
+        # source/git manifests list build-essential by hand and four C/C++
+        # builds (fldigi, glfer, mshv, wsjtx) rely on a neighbour for it --
+        # mshv's own note records the order-dependence. So every compiled
+        # build gets build-essential, and a cmake build gets cmake. qmake is
+        # not injected: all six qmake manifests declare qt5-qmake themselves.
+        if block.install.method in ("source", "git"):
+            tool_depends = (*tool_depends, "build-essential")
+            if getattr(block.install, "build_system", None) == "cmake":
+                tool_depends = (*tool_depends, "cmake")
         if block.install.method == "apt":
             packages = (*block.install.packages, *distro_depends)
             build_only: tuple[str, ...] = ()

--- a/src/hammunition/plan.py
+++ b/src/hammunition/plan.py
@@ -944,6 +944,16 @@ def resolve(
                 tool_depends = (*tool_depends, "patch")
         if getattr(block.install, "autoreconf", False):
             tool_depends = (*tool_depends, "autoconf", "automake", "libtool")
+        # The build system is the engine's tool as much as git is. wsjtx never
+        # declared cmake and built on five targets anyway, because js8call in
+        # the same profile is a git build there and declares it; on Pop!_OS
+        # 24.04 js8call comes from apt, nothing else asked for cmake, and
+        # digital-modes died at command 27 with 'cmake' not on PATH
+        # (2026-09-04). The other build systems are not injected here yet:
+        # every qmake manifest declares qt5-qmake itself, and what
+        # autotools and make builds get a compiler from is unmeasured.
+        if getattr(block.install, "build_system", None) == "cmake":
+            tool_depends = (*tool_depends, "cmake")
         if block.install.method == "apt":
             packages = (*block.install.packages, *distro_depends)
             build_only: tuple[str, ...] = ()

--- a/tests/test_displacement.py
+++ b/tests/test_displacement.py
@@ -153,7 +153,12 @@ def _plan_with_conflict(tmp_path: Path, method_block: dict[str, Any], installed:
     from test_plan import _apt  # reuse the fake-apt helper
 
     manifest = _conflicting_manifest(method_block)
-    known = {"distro-owned": "1.0" if installed else None, "clasher": None, "git": None}
+    known = {
+        "distro-owned": "1.0" if installed else None,
+        "clasher": None,
+        "git": None,
+        "build-essential": None,
+    }
     apt = _apt(tmp_path, known)
     return resolve(
         ["clasher"],

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -685,3 +685,61 @@ def test_a_git_build_pulls_git_itself_into_the_apt_set(tmp_path: Path) -> None:
     assert "git" in plan.apt_to_install
     planned = plan.packages[0]
     assert "git" in planned.build_only
+
+
+def test_a_cmake_build_pulls_cmake_itself_into_the_apt_set(tmp_path: Path) -> None:
+    """wsjtx never declared cmake and built on five targets anyway: js8call in
+    the same profile is a git build there and declares it. On Pop!_OS 24.04
+    js8call comes from apt, nothing else asked for cmake, and digital-modes
+    died at command 27 with 'cmake' not on PATH (2026-09-04). The build
+    system is the engine's tool, like git; a unit that declares cmake as well
+    gets it once."""
+    unit = _manifest(
+        name="cmakeunit",
+        install=[
+            {
+                "install": {
+                    "method": "git",
+                    "repo": "https://example.org/x",
+                    "ref": "1.0",
+                    "build_system": "cmake",
+                }
+            }
+        ],
+    )
+    known = {"git": None, "cmake": None, "cmakeunit": None}
+    plan = _resolve(tmp_path, ["cmakeunit"], catalog={"cmakeunit": unit}, known=known)
+    assert "cmake" in plan.apt_to_install and "git" in plan.apt_to_install
+    assert plan.packages[0].build_only.count("cmake") == 1
+    declared = _manifest(
+        name="declared",
+        install=[
+            {
+                "install": {
+                    "method": "source",
+                    "source": {"url": "https://example.invalid/c.tar.gz", "sha256": "d" * 64},
+                    "build_system": "cmake",
+                },
+                "build_depends": ["cmake"],
+            }
+        ],
+    )
+    plan = _resolve(tmp_path, ["declared"], catalog={"declared": declared}, known=known)
+    assert plan.packages[0].build_only.count("cmake") == 1
+    make = _manifest(
+        name="makeunit",
+        install=[
+            {
+                "install": {
+                    "method": "git",
+                    "repo": "https://example.org/y",
+                    "ref": "1.0",
+                    "build_system": "make",
+                }
+            }
+        ],
+    )
+    plan = _resolve(
+        tmp_path, ["makeunit"], catalog={"makeunit": make}, known={"git": None, "makeunit": None}
+    )
+    assert "cmake" not in plan.apt_to_install

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -545,16 +545,17 @@ def _source_manifest(**install: Any) -> PackageManifest:
 
 def test_build_depends_are_what_a_source_build_installs(tmp_path: Path) -> None:
     """A source build installs its toolchain from apt, not itself. The manifest's
-    own name is not an apt package and must not be treated as one."""
+    own name is not an apt package and must not be treated as one; the compiler
+    is the engine's and rides along whether or not the manifest names it."""
     plan = _resolve(
         tmp_path,
         ["example"],
         catalog={"example": _source_manifest()},
-        known={"libexample-dev": None, "fftw2": None},
+        known={"libexample-dev": None, "fftw2": None, "build-essential": None},
     )
     planned = plan.packages[0]
-    assert set(planned.apt_packages) == {"libexample-dev", "fftw2"}
-    assert set(planned.build_only) == {"libexample-dev", "fftw2"}
+    assert set(planned.apt_packages) == {"libexample-dev", "fftw2", "build-essential"}
+    assert set(planned.build_only) == {"libexample-dev", "fftw2", "build-essential"}
     assert "example" not in planned.apt_packages
 
 
@@ -652,7 +653,7 @@ def test_a_depends_naming_another_manifest_is_not_asked_of_apt(tmp_path: Path) -
         tmp_path,
         ["consumer"],
         catalog={"library": library, "consumer": consumer},
-        known={"cmake": None, "libreal-dev": None},  # note: no "library"
+        known={"cmake": None, "build-essential": None, "libreal-dev": None},  # no "library"
     )
 
     names = [p.name for p in plan.packages]
@@ -681,19 +682,26 @@ def test_a_git_build_pulls_git_itself_into_the_apt_set(tmp_path: Path) -> None:
             ],
         )
     }
-    plan = _resolve(tmp_path, ["gitunit"], catalog=catalog, known={"git": None, "gitunit": None})
+    plan = _resolve(
+        tmp_path,
+        ["gitunit"],
+        catalog=catalog,
+        known={"git": None, "build-essential": None, "gitunit": None},
+    )
     assert "git" in plan.apt_to_install
     planned = plan.packages[0]
     assert "git" in planned.build_only
 
 
-def test_a_cmake_build_pulls_cmake_itself_into_the_apt_set(tmp_path: Path) -> None:
-    """wsjtx never declared cmake and built on five targets anyway: js8call in
-    the same profile is a git build there and declares it. On Pop!_OS 24.04
-    js8call comes from apt, nothing else asked for cmake, and digital-modes
-    died at command 27 with 'cmake' not on PATH (2026-09-04). The build
-    system is the engine's tool, like git; a unit that declares cmake as well
-    gets it once."""
+def test_a_compiled_build_pulls_its_toolchain_into_the_apt_set(tmp_path: Path) -> None:
+    """wsjtx never declared cmake or a compiler and built on five targets
+    anyway: js8call in the same profile is a git build there and declares
+    both. On Pop!_OS 24.04 js8call comes from apt, nothing else asked for
+    cmake, and digital-modes died at command 27 with 'cmake' not on PATH
+    (2026-09-04); the Debian 13 baseline ships no gcc either. The toolchain
+    is the engine's tool, like git: every source/git build gets
+    build-essential, a cmake build gets cmake, and a unit that declares
+    either as well gets it once."""
     unit = _manifest(
         name="cmakeunit",
         install=[
@@ -707,9 +715,10 @@ def test_a_cmake_build_pulls_cmake_itself_into_the_apt_set(tmp_path: Path) -> No
             }
         ],
     )
-    known = {"git": None, "cmake": None, "cmakeunit": None}
+    known = {"git": None, "cmake": None, "build-essential": None, "cmakeunit": None}
     plan = _resolve(tmp_path, ["cmakeunit"], catalog={"cmakeunit": unit}, known=known)
     assert "cmake" in plan.apt_to_install and "git" in plan.apt_to_install
+    assert "build-essential" in plan.apt_to_install
     assert plan.packages[0].build_only.count("cmake") == 1
     declared = _manifest(
         name="declared",
@@ -720,12 +729,13 @@ def test_a_cmake_build_pulls_cmake_itself_into_the_apt_set(tmp_path: Path) -> No
                     "source": {"url": "https://example.invalid/c.tar.gz", "sha256": "d" * 64},
                     "build_system": "cmake",
                 },
-                "build_depends": ["cmake"],
+                "build_depends": ["build-essential", "cmake"],
             }
         ],
     )
     plan = _resolve(tmp_path, ["declared"], catalog={"declared": declared}, known=known)
     assert plan.packages[0].build_only.count("cmake") == 1
+    assert plan.packages[0].build_only.count("build-essential") == 1
     make = _manifest(
         name="makeunit",
         install=[
@@ -739,7 +749,7 @@ def test_a_cmake_build_pulls_cmake_itself_into_the_apt_set(tmp_path: Path) -> No
             }
         ],
     )
-    plan = _resolve(
-        tmp_path, ["makeunit"], catalog={"makeunit": make}, known={"git": None, "makeunit": None}
-    )
+    known = {"git": None, "build-essential": None, "makeunit": None}
+    plan = _resolve(tmp_path, ["makeunit"], catalog={"makeunit": make}, known=known)
     assert "cmake" not in plan.apt_to_install
+    assert "build-essential" in plan.apt_to_install


### PR DESCRIPTION
## What

`build_system: cmake` now injects `cmake` into the planner's `tool_depends` (→ `apt_to_install` and `build_only`), alongside the existing git / autoreconf / node injections.

## Why

Found by the Pop!_OS 24.04 profile campaign (2026-09-04): `digital-modes` FAILED at command 27/49, `'cmake' is not on PATH` at wsjtx's configure step.

`wsjtx.yaml` is the only cmake manifest without `cmake` in `build_depends`. On the other five targets `js8call` (same profile) is a git build and declares cmake, so wsjtx was carried by its neighbour. On Pop `js8call` resolves to apt and nothing asked for cmake.

Only cmake is injected — every qmake manifest declares `qt5-qmake` itself, and how make/autotools builds get a compiler on a baseline without build-essential is unmeasured (Debian 13's clean baseline has none and digital-modes still passed there — open question in the morning report).

## Evidence

- Test goes red without the fix: `assert 'cmake' in ('git',)`.
- Re-verified on the Pop VM: see PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)