### PR TITLE
scripts: GUI smoke lane reads stderr -- exit 0 with a fault is suspect, not clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,8 +345,12 @@ head.
   promised since day one. The WIP phase before it (2026-08-25 to 09-02)
   pushed directly to `main`; that ended when the whole catalog installed on
   five targets with zero failures and the maintainer said so. Small, logically
-  scoped PRs; CI's PR-only jobs (commit claims, pin reviews, udev citations)
-  run on every one. A PR is merged by the maintainer, never by the author of
+  scoped PRs; CI's PR-only job (commit claims) runs on every one. **Pin
+  reviews and udev rule citations are weekly, not per-PR** — the citation
+  check needs a ~264 MB archive sweep and the pin check needs the network —
+  so a PR that changes a hardware citation or a pin has not been checked
+  until `gh workflow run ci.yml --ref <branch>` says so; do that before
+  calling it green. A PR is merged by the maintainer, never by the author of
   the branch on their own say-so. `main` is tagged at releases; releases are
   annotated tags, and signed once a signing key is configured on the
   maintainer's machine (v0.7.0 is not — no key existed).

--- a/docs/contributing/vm-testing.md
+++ b/docs/contributing/vm-testing.md
@@ -212,6 +212,20 @@ unrecorded test result rots into an inherited verdict within weeks.
    gqrx, and whatever step 1 installed: launch, reach the main window, note
    any Wayland/X11 misbehaviour (AHRL's accumulated X11 guidance is a
    documentation obligation for us, not folklore).
+   `scripts/vm_gui_smoke.py` is the automated first pass: on the guest,
+   under `xvfb-run`, it starts every `.desktop` entry the catalog put there
+   and files each as **alive** (still running at the timeout), **exited
+   clean**, **suspect** (exit 0 *with* a fault line on stderr -- a
+   traceback, a JVM `Exception in thread`, the dynamic loader, Qt's
+   platform plugin, no display) or **failed** (non-zero). `suspect` exists
+   because yaac on a headless JRE raised `HeadlessException` and exited 0
+   (issue #31): by exit status alone that was clean. The lane was
+   falsified on Debian 13 (2026-09-05) by removing `default-jre` -- one
+   `suspect`, tail leading with the fault -- and restoring it -- `alive`.
+   A `failed` row is a finding to read, not a verdict: `radiosonde-auto-rx`
+   fails there by design until `station.cfg` exists, exactly as its
+   manifest says. "It launched" is still the weaker claim; the main window
+   is a human's call.
 6. **Hardware, on Parrot only at first.** USB-passthrough a real device
    (HackRF, Proxmark3, T-Deck), run detection, apply udev rules, replug,
    check group membership after re-login. This exercises the M4 code that

--- a/scripts/vm_gui_smoke.py
+++ b/scripts/vm_gui_smoke.py
@@ -15,9 +15,17 @@ Classification is by observed behaviour, not hope:
 
 - **alive** — still running when the timeout landed. A GUI came up (or is
   sitting in a first-run dialog, which counts: it launched).
-- **exited-clean** — exit 0 before the timeout. Some GUIs background
-  themselves and this is fine; some print ``--help`` and quit, which is
-  not. The report lists them for a human eye rather than guessing.
+- **exited-clean** — exit 0 before the timeout with nothing on stderr that
+  names a fault. Some GUIs background themselves and this is fine; some
+  print ``--help`` and quit, which is not. The report lists them for a
+  human eye rather than guessing.
+- **suspect** — exit 0 before the timeout *with* a fault line on stderr: a
+  traceback, a Java ``Caused by:``, the dynamic loader, Qt's platform
+  plugin, a segfault, no display. yaac on a headless JRE did exactly this
+  (issue #31): HeadlessException at the splash screen, then exit 0. By
+  exit status alone that was `exited-clean`; the verdict reads stderr too,
+  and the tail leads with the fault line rather than the last four frames.
+  Counts as red, like `failed`.
 - **failed** — non-zero exit, with the stderr tail that says why. This is
   the category the lane exists for: the missing shared library, the
   instant segfault, the Qt platform plugin that is not there.
@@ -128,8 +136,57 @@ def collect(only: list[str]) -> dict[str, list[tuple[str, str]]]:
     return todo
 
 
+# Lines that name a launch fault. Anchored to how the faults actually print,
+# not to the word "error": a Python traceback header, the JVM's `Exception in
+# thread "..."` line, a Java `Caused by:` or a bare `pkg.SomeException:` line,
+# the dynamic loader, Qt's platform plugin, a segfault, and the two ways X
+# reports no display. `ErrorDialog.class` and "INFO no errors" must not match
+# -- a lane that cries wolf gets ignored.
+FAULT = re.compile(
+    r"^(?:Traceback \(most recent call last\)"
+    r"|Exception in thread \""
+    r"|Caused by: "
+    r"|(?:[A-Za-z_][\w$]*\.)+[A-Z]\w*(?:Exception|Error)\b"
+    r"|[A-Z]\w*(?:Exception|Error): "
+    r"|.*error while loading shared libraries: "
+    r"|qt\.qpa\.plugin: "
+    r"|Segmentation fault"
+    r"|.*\bcannot open display\b"
+    r"|.*\bcould not connect to display\b"
+    r")"
+)
+
+
+def classify(rc: int, stderr: str) -> tuple[str, str]:
+    """('alive'|'exited-clean'|'suspect'|'failed', the tail worth reading).
+
+    The verdict reads the exit status *and* stderr. yaac on a headless JRE
+    raised java.awt.HeadlessException at the splash screen and exited 0
+    (issue #31): by exit status alone that is `exited-clean`, the same
+    bucket as a program that printed --help and left. With a fault line on
+    stderr it is `suspect`, and the tail leads with that line rather than
+    with whichever four stack frames happened to come last.
+    """
+    lines = stderr.strip().splitlines()
+    faults = [i for i, line in enumerate(lines) if FAULT.match(line)]
+    # A Java trace names the wrapper first and the real fault in its last
+    # `Caused by:` -- InvocationTargetException says nothing; the
+    # HeadlessException under it says everything. Lead with the innermost.
+    causes = [i for i in faults if lines[i].startswith("Caused by: ")]
+    first_fault = causes[-1] if causes else faults[0] if faults else None
+    if first_fault is None:
+        tail = "\n".join(lines[-4:])
+    else:
+        tail = "\n".join(lines[first_fault : first_fault + 4])
+    if rc == 124:
+        return "alive", tail
+    if rc == 0:
+        return ("suspect" if first_fault is not None else "exited-clean"), tail
+    return "failed", tail
+
+
 def smoke(cmd: str, timeout: int) -> tuple[str, int, str]:
-    """('alive'|'exited-clean'|'failed', rc, stderr tail)."""
+    """('alive'|'exited-clean'|'suspect'|'failed', rc, stderr tail)."""
     argv = [
         "timeout",
         "--signal=TERM",
@@ -143,12 +200,8 @@ def smoke(cmd: str, timeout: int) -> tuple[str, int, str]:
         *shlex.split(cmd),
     ]
     result = subprocess.run(argv, capture_output=True, text=True)
-    tail = "\n".join(result.stderr.strip().splitlines()[-4:])
-    if result.returncode == 124:
-        return "alive", 124, tail
-    if result.returncode == 0:
-        return "exited-clean", 0, tail
-    return "failed", result.returncode, tail
+    verdict, tail = classify(result.returncode, result.stderr)
+    return verdict, result.returncode, tail
 
 
 def main() -> int:
@@ -161,33 +214,39 @@ def main() -> int:
     total = sum(len(v) for v in todo.values())
     print(f"# GUI smoke — {total} desktop entr(ies) across {len(todo)} unit(s)\n")
 
-    counts = {"alive": 0, "exited-clean": 0, "failed": 0}
+    counts = {"alive": 0, "exited-clean": 0, "suspect": 0, "failed": 0}
     failures: list[str] = []
+    suspects: list[str] = []
     early: list[str] = []
     for unit, entries in todo.items():
         for entry, cmd in entries:
             verdict, rc, tail = smoke(cmd, args.timeout)
             counts[verdict] += 1
-            mark = {"alive": "✓", "exited-clean": "○", "failed": "✗"}[verdict]
+            mark = {"alive": "✓", "exited-clean": "○", "suspect": "?", "failed": "✗"}[verdict]
             # flush each line so a foreground run shows live progress rather
             # than one silent block at the end (the nohup wedge lesson).
             print(f"[{mark}] {unit}: {entry} — {verdict} (rc={rc})", flush=True)
             if verdict == "failed":
                 failures.append(f"### {unit} — {entry}\nrc={rc}\n```\n{tail}\n```")
+            elif verdict == "suspect":
+                suspects.append(f"### {unit} — {entry}\nrc=0\n```\n{tail}\n```")
             elif verdict == "exited-clean" and tail:
                 early.append(f"- {unit} / {entry}: {tail.splitlines()[-1][:120]}")
 
     print(
         f"\n**{counts['alive']} alive, {counts['exited-clean']} exited clean, "
-        f"{counts['failed']} failed** of {total}."
+        f"{counts['suspect']} suspect, {counts['failed']} failed** of {total}."
     )
     if failures:
         print("\n## Failures — read the tail, then decide\n")
         print("\n\n".join(failures))
+    if suspects:
+        print("\n## Exited 0 with a fault on stderr — read the tail, then decide\n")
+        print("\n\n".join(suspects))
     if early:
         print("\n## Exited clean before the timeout — worth a human eye\n")
         print("\n".join(early))
-    return 1 if counts["failed"] else 0
+    return 1 if counts["failed"] or counts["suspect"] else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""The GUI smoke lane's verdicts, against stderr recorded from a real failure.
+
+yaac with only default-jre-headless: the launcher raised
+java.awt.HeadlessException on the splash screen and then exited **0**
+(Debian 13 under Xvfb, 2026-09-05, issue #31). The lane's three verdicts
+filed that as `exited-clean`, the same bucket as a program that printed
+`--help` and left, and the four-line stderr tail it kept was stack frames
+-- the line that named the fault was thirty lines up. A verdict that reads
+the exit status and not the effect is the D-031 mistake again.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Verbatim shape of the recorded stderr, cut to the lines that matter: the
+# fault is a `Caused by:` line buried between two stack traces, and the last
+# four lines are frames from the event thread.
+YAAC_HEADLESS_STDERR = """\
+Sat Sep 05 22:00:45 EDT 2026: loading core GUI class....
+Sat Sep 05 22:00:45 EDT 2026: YAAC raising splash screen....
+java.lang.reflect.InvocationTargetException
+\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
+\tat org.ka2ddo.yaac.YAAC.main(YAAC.java:791)
+Caused by: java.awt.HeadlessException: \n\
+\tat java.desktop/java.awt.GraphicsEnvironment.checkHeadless(GraphicsEnvironment.java:164)
+\tat java.desktop/java.awt.Window.<init>(Window.java:553)
+\tat java.desktop/java.awt.Frame.<init>(Frame.java:428)
+\tat java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
+\tat java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
+\tat java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
+"""
+
+
+@pytest.fixture(scope="module")
+def smoke() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "vm_gui_smoke_under_test", REPO_ROOT / "scripts" / "vm_gui_smoke.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["vm_gui_smoke_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_exit_zero_with_an_exception_on_stderr_is_suspect_not_clean(smoke: ModuleType) -> None:
+    verdict, tail = smoke.classify(0, YAAC_HEADLESS_STDERR)
+    assert verdict == "suspect"
+    assert "java.awt.HeadlessException" in tail
+
+
+def test_the_tail_leads_with_the_line_that_names_the_fault(smoke: ModuleType) -> None:
+    _, tail = smoke.classify(0, YAAC_HEADLESS_STDERR)
+    assert tail.splitlines()[0].startswith("Caused by: java.awt.HeadlessException")
+
+
+def test_exit_zero_with_quiet_stderr_stays_exited_clean(smoke: ModuleType) -> None:
+    verdict, tail = smoke.classify(0, "gqrx: using PulseAudio backend\n")
+    assert verdict == "exited-clean"
+    assert tail == "gqrx: using PulseAudio backend"
+
+
+def test_the_timeout_is_alive_whatever_stderr_says(smoke: ModuleType) -> None:
+    # A live GUI that logged a caught exception on the way up is still a live
+    # GUI; the lane's claim is "it came up", and it did.
+    verdict, _ = smoke.classify(124, YAAC_HEADLESS_STDERR)
+    assert verdict == "alive"
+
+
+def test_non_zero_exit_is_failed_and_the_tail_names_the_fault(smoke: ModuleType) -> None:
+    stderr = (
+        "Traceback (most recent call last):\n"
+        '  File "/usr/local/share/hammunition/js8spotter/js8spotter.py", line 3, in <module>\n'
+        "    import tkinter\n"
+        "ModuleNotFoundError: No module named 'tkinter'\n"
+    )
+    verdict, tail = smoke.classify(1, stderr)
+    assert verdict == "failed"
+    assert tail.splitlines()[0] == "Traceback (most recent call last):"
+    assert "ModuleNotFoundError" in tail
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "error while loading shared libraries: libfftw3f.so.3: cannot open shared object file",
+        'qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.',
+        "Segmentation fault (core dumped)",
+        "Error: cannot open display: :99",
+        # The JVM's own uncaught-exception line. yaac's *second* headless run
+        # printed only this: with cached preferences the splash path that
+        # raised HeadlessException is skipped, and the lane's first live
+        # falsification on Debian 13 (2026-09-05) filed it exited-clean.
+        'Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: '
+        'Cannot invoke "org.ka2ddo.yaac.gui.FirstWindowInitIfc.initMenuBar()" '
+        'because "this.initialWindow" is null',
+    ],
+)
+def test_the_usual_launch_faults_are_recognised(smoke: ModuleType, line: str) -> None:
+    verdict, tail = smoke.classify(0, f"starting up\n{line}\nbye\n")
+    assert verdict == "suspect"
+    assert tail.splitlines()[0] == line
+
+
+def test_a_word_that_merely_contains_error_is_not_a_fault(smoke: ModuleType) -> None:
+    # "errors=replace", "ErrorDialog.class", a log level of INFO about errors:
+    # none of these is a fault line, and a lane that cried wolf on every
+    # mention of the word would be ignored inside a week.
+    verdict, _ = smoke.classify(0, "loaded ErrorDialog.class\nINFO no errors\n")
+    assert verdict == "exited-clean"


### PR DESCRIPTION
## What

`scripts/vm_gui_smoke.py` gains a fourth verdict, **suspect**: exit 0 before the timeout *with* a fault line on stderr. The tail it reports leads with the line that names the fault, not whichever four lines came last.

## Why

yaac with only `default-jre-headless` raised `java.awt.HeadlessException` at the splash screen and exited **0** (Debian 13 under Xvfb, #31). The lane filed that as `exited-clean` — the same bucket as a program that printed `--help` and left — and the four-line tail was event-thread frames; the fault line was thirty lines up. A verdict that reads the exit status and not the effect is the D-031 mistake again.

## Falsified live, and it needed to be

The first pattern set matched the recorded first-run stderr but **not the second run**: with cached preferences yaac skips the splash path, and the only fault line left is the JVM's own `Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException`. The deliberately broken yaac came back `exited-clean`. That line is now a fixture and a pattern.

Debian 13 guest, 2026-09-05, evidence in `~/.local/state/hammunition-campaigns/gui-smoke-suspect-debian13-2026-09-05.txt` on the host:

| state | verdict |
|---|---|
| `default-jre` removed (headless only) | `[?] yaac — suspect (rc=0)`, tail leads with the NPE, lane exits 1 |
| `default-jre` restored | `[✓] yaac — alive (rc=124)` |
| `mshv` | alive |
| `radiosonde-auto-rx` | **failed** — `CRITICAL:Config file station.cfg does not exist!` |

The `radiosonde-auto-rx` row is the lane doing its job on a documented precondition (its manifest's `prerequisites` says copy `station.cfg.example` first), not a catalog defect. Left as a finding; nothing changed there.

## Tests

`tests/test_gui_smoke.py` loads the script by path and drives `classify()` against the recorded stderr: suspect vs clean, tail leads with the innermost `Caused by:`, rc 124 is alive whatever stderr says, non-zero is failed, the usual launch faults are recognised, and `ErrorDialog.class` / `INFO no errors` do **not** match — a lane that cries wolf gets ignored. Every test was red before the code.

`docs/contributing/vm-testing.md` step 5 now names the lane and the four verdicts.
