### PR TITLE
scripts: campaign reports carry their evidence

### DIFF
--- a/docs/contributing/vm-testing.md
+++ b/docs/contributing/vm-testing.md
@@ -295,6 +295,47 @@ scripts/vm_campaign.py --host user@GUEST_IP \
 The budget is per profile here, and the source-heavy ones need it —
 `digital-modes` builds fldigi, WSJT-X and MSHV in one run.
 
+### What a report has to carry to be believed
+
+Six unit passes on 2026-09-04 filed `installed+confirmed` 1,375 times, and
+not one row could say *what* had confirmed it without a shell on the guest.
+`yaac` on Parrot rested on a single check — `libjssc-java 2.8.0-4`, a
+dependency. `wsjtx-improved` was refused on every target for colliding
+with a `wsjtx-data` that `jtdx` had pulled in hours earlier, an honest
+refusal that hid the unit's own failure on a clean Kali (#24). The report
+now carries the evidence rather than the verdict alone:
+
+- **Confirmed by** — per unit, every check the engine's D-031 re-probe
+  made (`package jtdx installed 2.2.159`; `binary fldigi:fldigi executable
+  at …`; `group user:dialout …`), read from the transaction-log lines the
+  unit appended. `no effect checks` means the re-probe had nothing to ask,
+  and the summary counts those units separately: not failures, but exit
+  codes rather than evidence. An engine that probes launchers and
+  installed trees would empty that list; until then it is the stated blind
+  spot.
+- **Provenance** — the engine commit *and whether the synced tree matched
+  it* (the guest gets the working tree, not the commit), the libvirt domain
+  and snapshot with the snapshot's creation time, when prepare ran, and the
+  `Date:` of every InRelease in the guest's apt lists after prepare. A
+  reader can put the same tree on the same snapshot against lists of the
+  same age. The guest's address is never in the report.
+- **Cumulative refusals** — the guest reports what dpkg gained during each
+  unit, dependencies included, and a later plan-time refusal that names one
+  of those packages is labelled *cumulative* with the package and the unit
+  that brought it. It is a fact about the pass, not the unit, so with
+  `--reset-first DOMAIN` the campaign re-runs each such unit **alone on the
+  restored snapshot** after the pass and files both verdicts side by side.
+  `--reset-each` passes label nothing: no unit sees another's state.
+- **`<out>.evidence.jsonl`** — the machine-readable record beside the
+  markdown: the provenance, then one line per unit with exit code, tail,
+  every transaction-log entry it appended and every package it added, then
+  the isolated re-runs. Rewritten with the report after every unit, so a
+  campaign that dies keeps what it measured, and the markdown can be
+  reconstructed from it.
+
+`tests/test_vm_campaign.py` holds one test per claim above, each first run
+against a report that lacked the field to watch it fail.
+
 ## Maintenance sweeps
 
 `scripts/check_artifact_urls.py` asks every pinned artifact URL in the

--- a/scripts/vm_campaign.py
+++ b/scripts/vm_campaign.py
@@ -38,17 +38,34 @@ The engine's own honesty does the heavy lifting: exit 0 means completed
 *and confirmed* (D-031), exit 2 means the plan refused with every blocker
 printed, exit 1 means a command failed with the log holding what completed.
 This script only files the outcomes.
+
+Files them with their evidence, since 2026-09-04. Six passes of 243 units
+each said `installed+confirmed` 1,375 times and could not answer, without a
+shell on the guest, what confirmed any one of them: `yaac` on Parrot was
+confirmed by one check, `libjssc-java 2.8.0-4`, a dependency. So every unit
+now brings back the transaction-log lines it appended, the report has a
+"Confirmed by" column and counts the units confirmed by no check at all,
+the header carries what a rerun needs (snapshot and its creation time, the
+InRelease dates of the apt lists, whether the synced tree was the named
+commit), a refusal naming a package the pass itself installed earlier is
+labelled *cumulative* and re-run alone on the snapshot, and a
+`.evidence.jsonl` sidecar holds the whole record. The guest's address is in
+none of it: a report is published, an address is not.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
+import re
 import subprocess
 import sys
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
@@ -72,16 +89,128 @@ OUTCOMES = {
 }
 
 
+#: What the report prints for the target when the guest's `status` probe
+#: gave nothing. Never the ssh address: the report is what gets published.
+TARGET_UNKNOWN = "(status probe returned nothing; the guest's os-release was not read)"
+
+
+def target_from_status(status_output: str) -> str:
+    """The guest's os-release line from `hammunition status`, minus the CLI's
+    own `Target: ` label -- the report adds its own, and every report to
+    2026-09-04 read `**Target:** Target: ...`."""
+    first = status_output.strip().splitlines()[0].strip() if status_output.strip() else ""
+    return first.removeprefix("Target:").strip() or TARGET_UNKNOWN
+
+
 @dataclass(frozen=True)
 class UnitResult:
     unit: str
     exit_code: int
     seconds: float
     tail: str
+    entries: tuple[dict[str, Any], ...] = ()
+    """The transaction-log lines this unit appended on the guest, parsed.
+    Empty for a plan-time refusal (nothing is logged before execution) and
+    for results filed before 2026-09-04."""
+    new_packages: tuple[str, ...] = ()
+    """What dpkg holds after this unit that it did not hold before --
+    dependencies included, which the transaction log never names. `jtdx`
+    brings `wsjtx-data`; only this delta knows."""
 
     @property
     def outcome(self) -> str:
         return OUTCOMES.get(self.exit_code, f"exit {self.exit_code}")
+
+    @property
+    def checks(self) -> tuple[dict[str, Any], ...]:
+        """The D-031 re-probe's findings, from `transaction_end`."""
+        return tuple(
+            check
+            for entry in self.entries
+            if entry.get("event") == "transaction_end"
+            for check in entry.get("checks", ())
+        )
+
+    @property
+    def evidence(self) -> str:
+        """What "confirmed" rested on, for the table. `no effect checks` is
+        the honest reading of an exit 0 whose re-probe asked nothing."""
+        if self.exit_code != 0:
+            return ""
+        if not self.checks:
+            return "no effect checks"
+        found = "; ".join(f"{c['kind']} {c['subject']} {c['detail']}" for c in self.checks)
+        n = len(self.checks)
+        return f"{n} check{'s' if n != 1 else ''}: {found}"
+
+    @property
+    def installed_packages(self) -> frozenset[str]:
+        """Every package the guest gained from this unit: what its transaction
+        asked apt for, what the re-probe confirmed, and what dpkg's before /
+        after delta shows apt pulled in besides. What a later refusal may
+        name."""
+        names: set[str] = set()
+        for entry in self.entries:
+            if entry.get("event") == "transaction_begin":
+                names.update(entry.get("apt_packages", ()))
+        names.update(c["subject"] for c in self.checks if c.get("kind") == "package")
+        names.update(self.new_packages)
+        return frozenset(names)
+
+
+@dataclass(frozen=True)
+class Provenance:
+    """What a reader needs to run the same campaign again.
+
+    The commit alone was not it: the tree tar'd to the guest is the working
+    tree, so a dirty checkout ships changes the commit does not name; the
+    snapshot's creation time bounds what the guest's own packages were; and
+    the apt lists resolution ran against are the ones `prepare` fetched,
+    each dated by its InRelease.
+    """
+
+    engine_commit: str
+    dirty_files: int
+    domain: str | None
+    snapshot: str | None
+    snapshot_created: str | None
+    apt_lists: tuple[tuple[str, str], ...]
+    prepared_at: str | None
+
+    def header_lines(self) -> list[str]:
+        dirty = (
+            f" (working tree dirty: {self.dirty_files} files not in that commit)"
+            if self.dirty_files
+            else ""
+        )
+        lines = [f"**Engine:** commit `{self.engine_commit}`{dirty}"]
+        if self.domain and self.snapshot:
+            created = f" (taken {self.snapshot_created})" if self.snapshot_created else ""
+            lines.append(f"**VM:** `{self.domain}` reset to snapshot `{self.snapshot}`{created}")
+        else:
+            lines.append(
+                "**VM:** not reset by this campaign — the guest held whatever state it "
+                "had when the first unit ran"
+            )
+        if self.prepared_at:
+            lines.append(f"**Prepared:** {self.prepared_at}")
+        if self.apt_lists:
+            when = " after prepare" if self.prepared_at else ", as found on the guest"
+            lines.append(f"**Apt lists (InRelease dates{when}):**")
+            lines += [f"- `{name}` — {date}" for name, date in self.apt_lists]
+        return lines
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "record": "provenance",
+            "engine_commit": self.engine_commit,
+            "dirty_files": self.dirty_files,
+            "domain": self.domain,
+            "snapshot": self.snapshot,
+            "snapshot_created": self.snapshot_created,
+            "apt_lists": [list(pair) for pair in self.apt_lists],
+            "prepared_at": self.prepared_at,
+        }
 
 
 # The runbook's "prepared" includes updated (vm-testing.md, baseline prep
@@ -128,6 +257,56 @@ def prepare(ssh: list[str], host: str, *, attempts: int = 2) -> None:
     sys.exit(f"{host} could not be prepared after {attempts} attempts; nothing was measured")
 
 
+def snapshot_created(domain: str, snapshot: str) -> str | None:
+    """When the snapshot was taken, from libvirt's own XML (`creationTime`,
+    epoch seconds) -- `snapshot-info` does not print it. ``None`` when
+    virsh cannot say, which the report shows rather than hides."""
+    proc = subprocess.run(
+        ["virsh", "--connect", "qemu:///system", "snapshot-dumpxml", domain, snapshot],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    match = re.search(r"<creationTime>(\d+)</creationTime>", proc.stdout)
+    if proc.returncode != 0 or not match:
+        return None
+    return datetime.fromtimestamp(int(match.group(1)), tz=UTC).isoformat()
+
+
+#: One line per InRelease the guest holds: file name, then its `Date:`.
+APT_LISTS_REMOTE = (
+    'for f in /var/lib/apt/lists/*_InRelease; do [ -f "$f" ] || continue; '
+    'printf "%s\\t%s\\n" "$(basename "$f")" "$(grep -m1 "^Date:" "$f" | cut -c7-)"; done'
+)
+
+
+def apt_lists(ssh: list[str], host: str) -> tuple[tuple[str, str], ...]:
+    """The apt lists the guest resolves against, dated by their InRelease.
+    Read after prepare, so they are the ones the units actually saw."""
+    proc = subprocess.run(
+        [*ssh, host, APT_LISTS_REMOTE], capture_output=True, text=True, check=False
+    )
+    pairs: list[tuple[str, str]] = []
+    for line in proc.stdout.splitlines():
+        name, _, date = line.partition("\t")
+        if name:
+            pairs.append((name, date.strip() or "(no Date field)"))
+    return tuple(pairs)
+
+
+def working_tree_dirty_files() -> int:
+    """How many paths the tar'd tree carries that HEAD does not: modified,
+    staged, or untracked-and-not-ignored. The commit in the header is only
+    the truth when this is zero."""
+    proc = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return len([ln for ln in proc.stdout.splitlines() if ln.strip()])
+
+
 def reset_and_prepare(domain: str, host: str, identity: str | None) -> None:
     """Back to `clean-baseline`, then the runbook's prepare steps.
 
@@ -164,6 +343,37 @@ def reset_and_prepare(domain: str, host: str, identity: str | None) -> None:
     prepare(ssh, host)
 
 
+#: The engine's transaction log on the guest, as the operator the campaign
+#: runs as (`hammunition.state.log.log_path`, XDG default). Not root's:
+#: apt goes through `sudo -n` per command and the log follows the operator.
+GUEST_LOG = "$HOME/.local/state/hammunition/transactions.jsonl"
+
+
+def remote_command(unit: str, timeout: int) -> str:
+    """The guest-side session for one unit, for ``bash -c``.
+
+    Counts the transaction log's lines *before* the engine runs and prints
+    everything after that count once it exits, behind a ``__LOG`` marker.
+    That delta is what attributes log entries to this unit -- a plan-time
+    refusal appends nothing and gets nothing. The same before/after is taken
+    of dpkg's package list and the new names printed behind
+    ``__NEW_PACKAGES``: the log names what the plan asked for, not what apt
+    pulled in beside it. Single quotes are not usable here: the whole string
+    is wrapped in them for ssh.
+    """
+    dpkg = 'dpkg-query -W -f "\\${Package}\\n" | sort -u'
+    return (
+        f"cd hammunition && L={GUEST_LOG}; "
+        'before=0; [ -f "$L" ] && before=$(wc -l < "$L"); '
+        f'P=$(mktemp); {dpkg} > "$P"; '
+        f"timeout -k 30 {timeout}s "
+        f".venv/bin/hammunition install {unit} --yes 2>&1 | tail -60; "
+        f'echo "__EXIT=${{PIPESTATUS[0]}}"; echo __LOG; '
+        '[ -f "$L" ] && tail -n +$((before+1)) "$L"; '
+        f'echo __NEW_PACKAGES; {dpkg} | comm -13 "$P" -; rm -f "$P"; true'
+    )
+
+
 def run_unit(host: str, identity: str | None, unit: str, timeout: int) -> UnitResult:
     """One engine install over SSH; the tail is the evidence.
 
@@ -175,15 +385,10 @@ def run_unit(host: str, identity: str | None, unit: str, timeout: int) -> UnitRe
     (2026-09-02). ``timeout`` on the VM signals the whole process group, so
     the compile stops with the engine, and exit 124 says so.
     """
-    remote = (
-        f"cd hammunition && timeout -k 30 {timeout}s "
-        f".venv/bin/hammunition install {unit} --yes 2>&1 | tail -60; "
-        f'echo "__EXIT=${{PIPESTATUS[0]}}"'
-    )
     argv = list(SSH_BASE)
     if identity:
         argv += ["-i", identity]
-    argv += [host, f"bash -c '{remote}'"]
+    argv += [host, f"bash -c '{remote_command(unit, timeout)}'"]
     started = datetime.now(UTC)
     try:
         proc = subprocess.run(
@@ -200,14 +405,41 @@ def classify(unit: str, raw: str, *, seconds: float, timeout: int) -> UnitResult
     """Turn the remote session's merged output into a filed result."""
     exit_code = 255
     tail_lines: list[str] = []
+    entries: list[dict[str, Any]] = []
+    new_packages: list[str] = []
+    section = "tail"
     for line in raw.splitlines():
-        if line.startswith("__EXIT="):
+        if line == "__LOG":
+            section = "log"
+        elif line == "__NEW_PACKAGES":
+            section = "packages"
+        elif section == "packages":
+            if line.strip():
+                new_packages.append(line.strip())
+        elif section == "log":
+            if not line.strip():
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                # Filed, not dropped: a log line that is not JSON is itself
+                # a finding about the engine's log.
+                parsed = {"event": "unparsed", "line": line}
+            entries.append(parsed)
+        elif line.startswith("__EXIT="):
             exit_code = int(line.split("=", 1)[1])
         else:
             tail_lines.append(line)
+    kept = tuple(entries)
+    gained = tuple(new_packages)
     if exit_code == 124:
         return UnitResult(
-            unit, 124, seconds, f"stopped by the {timeout}s budget; the build was still running"
+            unit,
+            124,
+            seconds,
+            f"stopped by the {timeout}s budget; the build was still running",
+            kept,
+            gained,
         )
     # Keep what a reader needs. Stderr outruns block-buffered stdout through
     # a pipe, so a failure's text can land ANYWHERE in the merged stream —
@@ -217,18 +449,51 @@ def classify(unit: str, raw: str, *, seconds: float, timeout: int) -> UnitResult
     markers = ("Failed:", "problem block", "error:", "E: ")
     start = next((i for i, ln in enumerate(nonempty) if any(m in ln for m in markers)), None)
     keep = nonempty[start : start + 10] if start is not None else nonempty[-6:]
-    return UnitResult(unit, exit_code, seconds, "\n".join(keep))
+    return UnitResult(unit, exit_code, seconds, "\n".join(keep), kept, gained)
+
+
+def cumulative_refusals(results: list[UnitResult]) -> dict[str, dict[str, str]]:
+    """Refusals that name a package an earlier unit of this pass installed.
+
+    ``{refused unit: {package named: unit that installed it}}``. A pass
+    accumulates state by design (one machine, like an operator's), and a
+    refusal caused by that state is a fact about the pass, not about the
+    unit: `wsjtx-improved` was refused on every target for colliding with
+    the `wsjtx-data` that `wsjtx` had installed hours earlier, and that
+    honest refusal hid the unit's own failure on a clean Kali (#24). The
+    match is on whole package-name tokens in the refusal text.
+    """
+    installed_by: dict[str, str] = {}
+    labelled: dict[str, dict[str, str]] = {}
+    for result in results:
+        if result.exit_code == 2:
+            tokens = set(re.findall(r"[a-z0-9][a-z0-9+.-]*", result.tail.lower()))
+            named = {pkg: unit for pkg, unit in installed_by.items() if pkg in tokens}
+            if named:
+                labelled[result.unit] = dict(sorted(named.items()))
+        for pkg in result.installed_packages:
+            installed_by.setdefault(pkg, result.unit)
+    return labelled
 
 
 def render_report(
     *,
     target_line: str,
-    engine_commit: str,
+    provenance: Provenance,
     results: list[UnitResult],
     noun: str = "Units",
+    isolated: Mapping[str, UnitResult] | None = None,
+    accumulating: bool = True,
 ) -> str:
+    """The markdown summary. ``isolated`` holds the re-runs of cumulative
+    refusals alone on the snapshot, keyed by unit. ``accumulating`` is
+    false for a ``--reset-each`` pass, where no unit sees another's state
+    and nothing may be labelled as if it had."""
+    isolated = isolated or {}
     ok = [r for r in results if r.exit_code == 0]
+    unchecked = [r for r in ok if not r.checks]
     refused = [r for r in results if r.exit_code == 2]
+    cumulative = cumulative_refusals(results) if accumulating else {}
     # A consent gate declining on a non-interactive stdin is the gate working
     # (D-021): the campaign never affirms one. It is neither a failure nor
     # coverage the engine lacks, so it gets its own count and no failure tail.
@@ -237,25 +502,43 @@ def render_report(
     failed = [r for r in results if r.exit_code not in (0, 2, 3, 124)]
     budget = f", {len(stopped)} stopped by the budget" if stopped else ""
     gated = f", {len(declined)} stopped at a consent gate" if declined else ""
+    caused = f" ({len(cumulative)} of them cumulative)" if cumulative else ""
+    blind = f" ({len(unchecked)} by no effect check)" if unchecked else ""
     lines = [
         "# VM campaign report",
         "",
         f"**Date:** {datetime.now(UTC).date().isoformat()}",
-        f"**Engine:** commit `{engine_commit}`",
+        *provenance.header_lines(),
         f"**Target:** {target_line}",
         f"**{noun}:** {len(results)} — "
-        f"{len(ok)} installed+confirmed, {len(refused)} refused at plan time, "
+        f"{len(ok)} installed+confirmed{blind}, {len(refused)} refused at plan time{caused}, "
         f"{len(failed)} failed{gated}{budget}",
         "",
         "Exit 0 is the engine's own bar: completed *and confirmed* by re-probe",
-        "(D-031). A plan-time refusal is honest coverage reporting, not a",
-        "failure — its text names what is missing.",
+        "(D-031); *Confirmed by* is what that re-probe found, and `no effect",
+        "checks` means it asked nothing. A plan-time refusal is honest coverage",
+        "reporting, not a failure — its text names what is missing. A refusal",
+        "marked *cumulative* names a package an earlier unit of this same pass",
+        "installed; it is a fact about the pass, and the unit is re-run alone.",
         "",
-        "| Name | Outcome | Seconds |",
-        "|---|---|---:|",
+        "| Name | Outcome | Confirmed by | Seconds |",
+        "|---|---|---|---:|",
     ]
+
+    def outcome_cell(r: UnitResult) -> str:
+        cell = r.outcome
+        if r.unit in cumulative:
+            named = ", ".join(
+                f"`{pkg}`, installed by `{unit}`" for pkg, unit in cumulative[r.unit].items()
+            )
+            cell += f" — cumulative: names {named} earlier this pass"
+        alone = isolated.get(r.unit)
+        if alone is not None and provenance.snapshot:
+            cell += f"; alone on `{provenance.snapshot}`: {alone.outcome} ({alone.seconds:.0f} s)"
+        return cell
+
     for r in results:
-        lines.append(f"| `{r.unit}` | {r.outcome} | {r.seconds:.0f} |")
+        lines.append(f"| `{r.unit}` | {outcome_cell(r)} | {r.evidence} | {r.seconds:.0f} |")
     buckets = (
         ("Failures", failed),
         ("Stopped by the budget (not a verdict; rerun with a larger --timeout)", stopped),
@@ -268,7 +551,73 @@ def render_report(
         lines += ["", f"## {title}", ""]
         for r in bucket:
             lines += [f"### `{r.unit}`", "", "```", r.tail, "```", ""]
+    if isolated and provenance.snapshot:
+        lines += [
+            "",
+            f"## Re-run alone on `{provenance.snapshot}`",
+            "",
+            "Each cumulative refusal above, installed by itself on the freshly",
+            "restored snapshot. This is the verdict a clean machine gives.",
+            "",
+        ]
+        for unit, alone in isolated.items():
+            lines += [
+                f"### `{unit}` — {alone.outcome} ({alone.seconds:.0f} s)",
+                "",
+                *([f"Confirmed by: {alone.evidence}", ""] if alone.evidence else []),
+                "```",
+                alone.tail,
+                "```",
+                "",
+            ]
+    if unchecked:
+        lines += [
+            "",
+            f"## Confirmed by no effect check ({len(unchecked)})",
+            "",
+            "The engine exited 0 and its re-probe had nothing to ask: no archive",
+            "package, no built binary, no group membership in the plan. These are",
+            "not failures; they are the units whose `confirmed` rests on exit",
+            "codes alone, which D-031 says is not evidence. An engine that probes",
+            "their effects (launchers, installed trees) would move them out of here.",
+            "",
+            *[f"- `{r.unit}`" for r in unchecked],
+        ]
     return "\n".join(lines) + "\n"
+
+
+def evidence_path(out: Path) -> Path:
+    """`campaign.md` → `campaign.evidence.jsonl`, beside it."""
+    return out.with_name(out.stem + ".evidence.jsonl")
+
+
+def write_evidence(
+    path: Path,
+    *,
+    provenance: Provenance,
+    results: list[UnitResult],
+    isolated: Mapping[str, UnitResult] | None = None,
+) -> None:
+    """The complete record: provenance, one line per unit with every
+    transaction entry it appended, then the isolated re-runs. Rewritten
+    whole with the report after every unit."""
+
+    def unit_record(kind: str, r: UnitResult) -> dict[str, Any]:
+        return {
+            "record": kind,
+            "unit": r.unit,
+            "exit_code": r.exit_code,
+            "outcome": r.outcome,
+            "seconds": r.seconds,
+            "tail": r.tail,
+            "entries": list(r.entries),
+            "new_packages": list(r.new_packages),
+        }
+
+    records = [provenance.to_record()]
+    records += [unit_record("unit", r) for r in results]
+    records += [unit_record("isolated", r) for r in (isolated or {}).values()]
+    path.write_text("".join(json.dumps(rec, sort_keys=True) + "\n" for rec in records))
 
 
 def main() -> int:
@@ -323,31 +672,61 @@ def main() -> int:
         check=False,
     ).stdout.strip()
 
+    ssh = [*SSH_BASE, *(["-i", args.identity] if args.identity else [])]
+    domain = args.reset_first or args.reset_each
+    prepared_at: str | None = None
     if args.reset_first:
         reset_and_prepare(args.reset_first, args.host, args.identity)
+        prepared_at = datetime.now(UTC).isoformat(timespec="seconds")
 
-    target_probe = (
+    # The guest's own os-release line, from the engine that ran there. The
+    # ssh address is deliberately not the fallback: the report is published.
+    target_probe = target_from_status(
         subprocess.run(
             [
-                *SSH_BASE,
-                *(["-i", args.identity] if args.identity else []),
+                *ssh,
                 args.host,
                 "cd hammunition && .venv/bin/hammunition status 2>/dev/null | head -1",
             ],
             capture_output=True,
             text=True,
             check=False,
-        ).stdout.strip()
-        or args.host
+        ).stdout
+    )
+    provenance = Provenance(
+        engine_commit=commit,
+        dirty_files=working_tree_dirty_files(),
+        domain=domain,
+        snapshot="clean-baseline" if domain else None,
+        snapshot_created=snapshot_created(domain, "clean-baseline") if domain else None,
+        apt_lists=apt_lists(ssh, args.host),
+        prepared_at=prepared_at,
     )
     noun = "Profiles (whole, from clean-baseline)" if args.whole_profiles else "Units"
 
-    def report_so_far(results: list[UnitResult]) -> str:
+    results: list[UnitResult] = []
+    isolated: dict[str, UnitResult] = {}
+
+    def report_so_far() -> str:
         return render_report(
-            target_line=target_probe, engine_commit=commit, results=results, noun=noun
+            target_line=target_probe,
+            provenance=provenance,
+            results=results,
+            noun=noun,
+            isolated=isolated,
+            accumulating=not args.reset_each,
         )
 
-    results: list[UnitResult] = []
+    def file_so_far() -> None:
+        # The report is rewritten after every unit, so a campaign that dies
+        # at unit 5 of 15 leaves the four results it had, and a failure's
+        # tail is readable while the next unit builds instead of hours later.
+        if args.out:
+            args.out.write_text(report_so_far())
+            write_evidence(
+                evidence_path(args.out), provenance=provenance, results=results, isolated=isolated
+            )
+
     for unit in units:
         print(f"[{len(results) + 1}/{len(units)}] {unit} ...", flush=True)
         if args.reset_each:
@@ -355,16 +734,30 @@ def main() -> int:
         result = run_unit(args.host, args.identity, unit, args.timeout)
         print(f"    {result.outcome} ({result.seconds:.0f}s)", flush=True)
         results.append(result)
-        # The report is rewritten after every unit, so a campaign that dies
-        # at unit 5 of 15 leaves the four results it had, and a failure's
-        # tail is readable while the next unit builds instead of hours later.
-        if args.out:
-            args.out.write_text(report_so_far(results))
+        file_so_far()
+
+    # A refusal the pass itself caused says nothing about the unit. With a
+    # snapshot to hand, ask the clean machine -- one restore per such unit,
+    # after the pass, so the pass's own accumulation is not disturbed.
+    cumulative = cumulative_refusals(results) if not args.reset_each else {}
+    if cumulative and args.reset_first:
+        for unit in cumulative:
+            print(f"[alone on clean-baseline] {unit} ...", flush=True)
+            reset_and_prepare(args.reset_first, args.host, args.identity)
+            isolated[unit] = run_unit(args.host, args.identity, unit, args.timeout)
+            print(f"    {isolated[unit].outcome} ({isolated[unit].seconds:.0f}s)", flush=True)
+            file_so_far()
+    elif cumulative:
+        print(
+            f"{len(cumulative)} cumulative refusal(s) not re-run alone: no snapshot "
+            f"(pass --reset-first DOMAIN): {', '.join(cumulative)}",
+            flush=True,
+        )
 
     if args.out:
-        print(f"wrote {args.out}")
+        print(f"wrote {args.out} and {evidence_path(args.out)}")
     else:
-        print(report_so_far(results))
+        print(report_so_far())
     return 0
 
 

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -83,6 +83,19 @@ def test_a_manifest_with_no_launchers_plans_nothing() -> None:
     assert launcher_steps(m, bin_dir=Path("/x"), applications_dir=Path("/y")) == []
 
 
+def _unreset(mod: object, commit: str) -> object:
+    """A campaign that reset nothing and read no apt lists: the header says so."""
+    return mod.Provenance(  # type: ignore[attr-defined]
+        engine_commit=commit,
+        dirty_files=0,
+        domain=None,
+        snapshot=None,
+        snapshot_created=None,
+        apt_lists=(),
+        prepared_at=None,
+    )
+
+
 def test_campaign_report_buckets_and_names_every_unit() -> None:
     """The campaign renderer: every unit gets a row, failures carry their
     evidence text, refusals are not counted as failures."""
@@ -105,9 +118,12 @@ def test_campaign_report_buckets_and_names_every_unit() -> None:
         mod.UnitResult("broken", 1, 300.0, "make: *** Error 1"),
     ]
     report = mod.render_report(
-        target_line="Testville 1.0", engine_commit="abc1234", results=results
+        target_line="Testville 1.0", provenance=_unreset(mod, "abc1234"), results=results
     )
-    assert "3 — 1 installed+confirmed, 1 refused at plan time, 1 failed" in report
+    assert (
+        "3 — 1 installed+confirmed (1 by no effect check), 1 refused at plan time, 1 failed"
+        in report
+    )
     for unit in ("good", "gap", "broken"):
         assert f"| `{unit}` |" in report
     assert "## Failures" in report and "make: *** Error 1" in report
@@ -138,8 +154,13 @@ def test_campaign_files_a_budget_stop_as_stopped_not_failed() -> None:
         "qlog", "Done. 11 command(s) completed.\n__EXIT=0\n", seconds=5, timeout=900
     )
     assert done.exit_code == 0 and "Done." in done.tail
-    report = mod.render_report(target_line="T", engine_commit="abc", results=[stopped, done])
-    assert "1 installed+confirmed, 0 refused at plan time, 0 failed, 1 stopped" in report
+    report = mod.render_report(
+        target_line="T", provenance=_unreset(mod, "abc"), results=[stopped, done]
+    )
+    assert (
+        "1 installed+confirmed (1 by no effect check), 0 refused at plan time, 0 failed, 1 stopped"
+        in report
+    )
     assert "STOPPED (budget)" in report and "## Stopped by the budget" in report
     assert "## Failures" not in report
 
@@ -161,10 +182,12 @@ def test_campaign_files_a_declined_consent_gate_as_neither_failure_nor_refusal()
 
     gated = mod.UnitResult("rf-research", 3, 4.0, "Do you affirm that you have the authorization")
     done = mod.UnitResult("sdr", 0, 162.0, "Done.")
-    report = mod.render_report(target_line="T", engine_commit="abc", results=[gated, done])
+    report = mod.render_report(
+        target_line="T", provenance=_unreset(mod, "abc"), results=[gated, done]
+    )
     assert (
-        "1 installed+confirmed, 0 refused at plan time, 0 failed, 1 stopped at a consent gate"
-        in report
+        "1 installed+confirmed (1 by no effect check), 0 refused at plan time, 0 failed, "
+        "1 stopped at a consent gate" in report
     )
     assert "| `rf-research` | consent declined |" in report
     assert "## Failures" not in report

--- a/tests/test_vm_campaign.py
+++ b/tests/test_vm_campaign.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""The campaign harness's evidence: what a report must carry to be rerun and
+believed.
+
+The overnight passes of 2026-09-04 filed 1,375 unit results and every one
+said `installed+confirmed` or named a refusal -- and still could not answer
+four questions without a shell on the VM: *what* confirmed each unit, which
+snapshot and apt lists it ran against, whether a refusal was caused by the
+pass's own earlier installs, and whether the tree that was synced was the
+commit the header named. Each test here is one of those questions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def campaign() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "vm_campaign_evidence", REPO_ROOT / "scripts" / "vm_campaign.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["vm_campaign_evidence"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _begin(*packages: str, apt: tuple[str, ...] = ()) -> str:
+    return json.dumps(
+        {
+            "event": "transaction_begin",
+            "version": 2,
+            "timestamp": "2026-09-04T06:02:00+00:00",
+            "target": {"id": "parrot"},
+            "packages": list(packages),
+            "apt_packages": list(apt),
+            "deferred": [],
+        }
+    )
+
+
+def _end(*checks: dict[str, object], verified: bool = True) -> str:
+    return json.dumps(
+        {
+            "event": "transaction_end",
+            "version": 2,
+            "timestamp": "2026-09-04T06:02:19+00:00",
+            "completed": 9,
+            "verified": verified,
+            "checks": list(checks),
+        }
+    )
+
+
+def _pkg(name: str, version: str) -> dict[str, object]:
+    return {
+        "kind": "package",
+        "subject": name,
+        "confirmed": True,
+        "detail": f"installed {version}",
+    }
+
+
+def _provenance(campaign: ModuleType, **overrides: object) -> object:
+    fields: dict[str, object] = {
+        "engine_commit": "b447ec6",
+        "dirty_files": 0,
+        "domain": "ParrotOS_Dev",
+        "snapshot": "clean-baseline",
+        "snapshot_created": "2026-08-26T05:37:34+00:00",
+        "apt_lists": (
+            ("deb.parrot.sh_parrot_dists_echo_InRelease", "Thu, 03 Sep 2026 14:23:55 UTC"),
+        ),
+        "prepared_at": "2026-09-04T05:58:00+00:00",
+    }
+    fields.update(overrides)
+    return campaign.Provenance(**fields)
+
+
+def test_classify_keeps_the_transaction_entries_the_unit_appended(campaign: ModuleType) -> None:
+    """The remote session prints the engine's tail, then `__EXIT=`, then a
+    `__LOG` marker followed by the transaction-log lines this unit added.
+    Those lines are the evidence: `yaac` on Parrot was `installed+confirmed`
+    on the strength of one check, `libjssc-java 2.8.0-4` -- a dependency,
+    not YAAC -- and nothing in the report said so."""
+    raw = "\n".join(
+        [
+            "Done. 9 command(s) completed and confirmed.",
+            "__EXIT=0",
+            "__LOG",
+            _begin("yaac", apt=("libjssc-java",)),
+            _end(_pkg("libjssc-java", "2.8.0-4")),
+        ]
+    )
+    result = campaign.classify("yaac", raw, seconds=15.0, timeout=1800)
+    assert result.exit_code == 0
+    assert "__LOG" not in result.tail and "transaction_begin" not in result.tail
+    assert [e["event"] for e in result.entries] == ["transaction_begin", "transaction_end"]
+    assert result.evidence == "1 check: package libjssc-java installed 2.8.0-4"
+
+    bare = campaign.classify(
+        "x", "Done.\n__EXIT=0\n__LOG\n" + _begin("x") + "\n" + _end(), seconds=1, timeout=9
+    )
+    assert bare.evidence == "no effect checks"
+
+
+def test_report_names_what_confirmed_each_unit_and_counts_the_unchecked(
+    campaign: ModuleType,
+) -> None:
+    """`installed+confirmed` is the engine's exit 0, and exit 0 is granted
+    to a run whose re-probe asked nothing (`checks: []`). The report must say
+    per unit what was probed, and count the units confirmed by no check at
+    all, because those are the blind spot -- not a failure, but not the
+    evidence the word suggests either."""
+    probed = campaign.classify(
+        "yaac",
+        "Done.\n__EXIT=0\n__LOG\n" + _begin("yaac") + "\n" + _end(_pkg("libjssc-java", "2.8.0-4")),
+        seconds=15,
+        timeout=9,
+    )
+    unchecked = campaign.classify(
+        "sdr-notes",
+        "Done.\n__EXIT=0\n__LOG\n" + _begin("sdr-notes") + "\n" + _end(),
+        seconds=1,
+        timeout=9,
+    )
+    report = campaign.render_report(
+        target_line="T", provenance=_provenance(campaign), results=[probed, unchecked]
+    )
+    assert "| Name | Outcome | Confirmed by | Seconds |" in report
+    assert (
+        "| `yaac` | installed+confirmed | 1 check: package libjssc-java installed 2.8.0-4 | 15 |"
+        in report
+    )
+    assert "| `sdr-notes` | installed+confirmed | no effect checks | 1 |" in report
+    assert "## Confirmed by no effect check (1)" in report
+    assert "`sdr-notes`" in report.split("## Confirmed by no effect check")[1]
+
+
+def test_report_carries_what_a_rerun_needs_and_never_the_ssh_address(campaign: ModuleType) -> None:
+    """Engine commit alone did not reproduce a pass: the tree synced to the
+    guest is the working tree, not the commit; the snapshot the guest was
+    reset to has a creation time the archive has moved past; and the apt
+    lists it resolved against are the ones `prepare` fetched, dated by their
+    InRelease. All three go in the header. The guest's `user@ip` goes
+    nowhere -- a report is published, an address is not."""
+    report = campaign.render_report(
+        target_line="Parrot 7.3",
+        provenance=_provenance(campaign, dirty_files=2),
+        results=[],
+    )
+    assert "**Engine:** commit `b447ec6` (working tree dirty: 2 files not in that commit)" in report
+    assert "**VM:** `ParrotOS_Dev` reset to snapshot `clean-baseline`" in report
+    assert "2026-08-26T05:37:34+00:00" in report
+    assert "deb.parrot.sh_parrot_dists_echo_InRelease" in report
+    assert "Thu, 03 Sep 2026 14:23:55 UTC" in report
+    assert "**Prepared:** 2026-09-04T05:58:00+00:00" in report
+
+    unreset = campaign.render_report(
+        target_line=campaign.TARGET_UNKNOWN,
+        provenance=_provenance(
+            campaign, domain=None, snapshot=None, snapshot_created=None, prepared_at=None
+        ),
+        results=[],
+    )
+    assert "**VM:** not reset by this campaign" in unreset
+    assert "192.168" not in unreset and "@" not in unreset
+    # Nothing was prepared, so the lists are whatever the guest held.
+    assert "**Apt lists (InRelease dates after prepare):**" in report
+    assert "**Apt lists (InRelease dates, as found on the guest):**" in unreset
+
+
+def test_the_target_line_is_the_guests_os_release_without_the_cli_label(
+    campaign: ModuleType,
+) -> None:
+    """`hammunition status` prints `Target: <describe()>`; every report to
+    date carried that label twice (`**Target:** Target: Kali ...`). The
+    probe's first line is stripped of the CLI's own prefix, and an empty
+    probe still names the unknown rather than the address."""
+    status = "Target: Kali GNU/Linux Rolling (ID=kali, version=2026.3, arch=x86_64)\n\nnothing\n"
+    assert campaign.target_from_status(status) == (
+        "Kali GNU/Linux Rolling (ID=kali, version=2026.3, arch=x86_64)"
+    )
+    assert campaign.target_from_status("") == campaign.TARGET_UNKNOWN
+    assert campaign.target_from_status("\n") == campaign.TARGET_UNKNOWN
+
+
+def test_a_refusal_naming_a_package_this_pass_installed_is_labelled_cumulative(
+    campaign: ModuleType,
+) -> None:
+    """`wsjtx-improved` was refused on all six targets because `wsjtx`, run
+    earlier in the same pass, had installed `wsjtx-data`. Filed as a plain
+    plan-time refusal it read as the D-022 rule working; it was, and it also
+    hid that the unit fails outright on Kali (#24). The harness knows what
+    the pass installed before each unit, so a refusal naming one of those
+    packages is labelled with the package and the unit that brought it."""
+    # `wsjtx-data` is not in jtdx's transaction at all -- apt pulled it as
+    # a dependency -- so the guest's dpkg delta (`__NEW_PACKAGES`) is the
+    # only place the harness can learn the pass now holds it.
+    jtdx = campaign.classify(
+        "jtdx",
+        "Done.\n__EXIT=0\n__LOG\n"
+        + _begin("jtdx", apt=("jtdx",))
+        + "\n"
+        + _end(_pkg("jtdx", "2.2.159"))
+        + "\n__NEW_PACKAGES\njtdx\nwsjtx-data\n",
+        seconds=6,
+        timeout=9,
+    )
+    assert jtdx.new_packages == ("jtdx", "wsjtx-data")
+    improved = campaign.UnitResult(
+        "wsjtx-improved",
+        2,
+        3.0,
+        "  wsjtx-improved: its vendor .deb collides with installed distribution "
+        "package(s): wsjtx-data\n    → remove them first",
+    )
+    absent = campaign.UnitResult("z8530-utils2", 2, 1.0, "z8530-utils2: not in the archive")
+    results = [jtdx, improved, absent]
+    assert campaign.cumulative_refusals(results) == {"wsjtx-improved": {"wsjtx-data": "jtdx"}}
+    report = campaign.render_report(
+        target_line="T", provenance=_provenance(campaign), results=results
+    )
+    assert (
+        "| `wsjtx-improved` | refused (plan) — cumulative: names `wsjtx-data`, installed by `jtdx` "
+        "earlier this pass |" in report
+    )
+    assert "| `z8530-utils2` | refused (plan) |" in report
+    assert "1 of them cumulative" in report
+
+    # `--reset-each` restores the guest before every unit: nothing
+    # accumulates, so nothing may be labelled as if it had.
+    isolated_pass = campaign.render_report(
+        target_line="T", provenance=_provenance(campaign), results=results, accumulating=False
+    )
+    assert "| `wsjtx-improved` | refused (plan) |" in isolated_pass
+    assert "cumulative" not in isolated_pass.split("| Name |")[1]
+
+
+def test_an_isolated_rerun_is_reported_beside_the_cumulative_refusal(campaign: ModuleType) -> None:
+    """A cumulative refusal is a fact about the pass, not the unit. When the
+    campaign knows a snapshot it re-runs the unit alone on it, and the
+    report shows both verdicts side by side -- the one an operator building
+    up a machine would see and the one a clean machine gives."""
+    wsjtx = campaign.classify(
+        "wsjtx",
+        "Done.\n__EXIT=0\n__LOG\n" + _begin("wsjtx", apt=("wsjtx-data",)) + "\n" + _end(),
+        seconds=400,
+        timeout=9,
+    )
+    improved = campaign.UnitResult("wsjtx-improved", 2, 3.0, "collides with ... wsjtx-data")
+    alone = campaign.UnitResult(
+        "wsjtx-improved",
+        1,
+        40.0,
+        "E: Unable to correct problems: libboost-log1.83.0 but it is not installable",
+    )
+    report = campaign.render_report(
+        target_line="T",
+        provenance=_provenance(campaign),
+        results=[wsjtx, improved],
+        isolated={"wsjtx-improved": alone},
+    )
+    assert "alone on `clean-baseline`: FAILED (40 s)" in report
+    assert "## Re-run alone on `clean-baseline`" in report
+    assert "libboost-log1.83.0" in report.split("## Re-run alone")[1]
+    assert "## Failures" not in report
+
+
+def test_evidence_sidecar_is_the_complete_machine_readable_record(
+    campaign: ModuleType, tmp_path: Path
+) -> None:
+    """The markdown is the summary; the sidecar is the record -- provenance,
+    then one line per unit with its exit, tail and every transaction entry,
+    then the isolated re-runs. It is rewritten with the report so a campaign
+    that dies keeps what it measured, and it must round-trip."""
+    yaac = campaign.classify(
+        "yaac",
+        "Done.\n__EXIT=0\n__LOG\n" + _begin("yaac") + "\n" + _end(_pkg("libjssc-java", "1")),
+        seconds=2,
+        timeout=9,
+    )
+    refused = campaign.UnitResult("gap", 2, 1.0, "no block")
+    out = tmp_path / "campaign.md"
+    campaign.write_evidence(
+        campaign.evidence_path(out),
+        provenance=_provenance(campaign),
+        results=[yaac, refused],
+        isolated={"gap": campaign.UnitResult("gap", 2, 1.0, "no block")},
+    )
+    lines = [
+        json.loads(ln) for ln in (tmp_path / "campaign.evidence.jsonl").read_text().splitlines()
+    ]
+    assert lines[0]["record"] == "provenance" and lines[0]["snapshot"] == "clean-baseline"
+    assert lines[1]["record"] == "unit" and lines[1]["unit"] == "yaac"
+    assert [e["event"] for e in lines[1]["entries"]] == ["transaction_begin", "transaction_end"]
+    assert lines[2]["unit"] == "gap" and lines[2]["exit_code"] == 2
+    assert lines[3]["record"] == "isolated" and lines[3]["unit"] == "gap"
+
+
+def test_remote_command_captures_only_the_lines_this_unit_appended(
+    tmp_path: Path, campaign: ModuleType
+) -> None:
+    """The delta is what attributes log entries to a unit, and it has to be
+    measured against the lines present *before* the engine ran: an
+    off-by-one here files unit 12's checks under unit 13 and every evidence
+    column is wrong by one row. Exercised against a fake engine that appends
+    to a real file, through the same `bash -c` the guest runs."""
+    home = tmp_path
+    engine = home / "hammunition" / ".venv" / "bin" / "hammunition"
+    engine.parent.mkdir(parents=True)
+    log = home / ".local" / "state" / "hammunition" / "transactions.jsonl"
+    log.parent.mkdir(parents=True)
+    log.write_text('{"event": "transaction_end", "stale": true}\n')
+    # A stand-in dpkg-query reads the fake machine's package list; the fake
+    # engine adds two packages to it, one of which was already there. That
+    # delta is how the harness learns a unit brought `wsjtx-data` when the
+    # unit's own transaction never named it (apt pulled it for jtdx).
+    fakebin = home / "fakebin"
+    fakebin.mkdir()
+    pkgs = home / "installed-packages"
+    pkgs.write_text("libc6\njtdx\n")
+    dpkg_query = fakebin / "dpkg-query"
+    dpkg_query.write_text(f"#!/bin/sh\ncat {pkgs}\n")
+    dpkg_query.chmod(dpkg_query.stat().st_mode | stat.S_IXUSR)
+    engine.write_text(
+        "#!/bin/sh\n"
+        f'echo \'{{"event": "transaction_begin", "packages": ["\'$2\'"]}}\' >> {log}\n'
+        f'echo \'{{"event": "transaction_end", "checks": []}}\' >> {log}\n'
+        f"printf 'jtdx\\nwsjtx-data\\n' >> {pkgs}\n"
+        "echo Done.\n"
+    )
+    engine.chmod(engine.stat().st_mode | stat.S_IXUSR)
+    proc = subprocess.run(
+        ["bash", "-c", campaign.remote_command("yaac", 60)],
+        cwd=home,
+        env={**os.environ, "HOME": str(home), "PATH": f"{fakebin}:{os.environ['PATH']}"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    result = campaign.classify("yaac", proc.stdout, seconds=1, timeout=60)
+    assert result.exit_code == 0, proc.stdout + proc.stderr
+    assert [e["event"] for e in result.entries] == ["transaction_begin", "transaction_end"]
+    assert result.entries[0]["packages"] == ["yaac"]
+    assert not any(e.get("stale") for e in result.entries)
+    assert result.new_packages == ("wsjtx-data",)
+    assert "__NEW_PACKAGES" not in result.tail and "wsjtx-data" not in result.tail


### PR DESCRIPTION
## Why

"Success is only as good as the confirmation." A unit-pass row said `ok` and could not answer what confirmed it, against what machine state, or whether the verdict was about the machine or about the order of the pass.

## What

`scripts/vm_campaign.py`:

- **Confirmed by** column per row, from the `transaction_end` effect checks the unit appended to the guest's log (captured by line-mark, not by re-reading the whole file); the summary counts rows confirmed by **no check**. On Kali `yaac` is confirmed only by its dependency `libjssc-java` — an engine gap this makes visible (issue to follow).
- **Provenance header**: engine commit + dirty-file count, libvirt domain/snapshot with the snapshot's creation time, prepare timestamp, InRelease dates of the guest's apt lists. The guest address is never a fallback; the target line is the engine's own `status` output with its `Target:` label stripped (every report to date printed it twice).
- **Cumulative refusals**: a plan-time refusal naming a package an earlier unit of the pass installed (including apt dependencies, via a dpkg delta) is labelled with the package and the unit, and re-run alone on the snapshot after the pass. `wsjtx-improved` vs `wsjtx-data` (pulled in by `jtdx`) stops masking its real failure on Kali (#24).
- `<out>.evidence.jsonl` sidecar: the complete machine-readable record.

`docs/contributing/vm-testing.md` gains *What a report has to carry to be believed*.

## Evidence

- `tests/test_vm_campaign.py` (8 tests, each watched red first; the remote command runs for real under `bash -c` with a fake engine and fake `dpkg-query`). 1564 pass locally; ruff, `mypy --strict`, doc links, gitignore audit all clean.
- Live trial on Kali, 2026-09-04, `--reset-first Kali_Dev_Box --units jtdx wsjtx-improved z8530-utils2 yaac`:

```
| `jtdx` | installed+confirmed | 1 check: package jtdx installed 2.2.159+improved-4 | 7 |
| `wsjtx-improved` | refused (plan) — cumulative: names `wsjtx-data`, installed by `jtdx` earlier this pass; alone on `clean-baseline`: FAILED (5 s) |  | 1 |
| `z8530-utils2` | refused (plan) |  | 1 |
| `yaac` | installed+confirmed | 1 check: package libjssc-java installed 2.8.0-4 | 6 |
```

The isolated re-run's failure text is `wsjtx:amd64=3.2.0 Depends libboost-log1.83.0 … [no choices]` — #24, now on the record from a clean snapshot rather than inferred. Report and sidecar grep clean for `192.168` and `@`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
