### PR TITLE
catalog: the four remaining Kali archive gaps say why

### DIFF
--- a/catalog/packages/cwdaemon.yaml
+++ b/catalog/packages/cwdaemon.yaml
@@ -10,6 +10,13 @@ install:
   - install:
       method: apt
       packages: [cwdaemon]
+    note: >-
+      **Not on Kali.** Debian removed `cwdaemon` from testing on 2025-11-03
+      over RC bug #1039160 -- the package ships a sysv-init script and no
+      systemd unit -- and Kali inherits testing. Debian 13 stable keeps
+      0.10.2-3, as do Parrot, Ubuntu and Mint. Checked against the Debian
+      tracker and Kali's archive on 2026-09-04; this is a packaging bug, not
+      a dead upstream, and `tlf`'s keying still expects it.
 
 update:
   probe:

--- a/catalog/packages/dump1090-mutability.yaml
+++ b/catalog/packages/dump1090-mutability.yaml
@@ -20,7 +20,12 @@ install:
       1.15~20180310. No candidate on Debian 13, Kali or Parrot (measured
       2026-08-28). That is worth stating precisely because it inverts the usual
       advice: on the primary target the package everyone's ADS-B tutorial names
-      does not exist, and `readsb` is what does.
+      does not exist, and `readsb` is what does. The why, from the Debian
+      tracker (2026-09-04): removed from testing on 2024-08-10 over RC bug
+      #1039187 -- a sysv-init script with no systemd unit -- and it never
+      re-entered, so Debian 13 released without it and Kali and Parrot follow
+      testing. Ubuntu's line kept it. Nothing about that is going to change
+      for a fork whose upstream stopped in 2018.
 
 update:
   probe:

--- a/catalog/packages/fbb.yaml
+++ b/catalog/packages/fbb.yaml
@@ -19,6 +19,12 @@ install:
       it matters because `ax25mail-utils`, which this catalog carries and which
       exists to forward mail with an FBB system, is present on every target.
       On the primary target you get the client side of a BBS you cannot run.
+      The why, from the Debian tracker (2026-09-04): removed from testing on
+      2025-01-23 over RC bug #1091298, a build failure on armhf
+      (`satupdat.c:664`, an incompatible pointer type the current GCC
+      rejects), and unstable's 7.011-3 has not migrated since. Ubuntu's
+      archive carries the same 7.011-3 regardless. It is a packaging bug in
+      Debian's queue, not something this engine can route around.
 
 update:
   probe:

--- a/catalog/packages/soapysdr-module-osmosdr.yaml
+++ b/catalog/packages/soapysdr-module-osmosdr.yaml
@@ -30,8 +30,9 @@ documentation:
     OsmoSDR hardware and its driver library, which apt pulls in.
   known_problems: >-
     The hardware was never widely produced and the software around it is
-    maintained rather than developed. Debian builds this and
-    `soapysdr-module-rfspace` from the same `soapyosmo` source package, so they
-    share a version and a release cadence.
+    maintained rather than developed. Debian built this and
+    `soapysdr-module-rfspace` from the same `soapyosmo` source package until
+    0.2.5-9 (2025-10-21) disabled the RFSpace module; from then on this one
+    ships everywhere and the RFSpace one only where the older source remains.
   upstream_url: https://github.com/pothosware/SoapyOsmo/wiki
   upstream_support: The Pothosware project.

--- a/catalog/packages/soapysdr-module-rfspace.yaml
+++ b/catalog/packages/soapysdr-module-rfspace.yaml
@@ -10,6 +10,17 @@ install:
   - install:
       method: apt
       packages: [soapysdr-module-rfspace]
+    note: >-
+      **Not on Kali or Ubuntu 26.04.** Debian's `soapyosmo` 0.2.5-9
+      (2025-10-21) changelog: "Disable SoapyOsmo rfspace by default in favor
+      of SoapyNetSDR". Testing and the releases that follow it build only the
+      OsmoSDR and MiriSDR modules from that source; Debian 13 stable and
+      Parrot stay on 0.2.5-8, which still has this one. The replacement
+      Debian named, SoapyNetSDR, has no Debian package at all as of
+      2026-09-04 (Kali's archive lists 17 `soapysdr-module-*` packages and no
+      `netsdr`; the tracker has no source for it), so on a testing-based machine RFSpace hardware currently has
+      no SoapySDR path from the archive at all. Checked against the Debian
+      tracker, the 0.2.5-11 changelog and Kali's archive on 2026-09-04.
 
 update:
   probe:
@@ -32,8 +43,8 @@ documentation:
     discovery is by broadcast, so a router in between usually means the device
     is not found.
   known_problems: >-
-    Built from the same `soapyosmo` source as the OsmoSDR module, so the two
-    move together in Debian. The maintainer does not own this hardware and
+    Built from the same `soapyosmo` source as the OsmoSDR module until Debian
+    disabled it there in 0.2.5-9 -- see the install note. The maintainer does not own this hardware and
     nothing here is maintainer-verified (D-027); it is carried because other
     operators have it.
   upstream_url: https://github.com/pothosware/SoapyOsmo/wiki

--- a/docs/packages/cwdaemon.md
+++ b/docs/packages/cwdaemon.md
@@ -23,6 +23,7 @@ A keying interface on a real serial or parallel port and a transmitter to key. A
 ## How it installs
 
 - apt: `cwdaemon`
+  - **Not on Kali.** Debian removed `cwdaemon` from testing on 2025-11-03 over RC bug #1039160 -- the package ships a sysv-init script and no systemd unit -- and Kali inherits testing. Debian 13 stable keeps 0.10.2-3, as do Parrot, Ubuntu and Mint. Checked against the Debian tracker and Kali's archive on 2026-09-04; this is a packaging bug, not a dead upstream, and `tlf`'s keying still expects it.
 
 ## Known problems
 

--- a/docs/packages/dump1090-mutability.md
+++ b/docs/packages/dump1090-mutability.md
@@ -25,7 +25,7 @@ An RTL-SDR that reaches 1090 MHz and an antenna for that band. It wants exclusiv
 ## How it installs
 
 - apt: `dump1090-mutability`
-  - **Only Ubuntu 26.04 and Linux Mint 22.3 carry this**, both at 1.15~20180310. No candidate on Debian 13, Kali or Parrot (measured 2026-08-28). That is worth stating precisely because it inverts the usual advice: on the primary target the package everyone's ADS-B tutorial names does not exist, and `readsb` is what does.
+  - **Only Ubuntu 26.04 and Linux Mint 22.3 carry this**, both at 1.15~20180310. No candidate on Debian 13, Kali or Parrot (measured 2026-08-28). That is worth stating precisely because it inverts the usual advice: on the primary target the package everyone's ADS-B tutorial names does not exist, and `readsb` is what does. The why, from the Debian tracker (2026-09-04): removed from testing on 2024-08-10 over RC bug #1039187 -- a sysv-init script with no systemd unit -- and it never re-entered, so Debian 13 released without it and Kali and Parrot follow testing. Ubuntu's line kept it. Nothing about that is going to change for a fork whose upstream stopped in 2018.
 
 ## Known problems
 

--- a/docs/packages/fbb.md
+++ b/docs/packages/fbb.md
@@ -24,7 +24,7 @@ A configured AX.25 stack and a callsign for the BBS. Forwarding partners, which 
 ## How it installs
 
 - apt: `fbb`
-  - **Only Ubuntu 26.04 and Linux Mint 22.3 carry this**, both at 7.011-3. No candidate on Debian 13, Kali or Parrot (measured 2026-08-28). The direction is unusual -- Debian's line lacks something Ubuntu's has -- and it matters because `ax25mail-utils`, which this catalog carries and which exists to forward mail with an FBB system, is present on every target. On the primary target you get the client side of a BBS you cannot run.
+  - **Only Ubuntu 26.04 and Linux Mint 22.3 carry this**, both at 7.011-3. No candidate on Debian 13, Kali or Parrot (measured 2026-08-28). The direction is unusual -- Debian's line lacks something Ubuntu's has -- and it matters because `ax25mail-utils`, which this catalog carries and which exists to forward mail with an FBB system, is present on every target. On the primary target you get the client side of a BBS you cannot run. The why, from the Debian tracker (2026-09-04): removed from testing on 2025-01-23 over RC bug #1091298, a build failure on armhf (`satupdat.c:664`, an incompatible pointer type the current GCC rejects), and unstable's 7.011-3 has not migrated since. Ubuntu's archive carries the same 7.011-3 regardless. It is a packaging bug in Debian's queue, not something this engine can route around.
 
 ## Known problems
 

--- a/docs/packages/soapysdr-module-osmosdr.md
+++ b/docs/packages/soapysdr-module-osmosdr.md
@@ -26,7 +26,7 @@ OsmoSDR hardware and its driver library, which apt pulls in.
 
 ## Known problems
 
-The hardware was never widely produced and the software around it is maintained rather than developed. Debian builds this and `soapysdr-module-rfspace` from the same `soapyosmo` source package, so they share a version and a release cadence.
+The hardware was never widely produced and the software around it is maintained rather than developed. Debian built this and `soapysdr-module-rfspace` from the same `soapyosmo` source package until 0.2.5-9 (2025-10-21) disabled the RFSpace module; from then on this one ships everywhere and the RFSpace one only where the older source remains.
 
 ## Keeping it current
 

--- a/docs/packages/soapysdr-module-rfspace.md
+++ b/docs/packages/soapysdr-module-rfspace.md
@@ -23,10 +23,11 @@ RFSpace hardware. Networked models must be reachable on the network, and discove
 ## How it installs
 
 - apt: `soapysdr-module-rfspace`
+  - **Not on Kali or Ubuntu 26.04.** Debian's `soapyosmo` 0.2.5-9 (2025-10-21) changelog: "Disable SoapyOsmo rfspace by default in favor of SoapyNetSDR". Testing and the releases that follow it build only the OsmoSDR and MiriSDR modules from that source; Debian 13 stable and Parrot stay on 0.2.5-8, which still has this one. The replacement Debian named, SoapyNetSDR, has no Debian package at all as of 2026-09-04 (Kali's archive lists 17 `soapysdr-module-*` packages and no `netsdr`; the tracker has no source for it), so on a testing-based machine RFSpace hardware currently has no SoapySDR path from the archive at all. Checked against the Debian tracker, the 0.2.5-11 changelog and Kali's archive on 2026-09-04.
 
 ## Known problems
 
-Built from the same `soapyosmo` source as the OsmoSDR module, so the two move together in Debian. The maintainer does not own this hardware and nothing here is maintainer-verified (D-027); it is carried because other operators have it.
+Built from the same `soapyosmo` source as the OsmoSDR module until Debian disabled it there in 0.2.5-9 -- see the install note. The maintainer does not own this hardware and nothing here is maintainer-verified (D-027); it is carried because other operators have it.
 
 ## Keeping it current
 


### PR DESCRIPTION
Closes the "remaining Kali gaps to characterize" item from the overnight campaign. Documentation only — the plan already defers or refuses an absent candidate; nothing in the engine changes.

| Unit | Missing on | Why (Debian tracker, checked 2026-09-04) |
|---|---|---|
| `cwdaemon` | Kali | removed from testing 2025-11-03, RC #1039160 (sysv-init script, no systemd unit); stable keeps 0.10.2-3 |
| `dump1090-mutability` | Debian 13, Kali, Parrot | removed from testing 2024-08-10, RC #1039187 (same bug); never re-entered |
| `fbb` | Debian 13, Kali, Parrot | removed from testing 2025-01-23, RC #1091298 (FTBFS on armhf); 7.011-3 stuck in unstable |
| `soapysdr-module-rfspace` | Kali, Ubuntu 26.04 | `soapyosmo` 0.2.5-9 (2025-10-21): "Disable SoapyOsmo rfspace by default in favor of SoapyNetSDR" — and SoapyNetSDR has no Debian package (tracker 404; Kali lists 17 `soapysdr-module-*`, no `netsdr`) |

The tracker agrees with the measured capability matrix on every row. The osmosdr manifest's "the two move together in Debian" was true until 0.2.5-9 and is corrected.

Not authorized for merge; left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)