### PR TITLE
D-041: requires_kernel — Linux 7.1 removed AX.25; the plan reads the running kernel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ Do not re-litigate these without being asked:
 | Profile members the target lacks | Defer by name, install the rest; a typed name, an engine gap or a manifest defect still refuses | Five of fifteen profiles withheld nineteen installable units over four absent ones (**D-039**) |
 | Third-party apt repos | Manifest pins the key fingerprint; added only when the archive offers nothing; consent is the fingerprint itself, never `1` or `--yes`; both files come out on uninstall | `code`/`codium` refused on every target and withheld all of `workstation` (**D-040**) |
 | Profile members a target lacks | Deferred by name, the rest installs; a name the operator typed, an engine gap or a manifest defect still refuses | `listening` withheld nineteen units on Ubuntu 24.04 over four the archive lacks (**D-039**) |
+| Kernel subsystems | `requires_kernel` on the manifest; the plan reads `/lib/modules/<uname -r>` and refuses or defers by name; never in the capability matrix, never a module we build | Linux 7.1 removed AX.25; Kali and the maintainer's own laptop have no `ax25.ko`, and `packet` had "installed whole" on Pop!_OS (**D-041**) |
 
 Full reasoning and evidence in `docs/DECISIONS.md`, which is authoritative.
 
@@ -450,6 +451,8 @@ longer a design question in the abstract; a shipped manifest depends on it. See
 `DESIGN.md` §15.3 and the D-004 amendment.
 
 **Open questions awaiting the maintainer** are in `docs/QUESTIONS.md`.
+**Q-018** (refresh apt lists by default) and **Q-019** (retire `z8530-utils2`;
+is the packet core userspace-primary now that Linux 7.1 has no AX.25) are open.
 **Q-001 through Q-016 are all resolved.** Q-006, Q-007 and Q-008 closed on
 2026-08-29: HamClock carries both clients defaulting to `openhamclock` with
 `ohb.works` as the backend; SuperSDR is carried under **D-033**; cellular

--- a/catalog/packages/aprsdigi.yaml
+++ b/catalog/packages/aprsdigi.yaml
@@ -5,6 +5,7 @@ name: aprsdigi
 version: "3.11.0"
 summary: APRS digipeater — repeats packets so they reach further than one hop
 categories: [tracking, packet]
+requires_kernel: [ax25]
 
 after: [ax25-tools]
 
@@ -34,6 +35,10 @@ documentation:
     considered decision about your paths. Also a callsign, which every
     repeated packet carries as having passed through you.
   known_problems: >-
+    Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65,
+    2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on
+    7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by
+    name. See `ax25-tools` and `docs/reference/kernel-ax25.md`.
     A badly configured digipeater is actively harmful to a local network:
     repeating everything, repeating too many hops, or failing to suppress
     duplicates floods a shared channel that everyone else needs. Learn the

--- a/catalog/packages/ax25-apps.yaml
+++ b/catalog/packages/ax25-apps.yaml
@@ -5,6 +5,7 @@ name: ax25-apps
 version: "0.0.8"
 summary: The programs you actually use over AX.25 once a port is up
 categories: [packet, emcomm]
+requires_kernel: [ax25]
 
 # ax25-tools brings the port up; these speak over it. Ordering, not dependency
 # (D-003) -- they install independently and are useless separately.
@@ -35,6 +36,10 @@ documentation:
     A working AX.25 port from ax25-tools. Without one these programs have
     nothing to talk to.
   known_problems: >-
+    Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65,
+    2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on
+    7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by
+    name. See `ax25-tools` and `docs/reference/kernel-ax25.md`.
     `listen` shows everything on the port including your own transmissions,
     which confuses a first diagnosis. `ax25ipd` links your local packet
     network to a wider one over the internet, which changes who can reach your

--- a/catalog/packages/ax25-tools.yaml
+++ b/catalog/packages/ax25-tools.yaml
@@ -5,6 +5,7 @@ name: ax25-tools
 version: "0.0.10"
 summary: Configures the kernel AX.25 stack — ports, interfaces, NET/ROM, Rose
 categories: [packet, emcomm]
+requires_kernel: [ax25]
 
 install:
   - install:
@@ -34,6 +35,21 @@ documentation:
     records as blocking. Until then this manifest installs the tools and the
     file is yours to write.
   known_problems: >-
+    Linux 7.1 removed the kernel AX.25 stack -- net/ax25, net/netrom, net/rose
+    and every driver in drivers/net/hamradio -- in merge 64edfa65 of
+    2026-04-24. On a 7.1 or newer kernel there is nothing for kissattach to
+    attach to: `socket(AF_AX25)` fails with "Address family not supported by
+    protocol", and no modprobe helps because the module does not exist.
+    Measured 2026-09-04: Kali rolling (7.1.5) and Pop!_OS 24.04 on its 7.1.5
+    kernel lack it; Debian 13 (6.12), Parrot 7.3 (7.0.13), Ubuntu 24.04 (6.8)
+    and Ubuntu 26.04 (7.0.0) carry it as a module. Debian removed ax25-tools
+    from testing on 2026-09-01 (#1143282) because it no longer builds against
+    the headers that left with the subsystem, so Kali's archive lacks the
+    package too. Hammunition reads the running kernel's module tree at plan
+    time and refuses this unit by name, or defers it out of a profile, on a
+    kernel without ax25. The userspace packet path is unaffected: Direwolf's
+    KISS and AGW ports serve pat (`ax25+agwpe`), linbpq, YAAC and Xastir
+    without kernel AX.25. See `docs/reference/kernel-ax25.md`.
     An unconfigured axports produces failures that name a port rather than
     saying the file is empty, which reads as a hardware problem. The AX.25
     stack has a long history of being lightly maintained in the kernel, and

--- a/catalog/packages/ax25-xtools.yaml
+++ b/catalog/packages/ax25-xtools.yaml
@@ -5,6 +5,7 @@ name: ax25-xtools
 version: "0.0.10"
 summary: X11 versions of the AX.25 monitoring tools
 categories: [packet]
+requires_kernel: [ax25]
 
 after: [ax25-tools]
 
@@ -31,6 +32,10 @@ documentation:
   prerequisites: >-
     An X11 session and a configured AX.25 port.
   known_problems: >-
+    Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65,
+    2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on
+    7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by
+    name. See `ax25-tools` and `docs/reference/kernel-ax25.md`.
     It is a thin X11 wrapper with no theming and no scrollback beyond what the
     widget holds. For anything to be captured rather than watched, the
     command-line `listen` piped to a file is the better tool.

--- a/catalog/packages/ax25mail-utils.yaml
+++ b/catalog/packages/ax25mail-utils.yaml
@@ -5,6 +5,7 @@ name: ax25mail-utils
 version: "0.15"
 summary: Utilities for exchanging mail with an FBB packet BBS
 categories: [packet, emcomm]
+requires_kernel: [ax25]
 
 after: [ax25-tools]
 
@@ -36,6 +37,10 @@ documentation:
     Parrot -- only Ubuntu 26.04 and Mint carry it (measured 2026-08-28) -- so on
     the primary target these utilities talk to somebody else's BBS.
   known_problems: >-
+    Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65,
+    2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on
+    7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by
+    name. See `ax25-tools` and `docs/reference/kernel-ax25.md`.
     The absence of `fbb` from the Debian line is the surprise here and it is
     the opposite of the usual direction. Forwarding protocols are old, lightly
     documented and unforgiving of configuration errors, and a mis-set

--- a/catalog/packages/axmail.yaml
+++ b/catalog/packages/axmail.yaml
@@ -5,6 +5,7 @@ name: axmail
 version: "2.13"
 summary: Mail reader that packet callers reach through a node
 categories: [packet, emcomm]
+requires_kernel: [ax25]
 
 after: [ax25-tools]
 
@@ -32,6 +33,10 @@ documentation:
     A working AX.25 stack, a node front end such as uronode configured to
     launch it, and a local mail system for it to read from.
   known_problems: >-
+    Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65,
+    2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on
+    7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by
+    name. See `ax25-tools` and `docs/reference/kernel-ax25.md`.
     It is a front end onto local mail, so anything wrong with mail delivery on
     the machine appears as a packet problem to the caller. Messages carried on
     behalf of others over amateur radio are subject to content rules in most

--- a/catalog/packages/direwolf.yaml
+++ b/catalog/packages/direwolf.yaml
@@ -43,6 +43,11 @@ documentation:
     the station-configuration question this catalog has open; the file is yours
     to write for now, and the shipped example is heavily commented.
   known_problems: >-
+    Unaffected by Linux 7.1's removal of the kernel AX.25 stack: it is the
+    userspace modem, and its KISS and AGW ports are what the other packet
+    programs talk to. Only attaching it to the kernel stack with `kissattach`
+    needs `ax25`, and that is `ax25-tools`' problem, not this unit's. See
+    `docs/reference/kernel-ax25.md`.
     Transmit audio level is the single biggest cause of a station that hears
     everyone and is heard by nobody -- overdriving the radio produces a signal
     that looks strong and does not decode. Direwolf will tell you its own

--- a/catalog/packages/fbb.yaml
+++ b/catalog/packages/fbb.yaml
@@ -5,6 +5,7 @@ name: fbb
 version: "7.011"
 summary: The classic packet radio BBS and mailbox
 categories: [packet, emcomm]
+requires_kernel: [ax25]
 
 after: [ax25-tools]
 
@@ -42,6 +43,10 @@ documentation:
     which is an arrangement with their operators rather than a setting.
     Somewhere for it to run continuously.
   known_problems: >-
+    Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65,
+    2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on
+    7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by
+    name. See `ax25-tools` and `docs/reference/kernel-ax25.md`.
     Not available on Debian 13, Kali or Parrot -- see the install note. It is
     old software with a configuration model to match: several files, a
     forwarding schedule in its own syntax, and unforgiving behaviour when they

--- a/catalog/packages/linbpq.yaml
+++ b/catalog/packages/linbpq.yaml
@@ -104,6 +104,9 @@ documentation:
     QtSoundModem, and a callsign in `/etc/bpq32.cfg`. Running a Winlink gateway
     additionally requires registration with the Winlink system.
   known_problems: >-
+    Unaffected by Linux 7.1's removal of the kernel AX.25 stack: it carries
+    its own AX.25 implementation and drives Direwolf over KISS or AGW, so no
+    AF_AX25 socket is involved. See `docs/reference/kernel-ax25.md`.
     Upstream publishes prebuilt binaries in a directory named Beta with no
     versioning or checksums; we ignore those and build from a tagged source
     revision instead. The generated configuration is a minimum viable node and

--- a/catalog/packages/linpac.yaml
+++ b/catalog/packages/linpac.yaml
@@ -5,6 +5,7 @@ name: linpac
 version: "0.28"
 summary: Terminal for AX.25 packet with a built-in mail client and macros
 categories: [packet, emcomm]
+requires_kernel: [ax25]
 
 install:
   - install:
@@ -34,6 +35,10 @@ documentation:
     configuration carries your callsign and is the step this catalog cannot yet
     generate for you; see the open station-configuration question in CLAUDE.md.
   known_problems: >-
+    Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65,
+    2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on
+    7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by
+    name. See `ax25-tools` and `docs/reference/kernel-ax25.md`.
     Nothing works until AX.25 is configured, and the failure is a terminal that
     connects to nothing rather than a message naming the missing port. AHRL
     installs `libax25` alongside it (inventory unit 25), which Debian's package

--- a/catalog/packages/pat.yaml
+++ b/catalog/packages/pat.yaml
@@ -36,6 +36,15 @@ documentation:
     -- the station-configuration question this catalog has open (CLAUDE.md,
     D-004 amendment) is exactly this file and LinBPQ's.
   known_problems: >-
+    Unaffected by Linux 7.1's removal of the kernel AX.25 stack when its AX.25
+    engine is `agwpe` or `serial-tnc` (`ax25+agwpe://`, `ax25+serial-tnc://`):
+    those talk to Direwolf's AGW port or a KISS TNC and never open an AF_AX25
+    socket. The `linux` engine (`ax25+linux://`, built with libax25) does, and
+    fails on 7.1 with "Address family not supported by protocol". The generic
+    `ax25://` scheme resolves to whichever engine `ax25.engine` names in the
+    config, so a config that says `linux` is the one that breaks. Read from
+    pat's `app/connect.go` and wl2k-go's `transport/ax25/ax25_linux.go`,
+    2026-09-04. See `docs/reference/kernel-ax25.md`.
     The web interface binds to localhost by default; exposing it to a network
     exposes your mailbox and your Winlink credentials, and there is no
     authentication in front of it. Winlink messages traverse a system with

--- a/catalog/packages/qtsoundmodem.yaml
+++ b/catalog/packages/qtsoundmodem.yaml
@@ -87,6 +87,9 @@ documentation:
     VOX. A program to connect to its KISS port: LinBPQ, Xastir, Pat or anything
     else that speaks KISS over TCP.
   known_problems: >-
+    Unaffected by Linux 7.1's removal of the kernel AX.25 stack: it is a
+    userspace modem exposing KISS and AGW over TCP, like Direwolf. See
+    `docs/reference/kernel-ax25.md`.
     **It needs four permissive compiler flags to build on a current toolchain**,
     recorded in the install block rather than left for you to discover. One of
     them silences an implicit declaration of `Sleep()`, which is a Windows

--- a/catalog/packages/uronode.yaml
+++ b/catalog/packages/uronode.yaml
@@ -5,6 +5,7 @@ name: uronode
 version: "2.15"
 summary: Node front end that lets other stations reach services on your machine
 categories: [packet, emcomm]
+requires_kernel: [ax25]
 
 after: [ax25-tools]
 
@@ -34,6 +35,10 @@ documentation:
     uronode. Your callsign appears in that configuration and in what callers
     see.
   known_problems: >-
+    Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65,
+    2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on
+    7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by
+    name. See `ax25-tools` and `docs/reference/kernel-ax25.md`.
     A node is a service other people use, and running one is a commitment: an
     unreliable node is worse for a network than no node. It relays traffic on
     your callsign's authority, so what passes through it is your

--- a/catalog/packages/xastir.yaml
+++ b/catalog/packages/xastir.yaml
@@ -45,6 +45,11 @@ documentation:
     a step nothing does for you -- and the project's own website, which is
     where that documentation lived, is currently unreachable (see below).
   known_problems: >-
+    Unaffected by Linux 7.1's removal of the kernel AX.25 stack for its Serial
+    KISS TNC and AGWPE interface types, which need no kernel stack. Only the
+    "AX.25 TNC" interface type (DEVICE_AX25_TNC in `src/interface.c`) opens an
+    AF_AX25 socket, and that one fails on 7.1 with "Address family not
+    supported by protocol". See `docs/reference/kernel-ax25.md`.
     The map configuration is the part everyone struggles with, and an empty
     map looks like a broken program rather than a missing data file. APRS is
     not private: your position, your callsign and your messages are relayed

--- a/catalog/packages/yaac.yaml
+++ b/catalog/packages/yaac.yaml
@@ -62,6 +62,8 @@ documentation:
     passcode for internet-only operation. Serial TNCs need the dialout
     group; libjssc-java supplies the serial bindings.
   known_problems: >-
+    Unaffected by Linux 7.1's removal of the kernel AX.25 stack: it speaks
+    KISS and AGW to Direwolf directly. See `docs/reference/kernel-ax25.md`.
     First run opens a setup wizard; give it a moment on the first tile
     download. The single-roll pin above means an upstream roll turns into
     a hash-mismatch refusal until this manifest is re-pinned -- deliberate,

--- a/catalog/packages/z8530-utils2.yaml
+++ b/catalog/packages/z8530-utils2.yaml
@@ -5,6 +5,7 @@ name: z8530-utils2
 version: "3.0-1"
 summary: Configures Z8530-based HDLC cards for high-speed packet
 categories: [packet, hardware]
+requires_kernel: [ax25]
 
 install:
   - install:
@@ -30,6 +31,11 @@ documentation:
     A Z8530-based card in an ISA or PCI slot, and a kernel with the matching
     driver. Both are museum conditions on current hardware.
   known_problems: >-
+    Needs the kernel AX.25 stack and the `scc` driver, both of which Linux 7.1
+    removed with the rest of drivers/net/hamradio (merge 64edfa65,
+    2026-04-24); the plan refuses or defers this unit by name on a 7.1 or
+    newer kernel, and Q-019 asks whether to retire it. See
+    `docs/reference/kernel-ax25.md`.
     The hardware predates PCI Express and most of it is ISA, so a modern
     machine cannot host it at all. Carried for completeness and for anyone
     maintaining an existing installation, not as a route to build a new one.

--- a/catalog/profiles/packet.yaml
+++ b/catalog/profiles/packet.yaml
@@ -59,6 +59,17 @@ documentation:
     end, a BBS and Winlink gateway, the Winlink client, an HF data modem, the
     full-featured APRS client, a digipeater and an internet gateway, mail
     tools, AMPRnet routing, and a GRIB weather viewer.
+
+    **On a kernel without AX.25 the kernel-side members are withheld, by
+    name.** Linux 7.1 removed the AX.25 stack (2026-04-24); Kali rolling and
+    Pop!_OS on their 7.1 kernels no longer have it, measured 2026-09-04. The
+    plan reads the running kernel and defers `ax25-tools`, `ax25-apps`,
+    `ax25-xtools`, `ax25mail-utils`, `axmail`, `aprsdigi`, `linpac` and
+    `uronode` with the reason, and the rest installs: Direwolf, pat over
+    `ax25+agwpe`, LinBPQ, YAAC and Xastir's AGWPE interface work with no
+    kernel stack. What such a machine cannot have is a kernel port — no
+    `axports`, `kissattach`, `ax25d` or NET/ROM. `docs/reference/kernel-ax25.md`
+    has the measurements.
   why_together: >-
     This is a network, not a set of programs. Direwolf turns a radio into a
     modem, ax25-tools brings the port up, and everything above that speaks over

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2699,6 +2699,27 @@ members it withholds on such a kernel and that the Direwolf–pat–APRS
 station still installs. `docs/reference/kernel-ax25.md` is the record and
 carries the reproduction commands.
 
-**Measured on 2026-09-04** with this engine on the Kali VM (7.1.5) and
-the Debian 13 VM (6.12.107): recorded on the pull request, and in the
-campaign reports under `~/.local/state/hammunition-campaigns/`.
+**Measured on 2026-09-04** with this engine (commit 383cf27) through
+`scripts/vm_campaign.py`, each VM restored to its clean snapshot first:
+
+| Machine | Unit | Outcome |
+|---|---|---|
+| Kali 2026.3, `7.1.5+kali-amd64` | `ax25-tools` | refused at plan time, two blockers: no apt candidate, *and* the kernel blocker naming `7.1.5+kali-amd64`, merge 64edfa65, the userspace path and D-024 |
+| Kali 2026.3 | `linpac` | refused at plan time on the kernel blocker alone — the package is in Kali's archive, so the archive check would have let it through |
+| Kali 2026.3 | `direwolf` | installed and confirmed, 5 s |
+| Debian 13, `6.12.107+deb13-amd64` | `ax25-tools` | installed and confirmed, 4 s |
+| Debian 13 | `linpac` | installed and confirmed, 2 s |
+
+The `packet` profile as a whole, dry-run on the same Kali VM: eight members
+deferred (`ax25-tools`, `linpac`, `aprsdigi`, `ax25-apps`, `ax25-xtools`,
+`ax25mail-utils`, `axmail`, `uronode`), 23 apt packages and the four git
+builds (`ardopcf`, `linbpq`, `qtsoundmodem`, `qttermtcp`) still planned,
+exit 0. That run found one defect the unit tests had not: a member the
+archive had already deferred (`ax25-tools`) had its reason *replaced* by the
+kernel's, and the deferral's "a release that carries it needs no change
+here" was then false of Kali's archive. A reason already recorded now
+stands; the typed-name refusal shows every one. The other two declaring
+units, `fbb` and `z8530-utils2`, are not `packet` members. The campaign
+reports are under
+`~/.local/state/hammunition-campaigns/` and the row-level evidence is in
+`docs/reference/kernel-ax25.md`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2616,3 +2616,89 @@ that records it:
   manifest declares is not added (D-022)*, no gate was presented, no
   file was written under `/etc/apt/keyrings/` or `sources.list.d/`, and
   the log holds no `consent_affirmed`. Rule 3, measured.
+
+---
+
+## D-041 — A manifest declares the kernel subsystems it cannot work without; the plan reads the running kernel's module tree and refuses or defers by name, never from the capability matrix, and never by building a module
+
+**Date:** 2026-09-04. **Status:** accepted; built the same day, awaiting
+the maintainer's review on the pull request.
+**Depends on:** D-018 (external claims tested before published), D-024
+(carry only what a distribution packages), D-031 (verify the effect, not
+the exit status), D-039 (a profile member the target lacks is deferred by
+name; a typed name still refuses), the rejected-list entry *a custom kernel*.
+**Amends:** D-008's description of the packet core as resting on "the
+kernel AX.25 stack" — see Q-019.
+
+**What was measured.** Linux 7.1 removed the amateur-radio networking
+subsystem — `net/ax25`, `net/netrom`, `net/rose`, every driver in
+`drivers/net/hamradio` and their uapi headers — in merge
+`64edfa65062dc4509ba75978116b2f6d392346f5` (2026-04-24). Debian removed
+`ax25-tools` from testing on 2026-09-01 (#1143282: it no longer builds
+without `linux/hdlcdrv.h`), which is the archive gap the Kali campaign
+reported. On 2026-09-04, on the seven machines this project has:
+
+| Kernel | `ax25.ko` |
+|---|---|
+| Debian 13 6.12.107, Parrot 7.3 7.0.13, Ubuntu 24.04 6.8.0, Ubuntu 26.04 7.0.0 | module; `socket(AF_AX25)` opens after `modprobe ax25` |
+| Kali 7.1.5, Pop!_OS 24.04 VM 7.1.5, Pop!_OS 22.04 laptop 7.1.1 | absent; errno 97, `modprobe: FATAL: Module ax25 not found` |
+
+The Pop!_OS VM still has its previous 7.0.11 tree installed, with
+`ax25.ko.zst` in it, beside the 7.1.5 tree without. **The kernel is a fact
+about the machine, not the distribution.** The overnight campaign
+(`hammunition-overnight-2026-09-04`) had filed `packet` as installing
+whole on Pop!_OS; every package arrived, and `kissattach` could never have
+worked. Confirming by packages is necessary and not sufficient — issue
+#27's shape, one layer down.
+
+**The rule.**
+
+1. **The manifest says what it needs.** `requires_kernel` is a list drawn
+   from a closed vocabulary (`KernelFeature`, today `ax25` only). The
+   vocabulary is exactly the set the probe can find — a test asserts the
+   schema's `Literal`, the probe's module map and its description map are
+   the same set — so a manifest can never name a subsystem the plan cannot
+   check. It is declared only where the software opens `AF_AX25` sockets
+   or configures the kernel stack and has no other mode: ten units, listed
+   in `docs/reference/kernel-ax25.md`. Software with a userspace mode
+   (Direwolf, pat, LinBPQ, YAAC, Xastir, QtSoundModem) declares nothing
+   and its `known_problems` says which of its interfaces needs the kernel
+   — for pat and Xastir read from their source, not their README.
+2. **The plan reads `/lib/modules/<uname -r>/`**, never `lsmod` or
+   `/proc/net/ax25`: on every kernel that carries it, `ax25` is a module
+   nothing loads until a root `kissattach` does, and an unloaded module is
+   not a missing one. Present as `kernel/net/ax25/ax25.ko*` or in
+   `modules.builtin` → the unit plans. Present tree, absent module → a
+   name the operator typed **refuses**, naming the unit, the release and
+   the merge; a profile member **defers** with the same reason and the
+   rest installs (D-039's shape, for a fact about the machine rather than
+   the target). No module tree for the running kernel at all — a container
+   on the host's kernel, which is every CI target — is **disclosed as
+   unchecked** and the unit plans; absence of evidence is not evidence.
+3. **The remedies are the ones that exist.** A distribution kernel that
+   still carries the stack, or the userspace path. The refusal never
+   offers to build the module: the out-of-tree `mod-orphan` suggested
+   upstream is packaged by no distribution (D-024), and a kernel module
+   we compile is a custom kernel by another name.
+4. **It never enters the capability matrix.** The matrix is per target;
+   this is per machine, and per reboot. Writing "Kali: ✗" would be false
+   on a Kali box that kept its 7.0 kernel and would hide the same truth
+   about an Ubuntu 24.04 box the day its HWE kernel crosses 7.1.
+
+**What this is not.** Not a kernel-version check — a version number is a
+proxy, and the module tree is the fact. Not a check that the module is
+loaded, for the reason in rule 2. Not a general hardware-capability probe;
+the vocabulary grows one measured entry at a time, and `netrom`, `rose`
+and the `scc` driver are not in it because no manifest yet needs one that
+`ax25` does not already settle.
+
+**Consequences.** `z8530-utils2` declares `ax25` today and Q-019 asks
+whether to retire it: its `scc` driver left in the same merge and the
+hardware predates PCI Express. The `packet` profile page says which
+members it withholds on such a kernel and that the Direwolf–pat–APRS
+station still installs. `docs/reference/kernel-ax25.md` is the record and
+carries the reproduction commands.
+
+**Measured on 2026-09-04** with this engine on the Kali VM (7.1.5) and
+the Debian 13 VM (6.12.107): recorded on the pull request, and in the
+campaign reports under `~/.local/state/hammunition-campaigns/`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2719,7 +2719,23 @@ archive had already deferred (`ax25-tools`) had its reason *replaced* by the
 kernel's, and the deferral's "a release that carries it needs no change
 here" was then false of Kali's archive. A reason already recorded now
 stands; the typed-name refusal shows every one. The other two declaring
-units, `fbb` and `z8530-utils2`, are not `packet` members. The campaign
-reports are under
-`~/.local/state/hammunition-campaigns/` and the row-level evidence is in
-`docs/reference/kernel-ax25.md`.
+units, `fbb` and `z8530-utils2`, are not `packet` members.
+
+**Installed for real on 2026-09-05** (engine 6b8c080, the fix included,
+both VMs restored to their clean snapshot first, `--whole-profiles`):
+
+| Machine | `packet` | Deferred by name | Installed and confirmed |
+|---|---|---|---|
+| Kali 2026.3, `7.1.5+kali-amd64` | exit 0, 39 s | eight — `ax25-tools` and `ax25-xtools` on the archive (*apt on Kali GNU/Linux Rolling has no candidate*; both build from the `ax25-tools` source Debian removed), `linpac`, `aprsdigi`, `ax25-apps`, `ax25mail-utils`, `axmail`, `uronode` on the kernel | 29 checks: 24 apt packages, the four git builds executable under `/usr/local/bin`, `dialout` membership |
+| Debian 13, `6.12.107+deb13-amd64` | exit 0, 61 s | none | 40 checks, the eight above among them |
+
+Two things the real run corrected. The dry-run paragraph above had
+`ax25-xtools` deferred on the kernel; that reading came from the pre-fix
+output, where the kernel had overwritten every archive reason, and the
+fresh run shows the archive reason it keeps. And the harness's own report
+read *`packet` installed+confirmed* for Kali with no mention of the eight
+— the deferrals are in the transaction log it filed (`transaction_begin`,
+version 2), not in its table. That is the D-041 problem statement in
+miniature, on the tool that exists to prevent it, and is fixed separately.
+The campaign reports are under `~/.local/state/hammunition-campaigns/`
+and the row-level evidence is in `docs/reference/kernel-ax25.md`.

--- a/docs/QUESTIONS.md
+++ b/docs/QUESTIONS.md
@@ -939,3 +939,46 @@ rule, so A with the opt-out is the only shape that survives. Whether the
 refresh also re-runs the candidate check against the fresh lists (a second,
 better plan, disclosed as such) is a follow-on, and worth doing if A is
 taken.
+
+---
+
+## Q-019 🟡 — Kernel AX.25 is gone from Linux 7.1: retire `z8530-utils2`, and does the packet core become userspace-primary?
+
+**Raised 2026-09-04**, from the Kali campaign's `ax25-tools` gap, which
+turned out to be a kernel removal rather than an archive accident
+(**D-041**, `docs/reference/kernel-ax25.md`). D-041 settles what the
+engine does on such a kernel. Two things it leaves to the maintainer:
+
+**1. `z8530-utils2`.** It configures the `scc` driver for Z8530 HDLC cards.
+That driver left the kernel with the rest of `drivers/net/hamradio` in the
+same merge; the cards are ISA and early PCI; the manifest already calls
+both "museum conditions". Today it carries `requires_kernel: [ax25]`, which
+is true but a proxy — a 7.0 kernel with `ax25.ko` and no `scc.ko` is
+possible in principle and the probe would pass it.
+
+| Option | For | Against |
+|---|---|---|
+| **A. Retire, verdict tested-by-us** ⭐ | The driver is gone upstream and no distribution will carry it back; the hardware has no modern host. A retire with the merge hash as evidence is exactly the "dead weight gone *with an explanation*" the parity policy asks for. | Somebody running a 6.12 kernel on a machine with an ISA slot loses a package they could still use. That person is running Debian 13 on a museum piece and can `apt install` it by hand. |
+| B. Add `scc` to the `requires_kernel` vocabulary and keep it | Precise. | A second probe entry for one unit nobody has run here; `scc.ko` would need its own measured path. Vocabulary that exists for one unit is the convention-over-measurement habit D-014 exists to refuse. |
+| C. Leave as is | Nothing to do. | The proxy above; and it stays a CARRY that has never been tested (M5 counts inherited verdicts against us). |
+
+**Recommendation: A.** The parity policy says every unit gets a verdict we
+tested; the test here is `git show 64edfa65 --stat` and it is conclusive.
+
+**2. D-008's packet-core statement.** D-008 and the `packet` profile prose
+both describe the core as the kernel AX.25 stack with Direwolf feeding it.
+On every 7.1+ kernel — Kali now, Ubuntu 24.04 when its HWE kernel moves,
+the maintainer's own laptop — the kernel half is unavailable and the
+userspace half (Direwolf → AGW/KISS → pat, LinBPQ, YAAC, Xastir) is the
+whole station. Should D-008 be amended to say the packet core is
+userspace-primary, with the kernel stack a bonus where the kernel still
+has it?
+
+| Option | For | Against |
+|---|---|---|
+| **A. Amend D-008: userspace-primary; kernel AX.25 where present** ⭐ | Matches what works on the maintainer's laptop today and on every target the day its kernel crosses 7.1. The getting-started packet guide would then teach the Direwolf–pat path first and `kissattach` second, which is the order a new operator should meet them in anyway. | The kernel path is the one that gives packet connections as sockets, which is the property the `ax25-tools` manifest praises; on Debian 13 it remains the fuller station. |
+| B. Leave D-008; let D-041's deferral carry it | No amendment. | The design record would describe a core whose primary member defers on the maintainer's own machine. |
+
+**Recommendation: A.** The amendment is a paragraph; the guide reorder is
+the real work and belongs to the getting-started packet page whenever it
+is written.

--- a/docs/packages/aprsdigi.md
+++ b/docs/packages/aprsdigi.md
@@ -8,6 +8,7 @@
 - **Categories:** `packet`, `tracking`
 - **Upstream:** <https://github.com/n2ygk/aprsdigi/>
 - **Install after:** `ax25-tools`
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -27,7 +28,7 @@ A configured AX.25 port, a radio that can transmit unattended, and a considered 
 
 ## Known problems
 
-A badly configured digipeater is actively harmful to a local network: repeating everything, repeating too many hops, or failing to suppress duplicates floods a shared channel that everyone else needs. Learn the local convention before switching one on -- the WIDEn-N rules exist because the earlier free-for-all did not scale. Unattended transmission has licence implications in most jurisdictions and they are yours to know.
+Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65, 2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on 7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by name. See `ax25-tools` and `docs/reference/kernel-ax25.md`. A badly configured digipeater is actively harmful to a local network: repeating everything, repeating too many hops, or failing to suppress duplicates floods a shared channel that everyone else needs. Learn the local convention before switching one on -- the WIDEn-N rules exist because the earlier free-for-all did not scale. Unattended transmission has licence implications in most jurisdictions and they are yours to know.
 
 ## Keeping it current
 

--- a/docs/packages/ax25-apps.md
+++ b/docs/packages/ax25-apps.md
@@ -8,6 +8,7 @@
 - **Categories:** `emcomm`, `packet`
 - **Upstream:** <https://linux-ax25.in-berlin.de/wiki/Ax25-apps>
 - **Install after:** `ax25-tools`
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -27,7 +28,7 @@ A working AX.25 port from ax25-tools. Without one these programs have nothing to
 
 ## Known problems
 
-`listen` shows everything on the port including your own transmissions, which confuses a first diagnosis. `ax25ipd` links your local packet network to a wider one over the internet, which changes who can reach your station and is worth deciding deliberately rather than copying from an example configuration.
+Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65, 2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on 7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by name. See `ax25-tools` and `docs/reference/kernel-ax25.md`. `listen` shows everything on the port including your own transmissions, which confuses a first diagnosis. `ax25ipd` links your local packet network to a wider one over the internet, which changes who can reach your station and is worth deciding deliberately rather than copying from an example configuration.
 
 ## Keeping it current
 

--- a/docs/packages/ax25-tools.md
+++ b/docs/packages/ax25-tools.md
@@ -7,6 +7,7 @@
 - **Version recorded:** 0.0.10
 - **Categories:** `emcomm`, `packet`
 - **Upstream:** <https://linux-ax25.in-berlin.de/wiki/Main_Page>
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -26,7 +27,7 @@ A port definition in `/etc/ax25/axports` naming your callsign, the device, and t
 
 ## Known problems
 
-An unconfigured axports produces failures that name a port rather than saying the file is empty, which reads as a hardware problem. The AX.25 stack has a long history of being lightly maintained in the kernel, and some of the more exotic paths -- Rose in particular -- have few users and correspondingly few bug reports. A callsign written into axports is transmitted; it is the station identity, not a label.
+Linux 7.1 removed the kernel AX.25 stack -- net/ax25, net/netrom, net/rose and every driver in drivers/net/hamradio -- in merge 64edfa65 of 2026-04-24. On a 7.1 or newer kernel there is nothing for kissattach to attach to: `socket(AF_AX25)` fails with "Address family not supported by protocol", and no modprobe helps because the module does not exist. Measured 2026-09-04: Kali rolling (7.1.5) and Pop!_OS 24.04 on its 7.1.5 kernel lack it; Debian 13 (6.12), Parrot 7.3 (7.0.13), Ubuntu 24.04 (6.8) and Ubuntu 26.04 (7.0.0) carry it as a module. Debian removed ax25-tools from testing on 2026-09-01 (#1143282) because it no longer builds against the headers that left with the subsystem, so Kali's archive lacks the package too. Hammunition reads the running kernel's module tree at plan time and refuses this unit by name, or defers it out of a profile, on a kernel without ax25. The userspace packet path is unaffected: Direwolf's KISS and AGW ports serve pat (`ax25+agwpe`), linbpq, YAAC and Xastir without kernel AX.25. See `docs/reference/kernel-ax25.md`. An unconfigured axports produces failures that name a port rather than saying the file is empty, which reads as a hardware problem. The AX.25 stack has a long history of being lightly maintained in the kernel, and some of the more exotic paths -- Rose in particular -- have few users and correspondingly few bug reports. A callsign written into axports is transmitted; it is the station identity, not a label.
 
 ## Keeping it current
 

--- a/docs/packages/ax25-xtools.md
+++ b/docs/packages/ax25-xtools.md
@@ -8,6 +8,7 @@
 - **Categories:** `packet`
 - **Upstream:** <https://linux-ax25.in-berlin.de/wiki/Main_Page>
 - **Install after:** `ax25-tools`
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -27,7 +28,7 @@ An X11 session and a configured AX.25 port.
 
 ## Known problems
 
-It is a thin X11 wrapper with no theming and no scrollback beyond what the widget holds. For anything to be captured rather than watched, the command-line `listen` piped to a file is the better tool.
+Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65, 2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on 7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by name. See `ax25-tools` and `docs/reference/kernel-ax25.md`. It is a thin X11 wrapper with no theming and no scrollback beyond what the widget holds. For anything to be captured rather than watched, the command-line `listen` piped to a file is the better tool.
 
 ## Keeping it current
 

--- a/docs/packages/ax25mail-utils.md
+++ b/docs/packages/ax25mail-utils.md
@@ -8,6 +8,7 @@
 - **Categories:** `emcomm`, `packet`
 - **Upstream:** <https://sourceforge.net/projects/ax25mail/>
 - **Install after:** `ax25-tools`
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -27,7 +28,7 @@ A configured AX.25 port and a BBS to forward with, which means an agreement with
 
 ## Known problems
 
-The absence of `fbb` from the Debian line is the surprise here and it is the opposite of the usual direction. Forwarding protocols are old, lightly documented and unforgiving of configuration errors, and a mis-set forwarding schedule can flood a slow RF link.
+Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65, 2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on 7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by name. See `ax25-tools` and `docs/reference/kernel-ax25.md`. The absence of `fbb` from the Debian line is the surprise here and it is the opposite of the usual direction. Forwarding protocols are old, lightly documented and unforgiving of configuration errors, and a mis-set forwarding schedule can flood a slow RF link.
 
 ## Keeping it current
 

--- a/docs/packages/axmail.md
+++ b/docs/packages/axmail.md
@@ -8,6 +8,7 @@
 - **Categories:** `emcomm`, `packet`
 - **Upstream:** <https://sourceforge.net/projects/axmail/>
 - **Install after:** `ax25-tools`
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -27,7 +28,7 @@ A working AX.25 stack, a node front end such as uronode configured to launch it,
 
 ## Known problems
 
-It is a front end onto local mail, so anything wrong with mail delivery on the machine appears as a packet problem to the caller. Messages carried on behalf of others over amateur radio are subject to content rules in most jurisdictions, and running the service means accepting that.
+Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65, 2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on 7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by name. See `ax25-tools` and `docs/reference/kernel-ax25.md`. It is a front end onto local mail, so anything wrong with mail delivery on the machine appears as a packet problem to the caller. Messages carried on behalf of others over amateur radio are subject to content rules in most jurisdictions, and running the service means accepting that.
 
 ## Keeping it current
 

--- a/docs/packages/direwolf.md
+++ b/docs/packages/direwolf.md
@@ -27,7 +27,7 @@ Audio in and out to the radio, and a way to key the transmitter -- a serial cont
 
 ## Known problems
 
-Transmit audio level is the single biggest cause of a station that hears everyone and is heard by nobody -- overdriving the radio produces a signal that looks strong and does not decode. Direwolf will tell you its own receive levels, which is the place to start. Running it as a digipeater or an igate puts traffic on the network under your callsign, and the default example configuration is deliberately not a digipeater; turning that on is a decision about a shared resource.
+Unaffected by Linux 7.1's removal of the kernel AX.25 stack: it is the userspace modem, and its KISS and AGW ports are what the other packet programs talk to. Only attaching it to the kernel stack with `kissattach` needs `ax25`, and that is `ax25-tools`' problem, not this unit's. See `docs/reference/kernel-ax25.md`. Transmit audio level is the single biggest cause of a station that hears everyone and is heard by nobody -- overdriving the radio produces a signal that looks strong and does not decode. Direwolf will tell you its own receive levels, which is the place to start. Running it as a digipeater or an igate puts traffic on the network under your callsign, and the default example configuration is deliberately not a digipeater; turning that on is a decision about a shared resource.
 
 ## Keeping it current
 

--- a/docs/packages/fbb.md
+++ b/docs/packages/fbb.md
@@ -8,6 +8,7 @@
 - **Categories:** `emcomm`, `packet`
 - **Upstream:** <https://sourceforge.net/projects/linfbb/>
 - **Install after:** `ax25-tools`
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -28,7 +29,7 @@ A configured AX.25 stack and a callsign for the BBS. Forwarding partners, which 
 
 ## Known problems
 
-Not available on Debian 13, Kali or Parrot -- see the install note. It is old software with a configuration model to match: several files, a forwarding schedule in its own syntax, and unforgiving behaviour when they disagree. Running a BBS means carrying other people's traffic under your callsign, which in most jurisdictions makes its content your responsibility.
+Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65, 2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on 7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by name. See `ax25-tools` and `docs/reference/kernel-ax25.md`. Not available on Debian 13, Kali or Parrot -- see the install note. It is old software with a configuration model to match: several files, a forwarding schedule in its own syntax, and unforgiving behaviour when they disagree. Running a BBS means carrying other people's traffic under your callsign, which in most jurisdictions makes its content your responsibility.
 
 ## Keeping it current
 

--- a/docs/packages/linbpq.md
+++ b/docs/packages/linbpq.md
@@ -43,7 +43,7 @@ Binaries this produces:
 
 ## Known problems
 
-Upstream publishes prebuilt binaries in a directory named Beta with no versioning or checksums; we ignore those and build from a tagged source revision instead. The generated configuration is a minimum viable node and is meant to be edited — read it before transmitting.
+Unaffected by Linux 7.1's removal of the kernel AX.25 stack: it carries its own AX.25 implementation and drives Direwolf over KISS or AGW, so no AF_AX25 socket is involved. See `docs/reference/kernel-ax25.md`. Upstream publishes prebuilt binaries in a directory named Beta with no versioning or checksums; we ignore those and build from a tagged source revision instead. The generated configuration is a minimum viable node and is meant to be edited — read it before transmitting.
 
 ## Keeping it current
 

--- a/docs/packages/linpac.md
+++ b/docs/packages/linpac.md
@@ -7,6 +7,7 @@
 - **Version recorded:** 0.28
 - **Categories:** `emcomm`, `packet`
 - **Upstream:** <https://sourceforge.net/projects/linpac/>
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -26,7 +27,7 @@ A configured AX.25 stack -- ax25-tools with a port defined in `/etc/ax25/axports
 
 ## Known problems
 
-Nothing works until AX.25 is configured, and the failure is a terminal that connects to nothing rather than a message naming the missing port. AHRL installs `libax25` alongside it (inventory unit 25), which Debian's package already depends on. The interface is from the era it comes from: function keys and modes, not menus.
+Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65, 2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on 7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by name. See `ax25-tools` and `docs/reference/kernel-ax25.md`. Nothing works until AX.25 is configured, and the failure is a terminal that connects to nothing rather than a message naming the missing port. AHRL installs `libax25` alongside it (inventory unit 25), which Debian's package already depends on. The interface is from the era it comes from: function keys and modes, not menus.
 
 ## Keeping it current
 

--- a/docs/packages/pat.md
+++ b/docs/packages/pat.md
@@ -26,7 +26,7 @@ A Winlink account, which is free and tied to your callsign. A path to a gateway:
 
 ## Known problems
 
-The web interface binds to localhost by default; exposing it to a network exposes your mailbox and your Winlink credentials, and there is no authentication in front of it. Winlink messages traverse a system with published policies about content and are not private. HF forwarding needs ARDOP or VARA, neither of which is in this catalog yet -- VARA is post-1.0 and runs under Wine -- so the honest state today is telnet and packet.
+Unaffected by Linux 7.1's removal of the kernel AX.25 stack when its AX.25 engine is `agwpe` or `serial-tnc` (`ax25+agwpe://`, `ax25+serial-tnc://`): those talk to Direwolf's AGW port or a KISS TNC and never open an AF_AX25 socket. The `linux` engine (`ax25+linux://`, built with libax25) does, and fails on 7.1 with "Address family not supported by protocol". The generic `ax25://` scheme resolves to whichever engine `ax25.engine` names in the config, so a config that says `linux` is the one that breaks. Read from pat's `app/connect.go` and wl2k-go's `transport/ax25/ax25_linux.go`, 2026-09-04. See `docs/reference/kernel-ax25.md`. The web interface binds to localhost by default; exposing it to a network exposes your mailbox and your Winlink credentials, and there is no authentication in front of it. Winlink messages traverse a system with published policies about content and are not private. HF forwarding needs ARDOP or VARA, neither of which is in this catalog yet -- VARA is post-1.0 and runs under Wine -- so the honest state today is telnet and packet.
 
 ## Keeping it current
 

--- a/docs/packages/qtsoundmodem.md
+++ b/docs/packages/qtsoundmodem.md
@@ -33,7 +33,7 @@ Binaries this produces:
 
 ## Known problems
 
-**It needs four permissive compiler flags to build on a current toolchain**, recorded in the install block rather than left for you to discover. One of them silences an implicit declaration of `Sleep()`, which is a Windows function -- the Linux path through that code should be treated as less exercised than the Windows one. Transmit audio level decides whether anyone decodes you, and the scope this program provides is the best tool available for getting it right, which is most of the argument for installing it.
+Unaffected by Linux 7.1's removal of the kernel AX.25 stack: it is a userspace modem exposing KISS and AGW over TCP, like Direwolf. See `docs/reference/kernel-ax25.md`. **It needs four permissive compiler flags to build on a current toolchain**, recorded in the install block rather than left for you to discover. One of them silences an implicit declaration of `Sleep()`, which is a Windows function -- the Linux path through that code should be treated as less exercised than the Windows one. Transmit audio level decides whether anyone decodes you, and the scope this program provides is the best tool available for getting it right, which is most of the argument for installing it.
 
 ## Toolkit risk
 

--- a/docs/packages/uronode.md
+++ b/docs/packages/uronode.md
@@ -8,6 +8,7 @@
 - **Categories:** `emcomm`, `packet`
 - **Upstream:** <https://uronode.sourceforge.net/>
 - **Install after:** `ax25-tools`
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -27,7 +28,7 @@ A configured AX.25 stack, and `ax25d` set up to hand inbound connections to uron
 
 ## Known problems
 
-A node is a service other people use, and running one is a commitment: an unreliable node is worse for a network than no node. It relays traffic on your callsign's authority, so what passes through it is your responsibility in most jurisdictions. Configuration is several files and getting the ax25d handoff right is the usual sticking point.
+Needs the kernel AX.25 stack, which Linux 7.1 removed (merge 64edfa65, 2026-04-24); on a 7.1 or newer kernel -- Kali rolling and Pop!_OS 24.04 on 7.1.5, measured 2026-09-04 -- the plan refuses or defers this unit by name. See `ax25-tools` and `docs/reference/kernel-ax25.md`. A node is a service other people use, and running one is a commitment: an unreliable node is worse for a network than no node. It relays traffic on your callsign's authority, so what passes through it is your responsibility in most jurisdictions. Configuration is several files and getting the ax25d handoff right is the usual sticking point.
 
 ## Keeping it current
 

--- a/docs/packages/xastir.md
+++ b/docs/packages/xastir.md
@@ -27,7 +27,7 @@ A callsign, which APRS transmits in clear and which identifies you. RF operation
 
 ## Known problems
 
-The map configuration is the part everyone struggles with, and an empty map looks like a broken program rather than a missing data file. APRS is not private: your position, your callsign and your messages are relayed globally and archived by several public sites indefinitely. Beaconing from a home station at a rate suited to a moving vehicle is the most common way to annoy a local network.
+Unaffected by Linux 7.1's removal of the kernel AX.25 stack for its Serial KISS TNC and AGWPE interface types, which need no kernel stack. Only the "AX.25 TNC" interface type (DEVICE_AX25_TNC in `src/interface.c`) opens an AF_AX25 socket, and that one fails on 7.1 with "Address family not supported by protocol". See `docs/reference/kernel-ax25.md`. The map configuration is the part everyone struggles with, and an empty map looks like a broken program rather than a missing data file. APRS is not private: your position, your callsign and your messages are relayed globally and archived by several public sites indefinitely. Beaconing from a home station at a rate suited to a moving vehicle is the most common way to annoy a local network.
 
 ## Keeping it current
 

--- a/docs/packages/yaac.md
+++ b/docs/packages/yaac.md
@@ -28,7 +28,7 @@ A TNC (Direwolf serves well -- this catalog configures it) or an APRS-IS passcod
 
 ## Known problems
 
-First run opens a setup wizard; give it a moment on the first tile download. The single-roll pin above means an upstream roll turns into a hash-mismatch refusal until this manifest is re-pinned -- deliberate, and the cadence hint says why.
+Unaffected by Linux 7.1's removal of the kernel AX.25 stack: it speaks KISS and AGW to Direwolf directly. See `docs/reference/kernel-ax25.md`. First run opens a setup wizard; give it a moment on the first tile download. The single-roll pin above means an upstream roll turns into a hash-mismatch refusal until this manifest is re-pinned -- deliberate, and the cadence hint says why.
 
 ## Keeping it current
 

--- a/docs/packages/z8530-utils2.md
+++ b/docs/packages/z8530-utils2.md
@@ -7,6 +7,7 @@
 - **Version recorded:** 3.0-1
 - **Categories:** `hardware`, `packet`
 - **Upstream:** <https://tracker.debian.org/pkg/z8530-utils2>
+- **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
 
 ## What it does
 
@@ -26,7 +27,7 @@ A Z8530-based card in an ISA or PCI slot, and a kernel with the matching driver.
 
 ## Known problems
 
-The hardware predates PCI Express and most of it is ISA, so a modern machine cannot host it at all. Carried for completeness and for anyone maintaining an existing installation, not as a route to build a new one. Suggests rather than Recommends in the Blend, marked hardware-specific.
+Needs the kernel AX.25 stack and the `scc` driver, both of which Linux 7.1 removed with the rest of drivers/net/hamradio (merge 64edfa65, 2026-04-24); the plan refuses or defers this unit by name on a 7.1 or newer kernel, and Q-019 asks whether to retire it. See `docs/reference/kernel-ax25.md`. The hardware predates PCI Express and most of it is ISA, so a modern machine cannot host it at all. Carried for completeness and for anyone maintaining an existing installation, not as a route to build a new one. Suggests rather than Recommends in the Blend, marked hardware-specific.
 
 ## Keeping it current
 

--- a/docs/profiles/packet.md
+++ b/docs/profiles/packet.md
@@ -9,6 +9,7 @@
 ## What it installs
 
 Two soundcard TNCs — one headless and one with a scope — the kernel AX.25 stack's configuration and user tools, two packet terminals, a node front end, a BBS and Winlink gateway, the Winlink client, an HF data modem, the full-featured APRS client, a digipeater and an internet gateway, mail tools, AMPRnet routing, and a GRIB weather viewer.
+**On a kernel without AX.25 the kernel-side members are withheld, by name.** Linux 7.1 removed the AX.25 stack (2026-04-24); Kali rolling and Pop!_OS on their 7.1 kernels no longer have it, measured 2026-09-04. The plan reads the running kernel and defers `ax25-tools`, `ax25-apps`, `ax25-xtools`, `ax25mail-utils`, `axmail`, `aprsdigi`, `linpac` and `uronode` with the reason, and the rest installs: Direwolf, pat over `ax25+agwpe`, LinBPQ, YAAC and Xastir's AGWPE interface work with no kernel stack. What such a machine cannot have is a kernel port — no `axports`, `kissattach`, `ax25d` or NET/ROM. `docs/reference/kernel-ax25.md` has the measurements.
 
 **Disk footprint:** Around 500 MB. LinBPQ and ardopcf are source builds from pinned upstream tags; everything else is apt.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -332,7 +332,10 @@ Resolution is a distinct phase that finishes before anything is executed
    reached the plan through a *profile*, and only for one of three reasons
    that are facts about the target: no install block matches this
    distro/version/arch, apt on this release has no candidate for the unit's
-   *own* packages, or the distribution's Node is below the manifest's floor.
+   *own* packages, or the distribution's Node is below the manifest's floor
+   — and for one fact about the *machine*: the running kernel lacks a
+   subsystem the manifest's `requires_kernel` names (**D-041**; Linux 7.1
+   removed AX.25, and Kali on 7.1.5 defers eight `packet` members).
    The member and its catalog dependents are listed under *Will NOT happen*
    with the reason, and the rest of the profile installs (**D-039**). A
    name you typed is never deferred: `hammunition install satdump` on
@@ -385,6 +388,7 @@ capability matrix that reports coverage the engine does not have is the shim
 | A profile every member of which this target cannot install | the profile by name, with each member's reason — installing nothing and reporting success is not an outcome (**D-039**) |
 | No apt package lists at all | that this is a stale-lists problem, with `--refresh` as the remedy |
 | A group membership with no identifiable operator | that `--user` is needed |
+| A unit whose `requires_kernel` names a subsystem the running kernel's module tree lacks | the unit, the kernel release and the merge that removed the subsystem, with the remedies that exist: a distribution kernel that still carries it, or the userspace path (Direwolf's KISS/AGW ports serve pat, LinBPQ, YAAC and Xastir without kernel AX.25). Never an offer to build the module — no distribution packages one, and Hammunition builds no kernel modules (**D-041**). A *profile* member is deferred instead, the D-039 shape. No module tree for the running kernel at all — a container — is disclosed as *cannot be checked* and the unit plans |
 
 The dependency check is the one that earns its keep. **D-016** names four AHRL
 dependency lines suspected of failing silently for years — `fftw2` (FFTW

--- a/docs/reference/kernel-ax25.md
+++ b/docs/reference/kernel-ax25.md
@@ -91,6 +91,7 @@ time:
 | `kernel/net/ax25/ax25.ko*`, or the path in `modules.builtin` | nothing; the unit plans as usual |
 | a module tree for the running kernel that lacks it | **refuses the unit by name** if you typed it, naming the kernel release and the merge; **defers it** with the same reason if it reached the plan through a profile, and the rest of the profile installs (the **D-039** shape) |
 | no module tree for the running kernel at all | plans the unit and adds a note that the requirement *cannot be checked on this machine*. This is a container on the host's kernel — the CI targets — and is not evidence either way |
+| a profile member the target had already deferred — Kali's archive has no `ax25-tools` *and* its kernel has no `ax25` | keeps the reason already recorded. The first live `packet` dry-run on Kali replaced it with the kernel's, and the deferral's "a release that carries it needs no change here" was then false of Kali's archive. `hammunition install ax25-tools` by name shows both |
 
 The refusal's remedies are the ones that exist: a distribution kernel that
 still carries the stack (Debian 13's 6.12, Parrot 7.3's and Ubuntu 26.04's
@@ -136,3 +137,32 @@ hammunition install ax25-tools --dry-run
 The last line is the engine's own answer. On a kernel without the module it
 exits 2 with the refusal; on one with it, it prints the plan (and, under
 `--dry-run`, executes nothing).
+
+## The engine, measured
+
+Engine commit 383cf27, 2026-09-04, through `scripts/vm_campaign.py` with
+each VM restored to its clean snapshot before the run. Reports are
+`kernel-ax25-kali-units-2026-09-04.md` and
+`kernel-ax25-debian13-units-2026-09-04.md` under
+`~/.local/state/hammunition-campaigns/` on the maintainer's machine; the
+harness stamps the engine commit and the guest's InRelease dates into each.
+
+| Machine | Unit | Outcome |
+|---|---|---|
+| Kali 2026.3, `7.1.5+kali-amd64` | `ax25-tools` | **refused (plan)**, two blockers: *apt has no candidate for ax25-tools*, and *needs the kernel's AX.25 stack (module ax25), which kernel 7.1.5+kali-amd64 does not carry — Linux 7.1 removed net/ax25 and the hamradio drivers (merge 64edfa65, 2026-04-24)*, with the remedy naming Debian 13's 6.12, Parrot 7.3's and Ubuntu 26.04's 7.0, the userspace path, and that no module is built (D-024) |
+| Kali 2026.3 | `linpac` | **refused (plan)** on the kernel blocker alone. `linpac` is still in Kali's archive: the archive check passes it and the kernel check is what catches it |
+| Kali 2026.3 | `direwolf` | **installed, confirmed** in 5 s — the userspace modem is untouched |
+| Debian 13, `6.12.107+deb13-amd64` | `ax25-tools` | **installed, confirmed** in 4 s |
+| Debian 13 | `linpac` | **installed, confirmed** in 2 s |
+
+The whole `packet` profile, `--dry-run` on the same Kali VM after the fix
+described in the engine table above: **eight members deferred** —
+`ax25-tools` on the archive reason it already had, `linpac`, `aprsdigi`,
+`ax25-apps`, `ax25-xtools`, `ax25mail-utils`, `axmail` and `uronode` on the
+kernel — and the rest planned: 23 apt packages and the four git builds
+(`ardopcf`, `linbpq`, `qtsoundmodem`, `qttermtcp`), exit 0. The two
+declaring units outside `packet`, `fbb` and `z8530-utils2`, were not run.
+
+What is **not** measured here: any of this on real packet hardware, and
+nothing on the maintainer's Parrot laptop yet — its 7.0.13 row above is the
+Parrot VM's.

--- a/docs/reference/kernel-ax25.md
+++ b/docs/reference/kernel-ax25.md
@@ -1,0 +1,138 @@
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+# Kernel AX.25 — what Linux 7.1 removed, and what the plan does about it
+
+**Measured 2026-09-04.** This page is the evidence behind `requires_kernel`
+(**D-041**) and the reason `packet`'s kernel-side members refuse or defer on
+some machines and not others.
+
+## What happened upstream
+
+Linux 7.1 removed the amateur-radio networking subsystem in one merge:
+`64edfa65062dc4509ba75978116b2f6d392346f5` (2026-04-24, Jakub Kicinski,
+"net-deletions"). Gone are `net/ax25`, `net/netrom`, `net/rose`, every
+driver in `drivers/net/hamradio` — `mkiss`, `6pack`, `bpqether`, `baycom`,
+`scc`, `yam`, `hdlcdrv` — and the uapi headers that went with them.
+
+Two consequences follow for a Debian-family machine:
+
+- **A 7.1 or newer kernel has no `ax25` module and cannot be given one.**
+  `socket(AF_AX25, SOCK_SEQPACKET)` fails with *Address family not supported
+  by protocol* (errno 97), and `modprobe ax25` reports that the module was
+  not found. There is nothing for `kissattach` to attach a TNC to.
+- **Debian removed `ax25-tools` from testing on 2026-09-01** (bug #1143282:
+  it no longer builds, because `linux/hdlcdrv.h` left with the drivers).
+  Kali inherits testing, so Kali's archive lacks the package as well. That
+  archive gap is the symptom the Kali campaign reported; the kernel is the
+  cause, and it reaches machines whose archives are untouched.
+
+An out-of-tree module (`mod-orphan`) was suggested upstream when the
+subsystem was removed. **No distribution packages it**, and Hammunition
+never builds a kernel module of its own: a custom kernel is on the rejected
+list, and **D-024** carries only what a distribution already packages.
+
+## What was measured
+
+Every row is `uname -r` plus a look at `/lib/modules/<release>/kernel/net/ax25/`
+on the machine named, followed by `socket(AF_AX25, SOCK_SEQPACKET)` from
+Python. Machine labels are the dev VMs and the maintainer's laptop; no
+hostnames.
+
+| Machine | Kernel | `ax25.ko` | `AF_AX25` socket, unprivileged | After `sudo modprobe ax25` |
+|---|---|---|---|---|
+| Debian 13 VM | 6.12.107 | module | errno 97 (not autoloaded) | opens |
+| Parrot 7.3 VM | 7.0.13 | module | errno 97 (not autoloaded) | opens |
+| Ubuntu 24.04 VM | 6.8.0 | module | errno 97 (not autoloaded) | opens |
+| Ubuntu 26.04 VM | 7.0.0 | module | errno 97 (not autoloaded) | opens |
+| Kali rolling 2026.3 VM | 7.1.5+kali-amd64 | **absent** | errno 97 | `modprobe: FATAL: Module ax25 not found in directory /lib/modules/7.1.5+kali-amd64` |
+| Pop!_OS 24.04 VM | 7.1.5-76070105-generic | **absent** | errno 97 | `modprobe: FATAL: Module ax25 not found in directory …` |
+| Pop!_OS 22.04 laptop | 7.1.1-76070101-generic | **absent** | errno 97 | module not found |
+
+Two things the table shows that the archive alone does not:
+
+1. **The kernel is a fact about the machine, not the distribution.** The
+   Pop!_OS 24.04 VM still has its previous kernel installed, and the two
+   module trees side by side are the whole finding:
+
+   ```
+   /lib/modules/7.0.11-76070011-generic/kernel/net/ax25/ax25.ko.zst
+   /lib/modules/7.1.5-76070105-generic/kernel/net/ax25/            (absent)
+   ```
+
+   The laptop shows the same: `ax25.ko` under its 6.17.4, 6.17.9, 7.0.9 and
+   7.0.11 trees, nothing under 7.1.1. Same distribution, same release, same
+   archive; one reboot apart. Ubuntu 24.04's 6.8 has it today and loses it
+   the day its HWE kernel crosses 7.1. This is why the check reads the
+   running kernel at plan time and is **never written into the capability
+   matrix**, which is per target.
+2. **The overnight campaign's "packet installs whole on Pop!_OS" was true of
+   packages and false of capability.** Every package arrived; `kissattach`
+   could never have worked. Confirming an install by its packages is
+   necessary and not sufficient — the same shape as issue #27.
+
+The unprivileged errno 97 on every row is expected and is not the finding:
+on a kernel that carries `ax25` as a module, nothing autoloads it until a
+root `kissattach` or `modprobe` does. That is why the probe reads the module
+tree rather than `lsmod` or `/proc/net/ax25` — an unloaded module is not a
+missing one.
+
+## What the engine does
+
+A manifest declares `requires_kernel: [ax25]` when the software opens
+`AF_AX25` sockets or configures the kernel stack and cannot do anything else.
+`hammunition.kernel.KernelProbe` reads `/lib/modules/<uname -r>/` at plan
+time:
+
+| The probe finds | The plan does |
+|---|---|
+| `kernel/net/ax25/ax25.ko*`, or the path in `modules.builtin` | nothing; the unit plans as usual |
+| a module tree for the running kernel that lacks it | **refuses the unit by name** if you typed it, naming the kernel release and the merge; **defers it** with the same reason if it reached the plan through a profile, and the rest of the profile installs (the **D-039** shape) |
+| no module tree for the running kernel at all | plans the unit and adds a note that the requirement *cannot be checked on this machine*. This is a container on the host's kernel — the CI targets — and is not evidence either way |
+
+The refusal's remedies are the ones that exist: a distribution kernel that
+still carries the stack (Debian 13's 6.12, Parrot 7.3's and Ubuntu 26.04's
+7.0), or the userspace packet path below. It never offers to build the module.
+
+## Which units this touches
+
+**Declare `requires_kernel: [ax25]`** — they configure or speak to the
+kernel stack and have no other mode:
+
+`ax25-tools`, `ax25-apps`, `ax25-xtools`, `ax25mail-utils`, `axmail`,
+`aprsdigi`, `fbb`, `linpac`, `uronode`, and `z8530-utils2` (whose `scc`
+driver left in the same merge; **Q-019** asks whether to retire it outright).
+
+**Unaffected, and their manifests say so** — the userspace packet path,
+which is most of what an operator actually runs:
+
+| Unit | Why it still works on 7.1 |
+|---|---|
+| `direwolf`, `qtsoundmodem` | userspace modems; their KISS and AGW TCP ports are what everything else talks to. Only `kissattach`-ing them to the kernel needs `ax25` |
+| `pat` | engines `agwpe` and `serial-tnc` (`ax25+agwpe://`, `ax25+serial-tnc://`) never open an `AF_AX25` socket. Engine `linux` (`ax25+linux://`) does and fails on 7.1. Read from `app/connect.go` and wl2k-go's `transport/ax25/ax25_linux.go` |
+| `linbpq` | carries its own AX.25 implementation; drives Direwolf over KISS or AGW |
+| `yaac` | KISS and AGW to Direwolf directly |
+| `xastir` | Serial KISS TNC and AGWPE interface types need no kernel stack; only the "AX.25 TNC" type (`DEVICE_AX25_TNC` in `src/interface.c`) opens `AF_AX25` |
+
+So on a 7.1 kernel `packet` still installs a working Direwolf–pat–APRS
+station. What it cannot give you is a kernel port: no `axports`, no
+`kissattach`, no `ax25d`, no `listen`, no NET/ROM. The profile page and
+**D-008**'s packet-core statement both said "kernel AX.25 stack"; **Q-019**
+asks whether that statement should now read userspace-primary.
+
+## Reproducing the measurement
+
+On any machine:
+
+```
+uname -r
+ls /lib/modules/$(uname -r)/kernel/net/ax25/ 2>&1
+python3 -c 'import socket; socket.socket(3, socket.SOCK_SEQPACKET)'
+hammunition install ax25-tools --dry-run
+```
+
+The last line is the engine's own answer. On a kernel without the module it
+exits 2 with the refusal; on one with it, it prints the plan (and, under
+`--dry-run`, executes nothing).

--- a/docs/reference/kernel-ax25.md
+++ b/docs/reference/kernel-ax25.md
@@ -155,13 +155,26 @@ harness stamps the engine commit and the guest's InRelease dates into each.
 | Debian 13, `6.12.107+deb13-amd64` | `ax25-tools` | **installed, confirmed** in 4 s |
 | Debian 13 | `linpac` | **installed, confirmed** in 2 s |
 
-The whole `packet` profile, `--dry-run` on the same Kali VM after the fix
-described in the engine table above: **eight members deferred** —
-`ax25-tools` on the archive reason it already had, `linpac`, `aprsdigi`,
-`ax25-apps`, `ax25-xtools`, `ax25mail-utils`, `axmail` and `uronode` on the
-kernel — and the rest planned: 23 apt packages and the four git builds
-(`ardopcf`, `linbpq`, `qtsoundmodem`, `qttermtcp`), exit 0. The two
-declaring units outside `packet`, `fbb` and `z8530-utils2`, were not run.
+The whole `packet` profile, installed for real on 2026-09-05 with engine
+commit 6b8c080 (the fix included), each VM restored to its clean snapshot
+first — `scripts/vm_campaign.py --reset-each <domain> --whole-profiles
+--units packet`, reports `kernel-ax25-kali-packet-whole-2026-09-05.md` and
+`kernel-ax25-debian13-packet-whole-2026-09-05.md`, each with an
+`.evidence.jsonl` beside it holding the guest's transaction log:
+
+| Machine | Result | Deferred by name | Confirmed by re-probe |
+|---|---|---|---|
+| Kali 2026.3, `7.1.5+kali-amd64` | exit 0, 39 s | **eight.** `ax25-tools` and `ax25-xtools` on the archive — *apt on Kali GNU/Linux Rolling has no candidate*; both build from the `ax25-tools` source package Debian removed from testing on 2026-09-01. `linpac`, `aprsdigi`, `ax25-apps`, `ax25mail-utils`, `axmail`, `uronode` on the kernel | 29 checks: 24 apt packages installed, `ardopcf`, `linbpq`, `qtsoundmodem` and `qttermtcp` executable under `/usr/local/bin`, `dialout` membership present |
+| Debian 13, `6.12.107+deb13-amd64` | exit 0, 61 s | none | 40 checks, the same four builds and every member above it, `ax25-tools 0.0.10-rc5+git20230513+d3e6d4f-3` and `linpac 0.28-3` included |
+
+Both runs also deferred `linbpq`'s `/etc/bpq32.cfg` for the station values
+the VM does not set (D-035); that is a config deferral, not a member one.
+The two declaring units outside `packet`, `fbb` and `z8530-utils2`, were
+not run.
+
+An earlier `--dry-run` of the same profile on Kali, before the fix, had
+`ax25-xtools` deferred on the kernel; that was the overwrite at work, and
+the fresh run shows the archive reason it keeps.
 
 What is **not** measured here: any of this on real packet hardware, and
 nothing on the maintainer's Parrot laptop yet — its 7.0.13 row above is the

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -21,6 +21,7 @@ A manifest is **strict**: an unknown field is an error, not ignored. That is del
 | `provides` | `list[str]` | no |  |
 | `conflicts_with_repo_package` | `list[str]` | no |  |
 | `after` | `list[str]` | no | Ordering, not dependency. |
+| `requires_kernel` | `list[Literal[ax25]]` | no | Kernel subsystems the software cannot work without, checked against the running kernel at plan time. A machine whose kernel lacks one defers the unit in a profile and refuses it by name. Linux 7.1 removed AX.25 (merge 64edfa65, 2026-04-24); `hammunition.kernel` reads the module tree. The vocabulary is what has been measured. |
 | `binaries` | `list[Binary]` | no |  |
 | `launchers` | `list[Launcher]` | no |  |
 | `service_endpoints` | `list[ServiceEndpoint]` | no |  |

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -34,6 +34,8 @@ or field use), not imagined. Where a fix is distribution-specific it says so.
   added to `dialout` at install, but group membership needs a fresh login.
 - **[A venv-installed program is "not found"](running.md#local-bin)** —
   `~/.local/bin` reaches PATH on next login; open a new shell.
+- **["Address family not supported by protocol" from a packet program](running.md#ax25)** —
+  Linux 7.1 removed kernel AX.25; the userspace path still works.
 - **[The FT8 waterfall is silent](../getting-started/first-contact.md#when-the-waterfall-is-silent)** —
   audio routing, covered in first contact.
 

--- a/docs/troubleshooting/running.md
+++ b/docs/troubleshooting/running.md
@@ -65,3 +65,42 @@ credentials, the things beyond the callsign/grid the engine already manages.
 The program's page under [`docs/packages/`](../packages/index.md) says which
 file and where; copy the shipped `*.example`, edit it, done. This is expected
 first-run setup, not a broken install.
+
+## <a name="ax25"></a>"Address family not supported by protocol" from a packet program
+
+```
+kissattach: Address family not supported by protocol
+OSError: [Errno 97] Address family not supported by protocol
+modprobe: FATAL: Module ax25 not found in directory /lib/modules/7.1.5-…
+```
+
+Your kernel has no AX.25 stack. **Linux 7.1 removed it** — `net/ax25`,
+NET/ROM, Rose and every `drivers/net/hamradio` driver, in one merge on
+2026-04-24 — so on a 7.1 or newer kernel there is no `ax25` module to load and
+nothing for `kissattach` to attach a TNC to. Check with:
+
+```
+uname -r
+ls /lib/modules/$(uname -r)/kernel/net/ax25/
+```
+
+A directory with `ax25.ko` (or `.ko.xz`, `.ko.zst`) in it means the kernel
+carries the stack and the module is merely not loaded yet — `sudo modprobe
+ax25`, or run `kissattach` as root, which autoloads it. No such directory
+means the kernel does not have it, and no package fixes that.
+
+What still works: the **userspace** packet path. Direwolf's KISS and AGW ports
+serve pat (`ax25+agwpe://`), LinBPQ, YAAC and Xastir's AGWPE interface with no
+kernel AX.25 at all. What does not: `axports`, `kissattach`, `ax25d`,
+`listen`, `mheard`, NET/ROM — everything in `ax25-tools` and `ax25-apps`, and
+the programs that sit on them (`linpac`, `uronode`, `fbb`, `aprsdigi`).
+
+Hammunition reads the running kernel at plan time and will refuse or defer
+those units by name on such a kernel, so the usual way to meet this is
+`hammunition install packet` on Kali (7.1.5) or a Pop!_OS machine on its
+current kernel — and the plan says which members it withheld and why. The
+measurements, and which units are affected, are in
+[`docs/reference/kernel-ax25.md`](../reference/kernel-ax25.md). If you need a
+kernel port, boot a kernel that still carries the stack: Debian 13's 6.12,
+Parrot 7.3's 7.0, Ubuntu 26.04's 7.0. Hammunition does not build kernel
+modules.

--- a/scripts/gen_package_reference.py
+++ b/scripts/gen_package_reference.py
@@ -128,6 +128,13 @@ def page(m: PackageManifest) -> str:
         out.append("- **Needs first:** " + ", ".join(f"`{p}`" for p in m.depends))
     if m.after:
         out.append("- **Install after:** " + ", ".join(f"`{p}`" for p in m.after))
+    if m.requires_kernel:
+        out.append(
+            "- **Needs from the kernel:** "
+            + ", ".join(f"`{f}`" for f in m.requires_kernel)
+            + " — checked against the running kernel at plan time; "
+            "see [kernel-ax25](../reference/kernel-ax25.md)"
+        )
     if m.supersedes:
         out.append("- **Supersedes:** " + ", ".join(f"`{p}`" for p in m.supersedes))
     if m.superseded_by:

--- a/src/hammunition/cli/main.py
+++ b/src/hammunition/cli/main.py
@@ -70,6 +70,7 @@ from hammunition.execute import (
     user_groups,
 )
 from hammunition.fetch import Fetcher
+from hammunition.kernel import KernelProbe
 from hammunition.manifest.hardware import DeviceClass, DeviceManifest
 from hammunition.manifest.load import CatalogError, load_catalog, load_profiles
 from hammunition.manifest.schema import (
@@ -699,6 +700,9 @@ def cmd_install(args: argparse.Namespace) -> int:
             refresh=args.refresh,
             station=station,
             repos=repos,
+            # The running kernel is a fact about this machine, not the target
+            # (one Pop!_OS 24.04 VM has AX.25 under 7.0.11 and not under 7.1.5).
+            kernel=KernelProbe.detect(),
         )
     except PlanError as exc:
         print(str(exc), file=sys.stderr)

--- a/src/hammunition/kernel.py
+++ b/src/hammunition/kernel.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""What the running kernel carries, read from ``/lib/modules/<release>``.
+
+Linux 7.1 removed the amateur-radio networking subsystem -- ``net/ax25``,
+``net/netrom``, ``net/rose`` and every driver in ``drivers/net/hamradio``
+(mkiss, 6pack, bpqether, baycom, scc, yam) -- in merge 64edfa65 of
+2026-04-24, and Debian dropped ``ax25-tools`` from testing on 2026-09-01
+when it stopped building against the headers that went with it (#1143282).
+A kernel is a fact about the machine, not the distribution: one Pop!_OS
+24.04 VM carries ``ax25.ko.zst`` in its 7.0.11 module tree and nothing in
+its 7.1.5 one (both measured 2026-09-04), so this is read at plan time and
+never written into the capability matrix.
+
+The check reads the module tree rather than ``lsmod`` or ``/proc/net/ax25``,
+which only say whether the module is *loaded*: on every kernel that carries
+it, ``ax25`` is a module that a root ``kissattach`` autoloads, and an
+unloaded module is not a missing one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Final
+
+# feature name (the manifest's `requires_kernel` vocabulary) -> the module's
+# path under /lib/modules/<release>/kernel/, without the compression suffix.
+# Only what has been measured is here; `KernelProbe.available` raises on
+# anything else, so a manifest cannot name a feature the probe cannot see.
+FEATURES: Final = MappingProxyType({"ax25": "kernel/net/ax25/ax25.ko"})
+
+# How the plan names each feature to the operator.
+DESCRIBE: Final = MappingProxyType({"ax25": "the kernel's AX.25 stack (module ax25)"})
+
+KERNEL_REMOVAL: Final = (
+    "Linux 7.1 removed net/ax25 and the hamradio drivers (merge 64edfa65, 2026-04-24)"
+)
+
+# What still works without the subsystem, and what does not. Direwolf speaks
+# KISS and AGW over TCP to pat (`ax25+agwpe`), linbpq, yaac and xastir with no
+# kernel AX.25 at all; only the kernel-interface tools (kissattach, axparms,
+# axlisten, the ax25-* daemons) have nothing to attach to.
+USERSPACE_PATH: Final = (
+    "the userspace packet path is unaffected -- Direwolf's KISS and AGW ports serve "
+    "pat (transport `ax25+agwpe`), linbpq, yaac and xastir without kernel AX.25"
+)
+
+# No distribution packages the out-of-tree module that was proposed when the
+# subsystem was removed, and Hammunition never builds a kernel module of its
+# own (a custom kernel is on the rejected list; D-024 carries only what a
+# distribution packages).
+NO_MODULE_BUILD: Final = (
+    "no distribution packages the out-of-tree module yet, and Hammunition never "
+    "builds a kernel module (D-024)"
+)
+
+
+@dataclass(frozen=True)
+class KernelProbe:
+    release: str
+    """``uname -r``; the directory under ``modules_root`` that is read."""
+
+    modules_root: Path = Path("/lib/modules")
+
+    @classmethod
+    def detect(cls) -> KernelProbe:
+        import os
+
+        return cls(release=os.uname().release)
+
+    def available(self, feature: str) -> bool | None:
+        """``True`` when the module is shipped or built in, ``False`` when the
+        kernel's module tree exists and lacks it, ``None`` when there is no
+        module tree for this release to read -- a container on the host's
+        kernel, typically -- which is not evidence either way."""
+        module = FEATURES[feature]
+        tree = self.modules_root / self.release
+        if not tree.is_dir():
+            return None
+        target = tree / module
+        if any(target.parent.glob(f"{target.name}*")):
+            return True
+        builtin = tree / "modules.builtin"
+        return builtin.is_file() and module in builtin.read_text().split()

--- a/src/hammunition/manifest/schema.py
+++ b/src/hammunition/manifest/schema.py
@@ -237,6 +237,12 @@ PinBasis = Literal["distribution_pin", "own_choice"]
     situation has changed.
 """
 
+# The `requires_kernel` vocabulary. One entry per subsystem the probe in
+# `hammunition.kernel` knows how to find; a name here without a module path
+# there is a test failure, so a manifest can never name a feature the plan
+# cannot check.
+KernelFeature = Literal["ax25"]
+
 
 class PinReview(Strict):
     """When a commit pin was last looked at, and by whom.  D-024.
@@ -907,6 +913,16 @@ class PackageManifest(Strict):
     provides: list[str] = Field(default_factory=list)
     conflicts_with_repo_package: list[str] = Field(default_factory=list)
     after: list[str] = Field(default_factory=list, description="Ordering, not dependency.")
+    requires_kernel: list[KernelFeature] = Field(
+        default_factory=list,
+        description=(
+            "Kernel subsystems the software cannot work without, checked against "
+            "the running kernel at plan time. A machine whose kernel lacks one "
+            "defers the unit in a profile and refuses it by name. Linux 7.1 "
+            "removed AX.25 (merge 64edfa65, 2026-04-24); `hammunition.kernel` "
+            "reads the module tree. The vocabulary is what has been measured."
+        ),
+    )
 
     binaries: list[Binary] = Field(default_factory=list)
     launchers: list[Launcher] = Field(default_factory=list)

--- a/src/hammunition/plan.py
+++ b/src/hammunition/plan.py
@@ -49,6 +49,13 @@ from hammunition.backends.apt import downgrades_refused
 from hammunition.backends.apt_repo import AptRepoBackend, RepoState
 from hammunition.backends.source import IMPLEMENTED_BUILD_SYSTEMS
 from hammunition.distro import Target
+from hammunition.kernel import (
+    DESCRIBE,
+    KERNEL_REMOVAL,
+    NO_MODULE_BUILD,
+    USERSPACE_PATH,
+    KernelProbe,
+)
 from hammunition.manifest.schema import (
     AptInstall,
     AptRepo,
@@ -839,6 +846,7 @@ def resolve(
     refresh: bool = False,
     station: Station | None = None,
     repos: AptRepoBackend | None = None,
+    kernel: KernelProbe | None = None,
 ) -> InstallPlan:
     """Build a complete plan, or raise :class:`PlanError` listing every blocker.
 
@@ -846,6 +854,10 @@ def resolve(
     transaction needs — the manifests' own apt packages and their ``depends``
     together. One probe means one answer about the machine's apt state rather
     than N answers taken at N different moments.
+
+    ``kernel`` is the running kernel's module tree, consulted only for units
+    that declare ``requires_kernel``; ``None`` means it was not read, which is
+    disclosed on those units rather than assumed either way.
     """
     blockers: list[Blocker] = []
     deferrals: list[Deferral] = []
@@ -1093,6 +1105,42 @@ def resolve(
                 blockers.append(outcome)
         else:
             notes.append(outcome)
+
+    # -- Kernel subsystems the unit cannot work without ---------------------
+    # A fact about the machine, not the target: one Pop!_OS 24.04 VM has
+    # AX.25 in its 7.0.11 module tree and not in its 7.1.5 one (2026-09-04).
+    # So it is read here, never written into the capability matrix, and a
+    # profile member whose kernel lacks it defers the way a target gap does.
+    for manifest, _, _, _ in resolved:
+        for feature in manifest.requires_kernel:
+            what = DESCRIBE[feature]
+            present = None if kernel is None else kernel.available(feature)
+            if present is True:
+                continue
+            if kernel is None or present is None:
+                which = f" {kernel.release}" if kernel is not None else ""
+                notes.append(
+                    f"{manifest.name} needs {what}, which cannot be checked on this "
+                    f"machine: no module tree for the running kernel{which} is readable."
+                )
+                continue
+            why = f"needs {what}, which kernel {kernel.release} does not carry -- {KERNEL_REMOVAL}"
+            if manifest.name in deferrable:
+                deferred[manifest.name] = _target_deferral(
+                    manifest.name, wanted, f"{manifest.name} {why}"
+                )
+            else:
+                blockers.append(
+                    Blocker(
+                        subject=manifest.name,
+                        reason=why,
+                        remedy=(
+                            f"a distribution kernel that still carries it (Debian 13's 6.12, "
+                            f"Parrot 7.3's and Ubuntu 26.04's 7.0 do); {USERSPACE_PATH}; "
+                            f"{NO_MODULE_BUILD}"
+                        ),
+                    )
+                )
 
     # -- Q-017: the deferred set closes over catalog dependencies -----------
     # pythonprop depends on voacapl; a target that lacks voacapl cannot have

--- a/src/hammunition/plan.py
+++ b/src/hammunition/plan.py
@@ -1112,6 +1112,11 @@ def resolve(
     # So it is read here, never written into the capability matrix, and a
     # profile member whose kernel lacks it defers the way a target gap does.
     for manifest, _, _, _ in resolved:
+        if manifest.name in deferred:
+            # Already withheld for a reason the target gave (Kali 2026.3 has
+            # no ax25-tools candidate AND no ax25 module). The first reason
+            # stands; the typed-name refusal shows every one.
+            continue
         for feature in manifest.requires_kernel:
             what = DESCRIBE[feature]
             present = None if kernel is None else kernel.available(feature)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -841,6 +841,26 @@ def test_install_dry_run_prints_the_plan_and_executes_nothing(
     assert "transaction log written to" in out
 
 
+def test_install_reads_the_running_kernel_and_refuses_ax25_tools_without_ax25(
+    monkeypatch: pytest.MonkeyPatch, capsys: Any, tmp_path: Path
+) -> None:
+    """The probe is wired in, end to end, against the shipped manifest: a 7.1
+    kernel with no ax25 module refuses `ax25-tools` by name and says why.
+    Measured on Kali 7.1.5 and Pop!_OS 7.1.5, 2026-09-04."""
+    from hammunition.kernel import KernelProbe
+
+    _mock_apt(monkeypatch, populated=True)
+    release = "7.1.5+kali-amd64"
+    (tmp_path / release / "kernel" / "net").mkdir(parents=True)
+    probe = KernelProbe(release=release, modules_root=tmp_path)
+    monkeypatch.setattr(KernelProbe, "detect", classmethod(lambda cls: probe))
+    rc = main(["--catalog", str(CATALOG), "install", "--dry-run", "ax25-tools"])
+    err = capsys.readouterr().err
+    assert rc == EXIT_UNPLANNABLE
+    assert "ax25-tools" in err and release in err and "AX.25" in err
+    assert "Nothing was changed" in err
+
+
 def test_install_refresh_on_empty_lists_is_plannable_through_main(
     monkeypatch: pytest.MonkeyPatch, capsys: Any
 ) -> None:

--- a/tests/test_docs_generated.py
+++ b/tests/test_docs_generated.py
@@ -66,6 +66,13 @@ def test_every_manifest_has_a_generated_page(rendered: dict[str, str]) -> None:
     assert not missing, f"no generated page for: {missing}"
 
 
+def test_a_kernel_requirement_is_rendered_on_the_page(rendered: dict[str, str]) -> None:
+    """`requires_kernel` is why a unit refuses on a 7.1 kernel; a reader must
+    see it without opening the manifest."""
+    assert "- **Needs from the kernel:** `ax25`" in rendered["ax25-tools.md"]
+    assert "Needs from the kernel" not in rendered["direwolf.md"]
+
+
 def test_regenerating_is_a_no_op(rendered: dict[str, str]) -> None:
     on_disk = {p.name: p.read_text() for p in PACKAGES.glob("*.md")}
     stale = sorted(set(on_disk) - set(rendered))

--- a/tests/test_kernel_features.py
+++ b/tests/test_kernel_features.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""A unit that needs a kernel subsystem says so, and the plan checks the
+running kernel for it.
+
+Linux 7.1 removed `net/ax25`, `net/netrom`, `net/rose` and every driver in
+`drivers/net/hamradio` (merge 64edfa65, 2026-04-24). Measured 2026-09-04:
+Kali rolling (7.1.5) and Pop!_OS 24.04 (7.1.5) have no `CONFIG_AX25` and no
+`ax25.ko`; `socket(AF_AX25)` fails with "Address family not supported by
+protocol". Debian 13 (6.12), Parrot 7.3 (7.0.13), Ubuntu 24.04 (6.8) and
+26.04 (7.0.0) carry it as a module. The overnight campaign had filed
+`packet` as installing whole on Pop!_OS -- every package arrived, and
+`kissattach` could never have worked. The kernel is a fact about the
+*machine*, not the distribution (the same Pop!_OS VM has `ax25.ko.zst`
+under its 7.0.11 kernel), so it is read at plan time, never from the
+capability matrix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from hammunition.kernel import KernelProbe
+from hammunition.plan import PlanError
+from test_plan import _apt, _manifest, _profile, _resolve
+
+
+def _modules(tmp_path: Path, release: str, *, module: bool, builtin: bool) -> Path:
+    root = tmp_path / "lib" / "modules"
+    tree = root / release
+    tree.mkdir(parents=True)
+    if module:
+        ko = tree / "kernel" / "net" / "ax25" / "ax25.ko.xz"
+        ko.parent.mkdir(parents=True)
+        ko.write_bytes(b"")
+    (tree / "modules.builtin").write_text("kernel/net/ax25/ax25.ko\n" if builtin else "")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# The probe reads /lib/modules/<release>, never the loaded-module list
+# ---------------------------------------------------------------------------
+
+
+def test_the_probe_finds_ax25_as_a_module(tmp_path: Path) -> None:
+    root = _modules(tmp_path, "6.12.107+deb13-amd64", module=True, builtin=False)
+    probe = KernelProbe(release="6.12.107+deb13-amd64", modules_root=root)
+    assert probe.available("ax25") is True
+
+
+def test_the_probe_finds_ax25_built_in(tmp_path: Path) -> None:
+    """A kernel with CONFIG_AX25=y ships no .ko; modules.builtin names it."""
+    root = _modules(tmp_path, "6.8.0-custom", module=False, builtin=True)
+    assert KernelProbe(release="6.8.0-custom", modules_root=root).available("ax25") is True
+
+
+def test_a_7_1_kernel_has_no_ax25_and_the_probe_says_so(tmp_path: Path) -> None:
+    root = _modules(tmp_path, "7.1.5+kali-amd64", module=False, builtin=False)
+    assert KernelProbe(release="7.1.5+kali-amd64", modules_root=root).available("ax25") is False
+
+
+def test_no_modules_tree_for_the_running_kernel_is_unknown_not_absent(tmp_path: Path) -> None:
+    """A container runs on the host's kernel with no /lib/modules for it. That
+    is not evidence either way, and the CI targets must not refuse packet
+    units over it."""
+    root = tmp_path / "lib" / "modules"
+    root.mkdir(parents=True)
+    assert KernelProbe(release="6.1.0-host", modules_root=root).available("ax25") is None
+
+
+def test_the_probe_only_knows_measured_features(tmp_path: Path) -> None:
+    root = _modules(tmp_path, "r", module=True, builtin=False)
+    with pytest.raises(KeyError, match="netrom"):
+        KernelProbe(release="r", modules_root=root).available("netrom")
+
+
+# ---------------------------------------------------------------------------
+# The manifest field
+# ---------------------------------------------------------------------------
+
+
+def test_the_schema_vocabulary_is_exactly_what_the_probe_can_see() -> None:
+    """A name the schema accepts that the probe has no module path for would
+    raise KeyError at plan time, on the operator's machine."""
+    from typing import get_args
+
+    from hammunition.kernel import DESCRIBE, FEATURES
+    from hammunition.manifest.schema import KernelFeature
+
+    assert set(get_args(KernelFeature)) == set(FEATURES) == set(DESCRIBE)
+
+
+def test_requires_kernel_takes_only_measured_feature_names() -> None:
+    assert _manifest(requires_kernel=["ax25"]).requires_kernel == ["ax25"]
+    with pytest.raises(ValidationError, match="ax25"):
+        _manifest(requires_kernel=["scc"])
+
+
+# ---------------------------------------------------------------------------
+# The plan
+# ---------------------------------------------------------------------------
+
+
+def _probe(answer: bool | None) -> KernelProbe:
+    class Fixed(KernelProbe):
+        def available(self, feature: str) -> bool | None:
+            assert feature == "ax25"
+            return answer
+
+    return Fixed(release="7.1.5+kali-amd64", modules_root=Path("/nonexistent"))
+
+
+def _catalog(*units: Any) -> dict[str, Any]:
+    return {u.name: u for u in units}
+
+
+def _unit(name: str, **overrides: Any) -> Any:
+    return _manifest(
+        name=name, install=[{"install": {"method": "apt", "packages": [name]}}], **overrides
+    )
+
+
+def test_a_unit_needing_ax25_is_refused_by_name_on_a_kernel_without_it(tmp_path: Path) -> None:
+    catalog = _catalog(_unit("ax25-tools", requires_kernel=["ax25"]))
+    with pytest.raises(PlanError) as excinfo:
+        _resolve(
+            tmp_path,
+            ["ax25-tools"],
+            catalog=catalog,
+            known={"ax25-tools": None},
+            kernel=_probe(False),
+        )
+    text = str(excinfo.value)
+    assert "ax25-tools" in text
+    assert "7.1.5+kali-amd64" in text
+    assert "AX.25" in text and "64edfa65" in text
+    # The remedies name what actually works, not a module we would build.
+    assert "userspace" in text.lower() or "user-space" in text.lower()
+    assert "dkms" not in text.lower() or "no distribution packages" in text.lower()
+
+
+def test_a_profile_member_needing_ax25_is_deferred_and_the_rest_installs(tmp_path: Path) -> None:
+    """The D-039 shape: the kernel is true of the machine, so a member defers."""
+    catalog = _catalog(_unit("direwolf"), _unit("ax25-tools", requires_kernel=["ax25"]))
+    profile = _profile(name="packet", packages=["direwolf", "ax25-tools"])
+    plan = _resolve(
+        tmp_path,
+        ["packet"],
+        catalog=catalog,
+        profiles={"packet": profile},
+        known={"direwolf": None, "ax25-tools": None},
+        kernel=_probe(False),
+    )
+    assert plan.apt_to_install == ("direwolf",)
+    (deferral,) = [d for d in plan.deferrals if d.kind == "package"]
+    assert deferral.subject == "ax25-tools"
+    assert "7.1.5+kali-amd64" in deferral.why
+
+
+def test_a_kernel_that_carries_ax25_plans_the_unit_without_comment(tmp_path: Path) -> None:
+    catalog = _catalog(_unit("ax25-tools", requires_kernel=["ax25"]))
+    plan = _resolve(
+        tmp_path,
+        ["ax25-tools"],
+        catalog=catalog,
+        known={"ax25-tools": None},
+        kernel=_probe(True),
+    )
+    assert plan.apt_to_install == ("ax25-tools",)
+    assert not any("ax25" in n.lower() for n in plan.notes)
+
+
+def test_an_unreadable_kernel_is_disclosed_as_unchecked_not_refused(tmp_path: Path) -> None:
+    catalog = _catalog(_unit("ax25-tools", requires_kernel=["ax25"]))
+    plan = _resolve(
+        tmp_path,
+        ["ax25-tools"],
+        catalog=catalog,
+        known={"ax25-tools": None},
+        kernel=_probe(None),
+    )
+    assert plan.apt_to_install == ("ax25-tools",)
+    (note,) = [n for n in plan.notes if "ax25-tools" in n]
+    assert "cannot be checked" in note
+
+
+def test_a_unit_without_the_field_never_consults_the_kernel(tmp_path: Path) -> None:
+    class Untouchable(KernelProbe):
+        def available(self, feature: str) -> bool | None:
+            raise AssertionError("consulted for a unit that declares nothing")
+
+    plan = _resolve(
+        tmp_path,
+        ["example"],
+        apt=_apt(tmp_path, {"example": None}),
+        kernel=Untouchable(release="x", modules_root=Path("/nonexistent")),
+    )
+    assert plan.apt_to_install == ("example",)

--- a/tests/test_kernel_features.py
+++ b/tests/test_kernel_features.py
@@ -162,6 +162,29 @@ def test_a_profile_member_needing_ax25_is_deferred_and_the_rest_installs(tmp_pat
     assert "7.1.5+kali-amd64" in deferral.why
 
 
+def test_a_member_already_deferred_by_the_archive_keeps_that_reason(tmp_path: Path) -> None:
+    """Kali 2026.3, live: `ax25-tools` is absent from the archive AND the
+    kernel lacks ax25. The first `packet` dry-run on the VM showed only the
+    kernel reason -- the kernel block had replaced the archive deferral --
+    and its remedy text ("a release that carries it needs no change here")
+    was then false of Kali's archive. A reason already recorded stands; the
+    typed-name refusal shows both."""
+    catalog = _catalog(_unit("direwolf"), _unit("ax25-tools", requires_kernel=["ax25"]))
+    profile = _profile(name="packet", packages=["direwolf", "ax25-tools"])
+    plan = _resolve(
+        tmp_path,
+        ["packet"],
+        catalog=catalog,
+        profiles={"packet": profile},
+        known={"direwolf": None},  # no candidate for ax25-tools
+        kernel=_probe(False),
+    )
+    (deferral,) = [d for d in plan.deferrals if d.kind == "package"]
+    assert deferral.subject == "ax25-tools"
+    assert "no candidate" in deferral.why
+    assert "7.1.5+kali-amd64" not in deferral.why
+
+
 def test_a_kernel_that_carries_ax25_plans_the_unit_without_comment(tmp_path: Path) -> None:
     catalog = _catalog(_unit("ax25-tools", requires_kernel=["ax25"]))
     plan = _resolve(

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -99,6 +99,7 @@ def _resolve(tmp_path: Path, names: list[str], **kwargs: Any) -> Any:
         target=kwargs.pop("target", TARGET),
         apt=kwargs.pop("apt", None) or _apt(tmp_path, known),
         user=kwargs.pop("user", "operator"),
+        kernel=kwargs.pop("kernel", None),
     )
 
 


### PR DESCRIPTION
## What this is

The Kali campaign reported `ax25-tools` missing from Kali's archive. The archive gap is the symptom; the cause is **Linux 7.1 removing `net/ax25`, `net/netrom`, `net/rose` and every `drivers/net/hamradio` driver** (merge `64edfa65`, 2026-04-24). Debian dropped `ax25-tools` from testing on 2026-09-01 (#1143282) because it no longer builds without `linux/hdlcdrv.h`; Kali inherits. The same removal reaches machines whose archives are untouched — the Pop!_OS 24.04 VM and the maintainer's own laptop are on 7.1 with no `ax25.ko`, and the overnight campaign's "packet installs whole on Pop!_OS" was true of packages and false of capability: `kissattach` could never have worked.

**D-041**: a manifest declares `requires_kernel: [ax25]`; the plan reads `/lib/modules/$(uname -r)/` and refuses the unit by name (typed) or defers it (profile member, D-039 shape). Never enters the capability matrix (a kernel is per machine, per reboot — the Pop!_OS VM has `ax25.ko.zst` under its 7.0.11 tree and nothing under 7.1.5). Never builds a module (custom kernel is on the rejected list; D-024). No module tree at all — a container on the host's kernel, i.e. the CI targets — is disclosed as "cannot be checked", not refused.

## Measured (2026-09-04, engine 383cf27, `scripts/vm_campaign.py`, clean snapshots)

| Machine | Unit | Outcome |
|---|---|---|
| Kali 2026.3, `7.1.5+kali-amd64` | `ax25-tools` | refused (plan): no apt candidate **and** the kernel blocker |
| Kali 2026.3 | `linpac` | refused (plan) on the kernel alone — it *is* in Kali's archive; the archive check would have let it through |
| Kali 2026.3 | `direwolf` | installed+confirmed, 5 s |
| Debian 13, `6.12.107` | `ax25-tools` | installed+confirmed, 4 s |
| Debian 13 | `linpac` | installed+confirmed, 2 s |

Whole `packet` profile dry-run on Kali: eight members deferred, 23 apt packages + four git builds still planned, exit 0. That live run found a defect the unit tests had not — a member the archive had already deferred got its reason *replaced* by the kernel's — fixed in the second commit, test written first.

Full evidence table (seven machines incl. the laptop, exact `modprobe` text, side-by-side module trees) in `docs/reference/kernel-ax25.md`.

## Ten manifests declare it; six say they are unaffected

`ax25-tools`, `ax25-apps`, `ax25-xtools`, `ax25mail-utils`, `axmail`, `aprsdigi`, `fbb`, `linpac`, `uronode`, `z8530-utils2`. The userspace path — `direwolf`, `qtsoundmodem`, `linbpq`, `yaac`, `xastir`, and `pat` with the `agwpe`/`serial-tnc` engines — is unaffected, and each manifest's `known_problems` says so, with the claim about `pat` and `xastir` read from their source (`app/connect.go`, wl2k-go `ax25_linux.go`, Xastir `src/interface.c`), not remembered (D-018).

## Open for the maintainer — Q-019

- Retire `z8530-utils2`? Its `scc` driver left in the same merge and the hardware predates PCI Express. Recommended: A (retire).
- Amend D-008's "kernel AX.25 stack" wording to userspace-primary? Recommended: A.

## Notes

- Both campaign reports show the doubled `**Target:** Target: …` label: this branch was cut from `main` before #26's `target_from_status` fix. Expected; resolves when #26 merges.
- Nothing here has run on the Parrot laptop; the Parrot 7.0.13 row is the VM's. Nothing is marked maintainer-verified.
- Not authorized for merge; left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
