### PR TITLE
CLAUDE.md: the action-pin note described a checkout@v4 the workflows no longer carry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,8 +277,9 @@ head.
 - **Never pin an action from memory; resolve it.** Every pin in that project's
   first workflow was a real commit and two major versions stale, and one failed
   outright against the runner's newer CLI. `git ls-remote --tags` is the check.
-  Worth a look here too: this repository's `actions/checkout@v4` is three majors
-  behind current.
+  This repository's pins were resolved the same way (e5c8260): `checkout`,
+  `setup-python` and `setup-qemu-action` sit on their current majors as of
+  2026-09-05, and the check is worth re-running whenever a workflow is touched.
 
 ## Conventions
 


### PR DESCRIPTION
e5c8260 resolved every workflow pin to its current major; the CLAUDE.md sentence saying `actions/checkout@v4` was three majors behind survived it. Re-measured 2026-09-05 with `git ls-remote --tags`: checkout v7, setup-python v7, setup-qemu-action v4 — all as pinned. One-line doc fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)