### PR TITLE
Campaign report names every member a whole-profile plan deferred

### DIFF
--- a/docs/contributing/vm-testing.md
+++ b/docs/contributing/vm-testing.md
@@ -332,6 +332,18 @@ now carries the evidence rather than the verdict alone:
   the isolated re-runs. Rewritten with the report after every unit, so a
   campaign that dies keeps what it measured, and the markdown can be
   reconstructed from it.
+- **Deferred by name** — a `--whole-profiles` row whose plan withheld
+  members (D-039, D-041) says so in its outcome cell (`installed+confirmed
+  — 8 members deferred, 1 config file deferred`), the summary counts the
+  members, and a section lists each with the plan's reason, read from
+  `transaction_begin`'s `deferred` list. Added after `packet` on Kali filed
+  as `installed+confirmed` in 39 s with its eight AX.25 members in the
+  sidecar and nowhere in the table (2026-09-05) — the "installed whole on
+  Pop!_OS" reading D-041 exists to prevent, produced by the harness itself.
+- **Target from the log** — the header's `Target:` prefers the os-release
+  reading the engine logged on the guest in `transaction_begin` over the
+  separate `status` probe, which returned nothing for that same Kali run.
+  The unknown placeholder is only for a pass that logged nothing either.
 
 `tests/test_vm_campaign.py` holds one test per claim above, each first run
 against a report that lacked the field to watch it fail.

--- a/docs/contributing/vm-testing.md
+++ b/docs/contributing/vm-testing.md
@@ -328,10 +328,17 @@ now carries the evidence rather than the verdict alone:
   `--reset-each` passes label nothing: no unit sees another's state.
 - **`<out>.evidence.jsonl`** — the machine-readable record beside the
   markdown: the provenance, then one line per unit with exit code, tail,
-  every transaction-log entry it appended and every package it added, then
-  the isolated re-runs. Rewritten with the report after every unit, so a
-  campaign that dies keeps what it measured, and the markdown can be
-  reconstructed from it.
+  the UTC wall clock it started and finished at, every transaction-log
+  entry it appended and every package it added, then the isolated re-runs.
+  Rewritten with the report after every unit, so a campaign that dies
+  keeps what it measured, and the markdown can be reconstructed from it.
+  **That rewrite is also a trap:** the report file exists from the first
+  unit on, so anything that waits for it to appear before starting a second
+  campaign on the same VM starts immediately. On 2026-09-05 a chained run
+  did exactly that and reverted the Parrot snapshot under the sweep's
+  `propagation`, which filed `exit 255`; the rows carried no clock, so
+  whether `rfid` overlapped too was undecidable, and both were re-run.
+  Wait on the harness **process**, and one VM runs one campaign at a time.
 - **Deferred by name** — a `--whole-profiles` row whose plan withheld
   members (D-039, D-041) says so in its outcome cell (`installed+confirmed
   — 8 members deferred, 1 config file deferred`), the summary counts the

--- a/scripts/vm_campaign.py
+++ b/scripts/vm_campaign.py
@@ -63,7 +63,7 @@ import sys
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -143,6 +143,20 @@ class UnitResult:
     """What dpkg holds after this unit that it did not hold before --
     dependencies included, which the transaction log never names. `jtdx`
     brings `wsjtx-data`; only this delta knows."""
+    started_at: str | None = None
+    """UTC wall clock the ssh session began, ISO 8601 to the second. A row
+    that cannot be placed in time cannot be correlated with anything else
+    that touched the machine: on 2026-09-05 a second campaign reverted the
+    Parrot snapshot under a running sweep, whose `propagation` row read
+    `exit 255` with nothing to say when. None for rows filed without one."""
+
+    @property
+    def finished_at(self) -> str | None:
+        """`started_at` plus the measured seconds; None without a start."""
+        if self.started_at is None:
+            return None
+        ended = datetime.fromisoformat(self.started_at) + timedelta(seconds=self.seconds)
+        return ended.isoformat(timespec="seconds")
 
     @property
     def outcome(self) -> str:
@@ -449,18 +463,27 @@ def run_unit(host: str, identity: str | None, unit: str, timeout: int) -> UnitRe
         argv += ["-i", identity]
     argv += [host, f"bash -c '{remote_command(unit, timeout)}'"]
     started = datetime.now(UTC)
+    started_at = started.isoformat(timespec="seconds")
     try:
         proc = subprocess.run(
             argv, capture_output=True, text=True, timeout=timeout + 120, check=False
         )
         raw = proc.stdout
     except subprocess.TimeoutExpired:
-        return UnitResult(unit, -1, timeout, f"ssh did not return {timeout + 120}s after start")
+        return UnitResult(
+            unit,
+            -1,
+            timeout,
+            f"ssh did not return {timeout + 120}s after start",
+            started_at=started_at,
+        )
     seconds = (datetime.now(UTC) - started).total_seconds()
-    return classify(unit, raw, seconds=seconds, timeout=timeout)
+    return classify(unit, raw, seconds=seconds, timeout=timeout, started_at=started_at)
 
 
-def classify(unit: str, raw: str, *, seconds: float, timeout: int) -> UnitResult:
+def classify(
+    unit: str, raw: str, *, seconds: float, timeout: int, started_at: str | None = None
+) -> UnitResult:
     """Turn the remote session's merged output into a filed result."""
     exit_code = 255
     tail_lines: list[str] = []
@@ -499,6 +522,7 @@ def classify(unit: str, raw: str, *, seconds: float, timeout: int) -> UnitResult
             f"stopped by the {timeout}s budget; the build was still running",
             kept,
             gained,
+            started_at=started_at,
         )
     # Keep what a reader needs. Stderr outruns block-buffered stdout through
     # a pipe, so a failure's text can land ANYWHERE in the merged stream —
@@ -508,7 +532,9 @@ def classify(unit: str, raw: str, *, seconds: float, timeout: int) -> UnitResult
     markers = ("Failed:", "problem block", "error:", "E: ")
     start = next((i for i, ln in enumerate(nonempty) if any(m in ln for m in markers)), None)
     keep = nonempty[start : start + 10] if start is not None else nonempty[-6:]
-    return UnitResult(unit, exit_code, seconds, "\n".join(keep), kept, gained)
+    return UnitResult(
+        unit, exit_code, seconds, "\n".join(keep), kept, gained, started_at=started_at
+    )
 
 
 def cumulative_refusals(results: list[UnitResult]) -> dict[str, dict[str, str]]:
@@ -698,6 +724,8 @@ def write_evidence(
             "exit_code": r.exit_code,
             "outcome": r.outcome,
             "seconds": r.seconds,
+            "started_at": r.started_at,
+            "finished_at": r.finished_at,
             "tail": r.tail,
             "entries": list(r.entries),
             "new_packages": list(r.new_packages),

--- a/scripts/vm_campaign.py
+++ b/scripts/vm_campaign.py
@@ -70,6 +70,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
+from hammunition.distro.detect import Target  # noqa: E402
 from hammunition.manifest.load import load_catalog, load_profiles  # noqa: E402
 
 SSH_BASE = [
@@ -102,6 +103,32 @@ def target_from_status(status_output: str) -> str:
     return first.removeprefix("Target:").strip() or TARGET_UNKNOWN
 
 
+def target_line(probed: str, results: list[UnitResult]) -> str:
+    """What the header names as the target.
+
+    The engine's own os-release reading, logged in ``transaction_begin`` by
+    the unit that ran on the guest, outranks the separate ``status`` probe:
+    the Kali ``packet`` report of 2026-09-05 read *status probe returned
+    nothing* while its evidence sidecar held the target all along. The
+    probe's answer stands when it gave one; the log fills the gap; the
+    unknown is only for a pass that logged nothing either.
+    """
+    if probed != TARGET_UNKNOWN:
+        return probed
+    for result in results:
+        for entry in result.entries:
+            logged = entry.get("target") if entry.get("event") == "transaction_begin" else None
+            if isinstance(logged, dict) and logged.get("distro"):
+                return Target(
+                    distro=str(logged["distro"]),
+                    version=str(logged.get("distro_version", "")),
+                    arch=str(logged.get("arch", "")),
+                    id_like=tuple(logged.get("id_like", ())),
+                    pretty_name=str(logged.get("pretty_name") or "") or None,
+                ).describe()
+    return TARGET_UNKNOWN
+
+
 @dataclass(frozen=True)
 class UnitResult:
     unit: str
@@ -130,6 +157,38 @@ class UnitResult:
             if entry.get("event") == "transaction_end"
             for check in entry.get("checks", ())
         )
+
+    @property
+    def deferrals(self) -> tuple[dict[str, Any], ...]:
+        """What the plan withheld by name, from `transaction_begin` (version
+        2, D-039/D-041): a member the target lacks, a config file the
+        station values do not fill (D-035)."""
+        return tuple(
+            deferral
+            for entry in self.entries
+            if entry.get("event") == "transaction_begin"
+            for deferral in entry.get("deferred", ())
+        )
+
+    @property
+    def deferred_members(self) -> tuple[dict[str, Any], ...]:
+        return tuple(d for d in self.deferrals if d.get("kind") == "package")
+
+    @property
+    def deferred_config(self) -> tuple[dict[str, Any], ...]:
+        return tuple(d for d in self.deferrals if d.get("kind") != "package")
+
+    @property
+    def outcome_with_deferrals(self) -> str:
+        """`installed+confirmed — 8 members deferred`: the Kali `packet` row
+        of 2026-09-05 said the first half only, with the eight in the log
+        beside it and nowhere in the table."""
+        parts = []
+        if members := len(self.deferred_members):
+            parts.append(f"{members} member{'s' if members != 1 else ''} deferred")
+        if config := len(self.deferred_config):
+            parts.append(f"{config} config file{'s' if config != 1 else ''} deferred")
+        return f"{self.outcome} — {', '.join(parts)}" if parts else self.outcome
 
     @property
     def evidence(self) -> str:
@@ -504,6 +563,15 @@ def render_report(
     gated = f", {len(declined)} stopped at a consent gate" if declined else ""
     caused = f" ({len(cumulative)} of them cumulative)" if cumulative else ""
     blind = f" ({len(unchecked)} by no effect check)" if unchecked else ""
+    withheld = [r for r in results if r.deferrals]
+    members = sum(len(r.deferred_members) for r in withheld)
+    config_files = sum(len(r.deferred_config) for r in withheld)
+    partial = f" ({members} members deferred)" if members else ""
+    counted = ", ".join(
+        f"{n} {noun_}{'s' if n != 1 else ''}"
+        for n, noun_ in ((members, "member"), (config_files, "config file"))
+        if n
+    )
     lines = [
         "# VM campaign report",
         "",
@@ -511,7 +579,8 @@ def render_report(
         *provenance.header_lines(),
         f"**Target:** {target_line}",
         f"**{noun}:** {len(results)} — "
-        f"{len(ok)} installed+confirmed{blind}, {len(refused)} refused at plan time{caused}, "
+        f"{len(ok)} installed+confirmed{blind}{partial}, "
+        f"{len(refused)} refused at plan time{caused}, "
         f"{len(failed)} failed{gated}{budget}",
         "",
         "Exit 0 is the engine's own bar: completed *and confirmed* by re-probe",
@@ -520,13 +589,15 @@ def render_report(
         "reporting, not a failure — its text names what is missing. A refusal",
         "marked *cumulative* names a package an earlier unit of this same pass",
         "installed; it is a fact about the pass, and the unit is re-run alone.",
+        "*Members deferred* on a confirmed row means the plan withheld those by",
+        "name (D-039, D-041) and installed the rest; the section below says which.",
         "",
         "| Name | Outcome | Confirmed by | Seconds |",
         "|---|---|---|---:|",
     ]
 
     def outcome_cell(r: UnitResult) -> str:
-        cell = r.outcome
+        cell = r.outcome_with_deferrals
         if r.unit in cumulative:
             named = ", ".join(
                 f"`{pkg}`, installed by `{unit}`" for pkg, unit in cumulative[r.unit].items()
@@ -570,6 +641,24 @@ def render_report(
                 "```",
                 "",
             ]
+    if withheld:
+        lines += [
+            "",
+            f"## Deferred by name ({counted})",
+            "",
+            "What the plan withheld and why, per unit, from the transaction log",
+            "each unit wrote on the guest. A member the target lacks is not a",
+            "failure and not coverage either: `packet` on a 7.1 kernel installs",
+            "its Direwolf, pat and APRS station and none of its AX.25 stack (D-041).",
+            "",
+        ]
+        for r in withheld:
+            lines += [f"### `{r.unit}`", ""]
+            for d in r.deferred_members:
+                lines.append(f"- `{d['subject']}` — {d['why']}")
+            for d in r.deferred_config:
+                lines.append(f"- `{d['subject']}` — {d['what']}: {d['why']}")
+            lines.append("")
     if unchecked:
         lines += [
             "",
@@ -709,7 +798,7 @@ def main() -> int:
 
     def report_so_far() -> str:
         return render_report(
-            target_line=target_probe,
+            target_line=target_line(target_probe, results),
             provenance=provenance,
             results=results,
             noun=noun,

--- a/tests/test_vm_campaign.py
+++ b/tests/test_vm_campaign.py
@@ -474,3 +474,39 @@ def test_remote_command_captures_only_the_lines_this_unit_appended(
     assert not any(e.get("stale") for e in result.entries)
     assert result.new_packages == ("wsjtx-data",)
     assert "__NEW_PACKAGES" not in result.tail and "wsjtx-data" not in result.tail
+
+
+def test_a_unit_record_says_when_it_ran_so_it_can_be_placed_beside_anything_else(
+    campaign: ModuleType, tmp_path: Path
+) -> None:
+    """Two campaigns touched the Parrot VM at once on 2026-09-05 -- a chained
+    run waited on the report file, which the harness rewrites after every
+    unit, and reverted the snapshot under the sweep's `propagation`. Its
+    row read `exit 255` and nothing in the record could say *when*, so the
+    overlap with `rfid` was undecidable and both were re-run. A row carries
+    the wall clock it started and finished at, UTC, or it cannot be placed
+    beside a libvirt event, a guest log or another campaign."""
+    yaac = campaign.classify(
+        "yaac",
+        "Done.\n__EXIT=0\n__LOG\n" + _begin("yaac") + "\n" + _end(_pkg("libjssc-java", "1")),
+        seconds=154.0,
+        timeout=3600,
+        started_at="2026-09-06T02:24:05+00:00",
+    )
+    assert yaac.started_at == "2026-09-06T02:24:05+00:00"
+    assert yaac.finished_at == "2026-09-06T02:26:39+00:00"
+
+    out = tmp_path / "campaign.md"
+    campaign.write_evidence(
+        campaign.evidence_path(out),
+        provenance=_provenance(campaign),
+        results=[yaac, campaign.UnitResult("gap", 2, 1.0, "no block")],
+    )
+    lines = [
+        json.loads(ln) for ln in (tmp_path / "campaign.evidence.jsonl").read_text().splitlines()
+    ]
+    assert lines[1]["started_at"] == "2026-09-06T02:24:05+00:00"
+    assert lines[1]["finished_at"] == "2026-09-06T02:26:39+00:00"
+    # A result filed without a clock (older code paths, hand-built rows) is
+    # honest about it rather than inventing one.
+    assert lines[2]["started_at"] is None and lines[2]["finished_at"] is None

--- a/tests/test_vm_campaign.py
+++ b/tests/test_vm_campaign.py
@@ -40,18 +40,32 @@ def campaign() -> ModuleType:
     return mod
 
 
-def _begin(*packages: str, apt: tuple[str, ...] = ()) -> str:
+def _begin(
+    *packages: str,
+    apt: tuple[str, ...] = (),
+    deferred: tuple[dict[str, str], ...] = (),
+    target: dict[str, object] | None = None,
+) -> str:
     return json.dumps(
         {
             "event": "transaction_begin",
             "version": 2,
             "timestamp": "2026-09-04T06:02:00+00:00",
-            "target": {"id": "parrot"},
+            "target": target if target is not None else {"id": "parrot"},
             "packages": list(packages),
             "apt_packages": list(apt),
-            "deferred": [],
+            "deferred": list(deferred),
         }
     )
+
+
+def _deferral(subject: str, why: str, *, kind: str = "package") -> dict[str, str]:
+    what = (
+        "will not be installed (profile packet)"
+        if kind == "package"
+        else "will not write /etc/bpq32.cfg"
+    )
+    return {"kind": kind, "subject": subject, "what": what, "why": why}
 
 
 def _end(*checks: dict[str, object], verified: bool = True) -> str:
@@ -311,6 +325,105 @@ def test_evidence_sidecar_is_the_complete_machine_readable_record(
     assert [e["event"] for e in lines[1]["entries"]] == ["transaction_begin", "transaction_end"]
     assert lines[2]["unit"] == "gap" and lines[2]["exit_code"] == 2
     assert lines[3]["record"] == "isolated" and lines[3]["unit"] == "gap"
+
+
+def test_a_whole_profile_row_names_every_member_the_plan_deferred(campaign: ModuleType) -> None:
+    """`packet` on Kali filed as `installed+confirmed` in 39 s with 29 checks
+    and not one word about the eight members the plan withheld (2026-09-05).
+    The deferrals were in the transaction log the harness itself captured --
+    `transaction_begin` version 2 -- and nowhere in the table. That is D-041's
+    "installed whole on Pop!_OS" again, on the tool that exists to prevent it.
+    The row says how many members, a section says which and why, and a
+    config-file deferral (D-035) is counted apart from a member one."""
+    kernel = (
+        "linpac needs the kernel's AX.25 stack (module ax25), which kernel "
+        "7.1.5+kali-amd64 does not carry"
+    )
+    packet = campaign.classify(
+        "packet",
+        "Done.\n__EXIT=0\n__LOG\n"
+        + _begin(
+            "direwolf",
+            "pat",
+            apt=("direwolf", "pat"),
+            deferred=(
+                _deferral("linbpq", "station values not set: callsign", kind="config"),
+                _deferral("ax25-tools", "apt on Kali GNU/Linux Rolling has no candidate"),
+                _deferral("linpac", kernel),
+            ),
+        )
+        + "\n"
+        + _end(_pkg("direwolf", "1.8.1+dfsg-2"), _pkg("pat", "1.0.0-2")),
+        seconds=39,
+        timeout=9,
+    )
+    assert [d["subject"] for d in packet.deferred_members] == ["ax25-tools", "linpac"]
+    assert [d["subject"] for d in packet.deferred_config] == ["linbpq"]
+
+    report = campaign.render_report(
+        target_line="T",
+        provenance=_provenance(campaign),
+        results=[packet],
+        noun="Profiles (whole, from clean-baseline)",
+    )
+    assert (
+        "| `packet` | installed+confirmed — 2 members deferred, 1 config file deferred |"
+        " 2 checks: package direwolf installed 1.8.1+dfsg-2; package pat installed 1.0.0-2"
+        " | 39 |"
+    ) in report
+    assert "1 installed+confirmed (2 members deferred)" in report
+    assert "## Deferred by name (2 members, 1 config file)" in report
+    section = report.split("## Deferred by name (2 members, 1 config file)")[1]
+    assert "`packet`" in section
+    assert "`ax25-tools` — apt on Kali GNU/Linux Rolling has no candidate" in section
+    assert f"`linpac` — {kernel}" in section
+    assert "`linbpq` — will not write /etc/bpq32.cfg: station values not set: callsign" in section
+
+    plain = campaign.classify(
+        "direwolf",
+        "Done.\n__EXIT=0\n__LOG\n" + _begin("direwolf") + "\n" + _end(_pkg("direwolf", "1")),
+        seconds=5,
+        timeout=9,
+    )
+    quiet = campaign.render_report(
+        target_line="T", provenance=_provenance(campaign), results=[plain]
+    )
+    assert "## Deferred by name" not in quiet and "members deferred)" not in quiet
+    assert (
+        "| `direwolf` | installed+confirmed | 1 check: package direwolf installed 1 | 5 |" in quiet
+    )
+
+
+def test_the_target_falls_back_to_what_the_engine_logged_on_the_guest(
+    campaign: ModuleType,
+) -> None:
+    """The Kali `packet` report of 2026-09-05 read `**Target:** (status probe
+    returned nothing; ...)` while its own evidence sidecar held the engine's
+    os-release reading in `transaction_begin.target`. The log is the stronger
+    source -- the engine that ran the unit read it, on the guest, at the time
+    -- so it wins over the separate probe, and the probe's unknown is only
+    for a pass that logged nothing. The line is formatted exactly as the
+    engine's `Target.describe()` prints it."""
+    logged: dict[str, object] = {
+        "distro": "kali",
+        "distro_version": "2026.3",
+        "arch": "x86_64",
+        "id_like": ["debian"],
+        "pretty_name": "Kali GNU/Linux Rolling",
+    }
+    packet = campaign.classify(
+        "packet",
+        "Done.\n__EXIT=0\n__LOG\n" + _begin("direwolf", target=logged) + "\n" + _end(),
+        seconds=1,
+        timeout=9,
+    )
+    refused = campaign.UnitResult("gap", 2, 1.0, "no block")
+    assert campaign.target_line(campaign.TARGET_UNKNOWN, [refused, packet]) == (
+        "Kali GNU/Linux Rolling (ID=kali, version=2026.3, arch=x86_64)"
+    )
+    assert campaign.target_line(campaign.TARGET_UNKNOWN, [refused]) == campaign.TARGET_UNKNOWN
+    # A probe that answered is not second-guessed by the log.
+    assert campaign.target_line("Probed", [packet]) == "Probed"
 
 
 def test_remote_command_captures_only_the_lines_this_unit_appended(


### PR DESCRIPTION
## What

`scripts/vm_campaign.py`: a `--whole-profiles` row whose plan withheld members now says so — `installed+confirmed — 8 members deferred, 1 config file deferred` — the summary counts them, and a **Deferred by name** section lists each with the plan's reason, read from `transaction_begin`'s `deferred` list. The header's **Target** falls back to the os-release the engine logged on the guest when the `status` probe returns nothing.

## Why

The two real `packet` campaigns of 2026-09-05 (Kali and Debian 13, each from its clean snapshot, engine 6b8c080, filed for PR #28): Kali's report read `packet | installed+confirmed | 29 checks` and said nothing about the eight AX.25 members the plan deferred — they were in the evidence sidecar the harness itself wrote, and nowhere in the table. That is D-041's "installed whole on Pop!_OS" reading, produced by the tool that exists to prevent it. The same report's Target line read *status probe returned nothing* while the sidecar held `Kali GNU/Linux Rolling (ID=kali, version=2026.3, arch=x86_64)`.

## Evidence

- Two new tests in `tests/test_vm_campaign.py`, each watched to fail on the unchanged script (`no attribute 'deferred_members'`, `no attribute 'target_line'`).
- Re-rendering both real 2026-09-05 sidecars with the new code: Kali shows all eight (`ax25-tools`, `ax25-xtools` on the archive; six on the kernel) plus `linbpq`'s config deferral and the Kali target line; Debian 13 shows only the config deferral.
- `docs/contributing/vm-testing.md` documents both fields.

Gates: ruff format/check, mypy --strict, full pytest, doc links — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also (4688505)

Every unit row in the evidence sidecar now carries `started_at`/`finished_at` (UTC, ISO 8601). Why: on 2026-09-05 a chained campaign waited on the report *file* — which the harness rewrites after every unit, so it already existed — and reverted the Parrot snapshot under the running sweep. Its `propagation` row read `exit 255`; with no clock on any row, whether `rfid` overlapped was undecidable and both were re-run. Test: `test_a_unit_record_says_when_it_ran_so_it_can_be_placed_beside_anything_else` (red first). `docs/contributing/vm-testing.md` names the trap: wait on the process, one VM one campaign.
