### PR TITLE
catalog: wsjtx declares libhamlib-dev — it had been building in js8call's wake

### DIFF
--- a/catalog/packages/wsjtx.yaml
+++ b/catalog/packages/wsjtx.yaml
@@ -19,7 +19,6 @@ install:
       repo: https://github.com/WSJTX/wsjtx
       ref: "v3.0.2"
       build_system: cmake
-      configure_args: ["-DWSJT_SKIP_MANPAGES=ON", "-DWSJT_GENERATE_DOCS=OFF"]
       configure_args:
         - -DWSJT_SKIP_MANPAGES=ON
         - -DWSJT_GENERATE_DOCS=OFF
@@ -41,6 +40,15 @@ install:
       - libreadline-dev
       - libusb-1.0-0-dev
       - libudev-dev
+      # Never declared here, and never missed: on every target where js8call
+      # is a git build it declares libhamlib-dev and wsjtx built in its wake.
+      # Pop!_OS 24.04 resolves js8call from apt, and the first isolated
+      # configure stopped at "We could not find development headers for
+      # Hamlib" (VM campaign, 2026-09-04). D-016's order-dependence again.
+      - libhamlib-dev
+
+# libhamlib4t64, not libhamlib4 — see the note in fldigi.yaml.
+depends: [libhamlib4t64]
 
 # SHAPE 3 — the collision, resolved by declaration rather than choreography.
 # Both this package and wsjtx-improved emit a binary called `wsjtx`. AHRL

--- a/docs/packages/wsjtx.md
+++ b/docs/packages/wsjtx.md
@@ -7,6 +7,7 @@
 - **Version recorded:** 3.0.2
 - **Categories:** `digital-modes`
 - **Upstream:** <https://wsjtx.github.io/wsjtx/index.html>
+- **Needs first:** `libhamlib4t64`
 
 ## What it does
 
@@ -23,7 +24,7 @@ Accurate system clock (within about a second), CAT rig control, and audio routed
 ## How it installs
 
 - git (cmake) — https://github.com/WSJTX/wsjtx at `v3.0.2`
-  - build dependencies: `gfortran`, `libboost-dev`, `libboost-log-dev`, `libboost-filesystem-dev`, `qttools5-dev`, `qttools5-dev-tools`, `qtmultimedia5-dev`, `libqt5serialport5-dev`, `libfftw3-dev`, `libreadline-dev`, `libusb-1.0-0-dev`, `libudev-dev`
+  - build dependencies: `gfortran`, `libboost-dev`, `libboost-log-dev`, `libboost-filesystem-dev`, `qttools5-dev`, `qttools5-dev-tools`, `qtmultimedia5-dev`, `libqt5serialport5-dev`, `libfftw3-dev`, `libreadline-dev`, `libusb-1.0-0-dev`, `libudev-dev`, `libhamlib-dev`
 
 Binaries this produces:
 


### PR DESCRIPTION
## What

`wsjtx.yaml` gains `libhamlib-dev` in `build_depends` and `depends: [libhamlib4t64]` (mirroring `js8call` and `fldigi`). Also drops a duplicated `configure_args` key whose first copy YAML was silently discarding.

## Why

Second finding from the Pop!_OS 24.04 campaign (2026-09-04). With cmake supplied by #21, wsjtx's configure stopped at *"We could not find development headers for Hamlib"*. The manifest never declared it; on the four targets where `js8call` is a git build in the same profile, js8call's `libhamlib-dev` carried it. On Ubuntu 24.04, Pop!_OS and Mint 22.3 `js8call` resolves to apt, so the headers were never installed.

Independent of #21 (a library the software needs is the manifest's job; the toolchain is the engine's).

## Evidence

Pop VM re-verification in a PR comment once the profile campaign reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)