### PR TITLE
fix: untrack the .venv symlink that 0e90998 committed — `.venv/` ignores directories only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,9 +100,14 @@ share/python-wheels/
 # any depth. It is a setuptools artifact and only ever appears at the root.
 /MANIFEST
 
-# Environments
-.venv/
-venv/
+# Environments. No trailing slash on the two names a virtualenv actually gets:
+# `.venv/` matches only a *directory*, so a worktree whose `.venv` is a symlink
+# to the main checkout's venv was not ignored, `git add -A` took it, and commit
+# 0e90998 shipped a symlink carrying an absolute home-directory path to main.
+# CI stayed green. A test now builds that symlink in a scratch repo against
+# this file and asserts it is ignored.
+.venv
+venv
 ENV/
 env/
 .python-version

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/home/chiefgyk3d/src/hammunition/.venv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,11 @@ head.
   nothing in the source tree may be ignored, and an unanchored pattern must be
   listed by name with why it must match at any depth. Three silent exclusions
   came from the same mistake — a trailing slash reads as anchored and anchors
-  nothing. CI runs it.
+  nothing. The slash has a second trap: it matches only a *directory*, so
+  `.venv/` let a worktree's `.venv` **symlink** into a commit on `main`
+  (0e90998), absolute home path and all, with CI green. The virtualenv names
+  carry no slash, and `tests/test_repo_hygiene.py` builds that symlink in a
+  scratch repo and asserts it is ignored. CI runs it.
 - `/reference/` and `/vendor/` are gitignored, **anchored to the repo root**:
   third-party tarballs and extracted upstream trees are studied locally, never
   committed. Keep provenance clean. The anchoring matters — the unanchored form

--- a/scripts/audit_gitignore.py
+++ b/scripts/audit_gitignore.py
@@ -124,8 +124,8 @@ JUSTIFIED_UNANCHORED: dict[str, str] = {
             ".eggs/",
             "*.egg-info/",
             "*.egg",
-            ".venv/",
-            "venv/",
+            ".venv",  # no slash: a symlink named .venv must be ignored too
+            "venv",
             "ENV/",
             "env/",
             ".python-version",

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -146,6 +146,73 @@ def test_no_files_tracked_from_root_reference_tree() -> None:
 
 
 # --------------------------------------------------------------------------
+# A virtualenv must never be tracked, and a symlink must never leave the repo
+#
+# Commit 0e90998 tracked `.venv` -- as a symlink, mode 120000, whose target was
+# an absolute path into one maintainer's home directory. `.gitignore` said
+# `.venv/`, and the trailing slash matches only a directory, so the worktree's
+# symlink was not ignored and `git add -A` took it. Every CI job passed.
+# Checking out main afterwards replaced a real venv with a link to itself.
+#
+# Three properties, each of which was false on that commit.
+# --------------------------------------------------------------------------
+
+_VENV_NAMES = frozenset({".venv", "venv"})
+
+
+def _tracked_symlinks() -> dict[str, str]:
+    """Tracked symlinks and their targets, read from the index, not the disk."""
+    result = _git("ls-files", "-s")
+    assert result.returncode == 0, result.stderr
+    links: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        meta, _, path = line.partition("\t")
+        mode, blob, _stage = meta.split()
+        if mode == "120000":
+            links[path] = _git("cat-file", "-p", blob).stdout
+    return links
+
+
+def test_no_virtualenv_is_tracked() -> None:
+    offenders = [f for f in _tracked_files() if set(Path(f).parts) & _VENV_NAMES]
+    assert not offenders, f"a virtualenv is tracked: {offenders}"
+
+
+def test_no_tracked_symlink_points_outside_the_repo() -> None:
+    """A tracked link resolves inside the repo, and never by absolute path.
+
+    An absolute target is wrong twice over: it is a path on one machine, and it
+    is that machine's directory layout published in the history.
+    """
+    offenders = {}
+    for path, target in _tracked_symlinks().items():
+        resolved = (REPO_ROOT / path).parent.joinpath(target).resolve()
+        if Path(target).is_absolute() or not resolved.is_relative_to(REPO_ROOT.resolve()):
+            offenders[path] = target
+    assert not offenders, f"tracked symlink(s) leave the repository: {offenders}"
+
+
+@pytest.mark.parametrize("name", sorted(_VENV_NAMES))
+def test_virtualenv_is_ignored_even_as_a_symlink(name: str, tmp_path: Path) -> None:
+    """The repository's own .gitignore, applied to a scratch repo holding only
+    a symlink of that name. `git status` must not offer it -- which is exactly
+    what `.venv/` failed to do."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / ".gitignore").write_text((REPO_ROOT / ".gitignore").read_text())
+    (tmp_path / name).symlink_to(tmp_path / "somewhere-else")
+    status = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert f"?? {name}" not in status.splitlines(), (
+        f"a symlink named {name} is not ignored by .gitignore:\n{status}"
+    )
+
+
+# --------------------------------------------------------------------------
 # dispositions.md must stay internally consistent
 #
 # PARITY-POLICY.md requires that no unit is left unclassified, and the summary


### PR DESCRIPTION
## What happened

Commit `0e90998` (PR #20) committed `.venv` **as a symlink** (mode 120000) whose target is an absolute path into one maintainer's home directory, and the merge of #20 this morning put it on `main`. Every CI job was green throughout. Checking out `main` afterwards replaced a real venv with a link to itself.

## Why

The fix branches were git worktrees whose `.venv` is a symlink to the main checkout's venv. `.gitignore` had `.venv/` — and a trailing slash matches only a *directory*, so the symlink was not ignored and `git add -A` took it. Measured in a scratch repo first: with `.venv/`, a symlink named `.venv` shows as `?? .venv`; with `.venv`, it is ignored.

## Fix

- `git rm --cached .venv`; `.venv` and `venv` lose their trailing slash, with the reason recorded in `.gitignore`; `scripts/audit_gitignore.py`'s justified list follows.
- Three new tests in `tests/test_repo_hygiene.py` — **all four parametrised cases fail on `main` as merged** (run against a fresh clone) and pass here:
  - no tracked path has a virtualenv component;
  - no tracked symlink is absolute or resolves outside the repo (read from the index with `cat-file`, not the working tree);
  - a scratch repo holding this repository's own `.gitignore` and only a symlink named `.venv`/`venv` does not offer it in `git status`.
- `CLAUDE.md` records the second trailing-slash trap beside the first.

All gates green locally: ruff, `mypy --strict`, pytest, doc links, gitignore audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
