### PR TITLE
catalog: re-pin yaac to upstream beta build#230

### DIFF
--- a/catalog/packages/yaac.yaml
+++ b/catalog/packages/yaac.yaml
@@ -2,22 +2,29 @@
 # SPDX-License-Identifier: CC0-1.0
 
 name: yaac
-version: "snapshot-2026-08-30"
+version: "build-230"
 summary: Yet Another APRS Client — the deep, portable Java one
 categories: [packet, tracking]
 
 # CARRY from AHRL. Upstream publishes exactly one artifact, an unversioned
 # rolling YAAC.zip -- the same shape 73Linux's Beta directory had, but with
-# no versioned alternative anywhere. The pin below is a dated snapshot
-# hash: it verifies what we measured, and it WILL break on upstream's next
+# no versioned alternative anywhere. The pin below is the hash of one
+# roll: it verifies what we measured, and it WILL break on upstream's next
 # roll, which is the honest failure mode -- refetch, rehash, rebump. The
 # alternative (no hash) is a path this catalog does not have (D-004).
+#
+# `version` is upstream's own build number, read from the first line of
+# https://www.ka2ddo.org/ka2ddo/YAACBuildNotes.txt, which is the one place
+# upstream names what YAAC.zip currently is. First roll caught by the pin:
+# the 2026-08-30 snapshot (e64c3fca…) failed on Kali on 2026-09-04 against
+# beta build#230, dated 2026-Sep-03 -- exactly the failure this comment
+# predicted. Digest measured twice from the host, identical.
 install:
   - install:
       method: binary
       artifact:
         url: https://www.ka2ddo.org/ka2ddo/YAAC.zip
-        sha256: e64c3fca5fa466f08af49c2104ca604c14d6c1c9d681771408dd07c7db5007e6
+        sha256: a56c4037d1384e399290a1024e3b2d781a251257715528287db83a19429d5d5f
       format: zip
       install_tree: true
     note: >-
@@ -56,7 +63,7 @@ documentation:
     group; libjssc-java supplies the serial bindings.
   known_problems: >-
     First run opens a setup wizard; give it a moment on the first tile
-    download. The dated-snapshot pin above means an upstream roll turns into
+    download. The single-roll pin above means an upstream roll turns into
     a hash-mismatch refusal until this manifest is re-pinned -- deliberate,
     and the cadence hint says why.
   upstream_url: https://www.ka2ddo.org/ka2ddo/YAAC.html

--- a/docs/packages/yaac.md
+++ b/docs/packages/yaac.md
@@ -4,7 +4,7 @@
 
 **Yet Another APRS Client — the deep, portable Java one**
 
-- **Version recorded:** snapshot-2026-08-30
+- **Version recorded:** build-230
 - **Categories:** `packet`, `tracking`
 - **Upstream:** <https://www.ka2ddo.org/ka2ddo/YAAC.html>
 - **Needs first:** `default-jre-headless`, `libjssc-java`
@@ -28,7 +28,7 @@ A TNC (Direwolf serves well -- this catalog configures it) or an APRS-IS passcod
 
 ## Known problems
 
-First run opens a setup wizard; give it a moment on the first tile download. The dated-snapshot pin above means an upstream roll turns into a hash-mismatch refusal until this manifest is re-pinned -- deliberate, and the cadence hint says why.
+First run opens a setup wizard; give it a moment on the first tile download. The single-roll pin above means an upstream roll turns into a hash-mismatch refusal until this manifest is re-pinned -- deliberate, and the cadence hint says why.
 
 ## Keeping it current
 


### PR DESCRIPTION
## What

`yaac` FAILED on the Kali unit pass (2026-09-04, 6 s): the sha256 of `https://www.ka2ddo.org/ka2ddo/YAAC.zip` no longer matches the pin. The manifest predicted exactly this — upstream rolls one unversioned zip in place, and its `update.cadence_hint` says a hash mismatch *is* the update signal.

## Measured before re-pinning

- The zip fetched twice from the host: same digest both times, `a56c4037…`.
- `Last-Modified: 2026-09-04 03:25 GMT`; twenty entries in `YAAC.jar` dated 2026-09-03.
- First line of upstream's `YAACBuildNotes.txt`: **"next beta build#230 of YAAC, 2026-Sep-03"**.

A real roll, not a corrupt transfer.

## Changes

- `sha256` re-pinned to build#230.
- `version` is now upstream's build number (`build-230`) instead of our snapshot date — upstream does number its builds, and that is the one identifier that says what `YAAC.zip` currently is. Comment records the first roll the pin caught.
- `docs/packages/yaac.md` regenerated.

## Verification

Gates green locally (ruff, pytest, doc links). Kali VM re-verification from a clean baseline is running; result will be posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
