### PR TITLE
smoke lane: own the deadline — timeout(1) bounds the child, not the pipe

### DIFF
--- a/docs/contributing/vm-testing.md
+++ b/docs/contributing/vm-testing.md
@@ -226,6 +226,24 @@ unrecorded test result rots into an inherited verdict within weeks.
    fails there by design until `station.cfg` exists, exactly as its
    manifest says. "It launched" is still the weaker claim; the main window
    is a human's call.
+   The lane owns its deadline. `timeout(1)` bounds the *child*; it does not
+   bound the pipe. On Parrot (2026-09-05) `timeout 12 xvfb-run … gpredict`
+   returned 124 as designed, gpredict was reparented to PID 1 still holding
+   the lane's stderr, and `subprocess.run(capture_output=True)` waited for
+   EOF for twenty-four hours until a TERM sent by hand killed it -- the run
+   then resumed at the next entry. Each entry now runs in its own session;
+   at `--timeout` plus a five-second grace the lane SIGKILLs the whole
+   session and reports what it had. A process that leaves the session
+   (`setsid`) is out of that reach: the lane says so in the tail and stops
+   waiting rather than trade the verdict for a hang. `tests/test_gui_smoke.py`
+   runs both cases against real orphans; the pre-fix call blocked on the
+   first one in eight seconds on the dev machine. The old lane hung a
+   second time the same night, on `satdump-ui`, which ignored the TERM
+   and needed a SIGKILL by hand -- which is why the lane's own kill is
+   SIGKILL and not TERM. The fixed lane then ran the same 52 entries on
+   the same Parrot VM unattended: 9.5 minutes, no hand kills, no orphans
+   left behind, and the same 45/2/0/5 verdicts the old lane had reached
+   in a day and two kills.
 6. **Hardware, on Parrot only at first.** USB-passthrough a real device
    (HackRF, Proxmark3, T-Deck), run detection, apply udev rules, replug,
    check group membership after re-login. This exercises the M4 code that

--- a/scripts/vm_gui_smoke.py
+++ b/scripts/vm_gui_smoke.py
@@ -53,8 +53,11 @@ Usage, on the VM, from the repo checkout:
 from __future__ import annotations
 
 import argparse
+import contextlib
+import os
 import re
 import shlex
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -185,6 +188,62 @@ def classify(rc: int, stderr: str) -> tuple[str, str]:
     return "failed", tail
 
 
+# Seconds the lane allows past timeout(1)'s own deadline for Xvfb to start,
+# TERM to land and the pipes to drain, before it kills the whole session.
+GRACE = 5
+
+
+def _text(partial: str | bytes | None) -> str:
+    if partial is None:
+        return ""
+    return partial if isinstance(partial, str) else partial.decode(errors="replace")
+
+
+def run_bounded(argv: list[str], deadline: float) -> tuple[int, str, str]:
+    """Run argv in its own session; (rc, stdout, stderr) within the deadline.
+
+    ``subprocess.run(capture_output=True)`` waits for EOF on the pipes, and
+    EOF comes only when every process holding them has gone -- not when the
+    child has. On Parrot (2026-09-05) ``timeout 12 xvfb-run … gpredict``
+    returned 124 as designed, gpredict was reparented to PID 1 still holding
+    stderr, and the lane sat on that pipe for twenty-four hours until a TERM
+    sent by hand killed it. The lane owns its deadline here: the command runs
+    as a new session, and when the deadline passes the whole session is
+    SIGKILLed, orphans included. A process that left the session (setsid)
+    is outside that reach; the lane reports it and stops waiting, rather
+    than trading a verdict for a hang.
+    """
+    proc = subprocess.Popen(
+        argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, start_new_session=True
+    )
+    try:
+        out, err = proc.communicate(timeout=deadline)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        try:
+            out, err = proc.communicate(timeout=GRACE)
+        except subprocess.TimeoutExpired as exc:
+            proc.kill()
+            assert proc.stdout is not None and proc.stderr is not None
+            proc.stdout.close()
+            proc.stderr.close()
+            proc.wait()
+            # communicate() hands back what it had read when it gave up --
+            # as bytes, even in text mode.
+            out = _text(exc.stdout)
+            err = _text(exc.stderr)
+            return (
+                proc.returncode,
+                out,
+                err + "\n<lane deadline passed: a process outside the session still holds"
+                " the pipe; the rest of its output is withheld>",
+            )
+        if proc.returncode == -signal.SIGKILL:
+            err += "\n<lane deadline passed: session killed by the lane>"
+    return proc.returncode, out, err
+
+
 def smoke(cmd: str, timeout: int) -> tuple[str, int, str]:
     """('alive'|'exited-clean'|'suspect'|'failed', rc, stderr tail)."""
     argv = [
@@ -199,9 +258,9 @@ def smoke(cmd: str, timeout: int) -> tuple[str, int, str]:
         "--",
         *shlex.split(cmd),
     ]
-    result = subprocess.run(argv, capture_output=True, text=True)
-    verdict, tail = classify(result.returncode, result.stderr)
-    return verdict, result.returncode, tail
+    rc, _, stderr = run_bounded(argv, deadline=timeout + GRACE)
+    verdict, tail = classify(rc, stderr)
+    return verdict, rc, tail
 
 
 def main() -> int:

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -14,8 +14,12 @@ the exit status and not the effect is the D-031 mistake again.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import os
+import signal
 import sys
+import time
 from pathlib import Path
 from types import ModuleType
 
@@ -119,3 +123,69 @@ def test_a_word_that_merely_contains_error_is_not_a_fault(smoke: ModuleType) -> 
     # mention of the word would be ignored inside a week.
     verdict, _ = smoke.classify(0, "loaded ErrorDialog.class\nINFO no errors\n")
     assert verdict == "exited-clean"
+
+
+# --- the lane's own deadline ------------------------------------------------
+#
+# Parrot, 2026-09-05/06: `timeout 12 xvfb-run … gpredict` TERM'd its child,
+# gpredict was reparented to PID 1 still holding the lane's stderr pipe, and
+# `subprocess.run(capture_output=True)` waited for EOF for twenty-four hours.
+# The lane has to own the deadline, not lend it to timeout(1).
+
+
+def _orphan_holding_the_pipe(prefix: str = "") -> list[str]:
+    # The child exits 0 at once; its background grandchild inherits our
+    # stderr pipe and keeps it open. `prefix` lets the grandchild leave the
+    # session first (setsid), which is the one case a group kill cannot reach.
+    return ["sh", "-c", f"{prefix} sleep 300 </dev/null >/dev/null & echo $! ; exit 0"]
+
+
+def _alive(pid: int) -> bool:
+    # A killed orphan is a zombie until PID 1 reaps it, and kill(pid, 0) still
+    # succeeds on a zombie; read the state rather than race the reaper.
+    try:
+        state = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
+    except OSError:
+        return False
+    return state != "Z"
+
+
+def test_a_grandchild_holding_the_pipe_does_not_stall_the_lane(smoke: ModuleType) -> None:
+    started = time.monotonic()
+    rc, out, _ = smoke.run_bounded(_orphan_holding_the_pipe(), deadline=2)
+    elapsed = time.monotonic() - started
+    orphan = int(out.strip())
+    try:
+        assert rc == 0
+        assert elapsed < 10, f"lane waited {elapsed:.0f}s on an orphan's pipe"
+        assert not _alive(orphan), "the orphan survived the lane's deadline"
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(orphan, signal.SIGKILL)
+
+
+def test_a_grandchild_that_left_the_session_is_reported_not_waited_for(
+    smoke: ModuleType,
+) -> None:
+    started = time.monotonic()
+    rc, out, err = smoke.run_bounded(_orphan_holding_the_pipe("setsid"), deadline=2)
+    elapsed = time.monotonic() - started
+    orphan = int(out.strip())
+    try:
+        assert rc == 0
+        assert elapsed < 15, f"lane waited {elapsed:.0f}s on an escaped orphan's pipe"
+        assert "still holds" in err, err
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(orphan, signal.SIGKILL)
+
+
+def test_a_command_that_finishes_returns_its_status_and_stderr(smoke: ModuleType) -> None:
+    rc, out, err = smoke.run_bounded(["sh", "-c", "echo hi; echo oops >&2; exit 3"], deadline=5)
+    assert (rc, out, err) == (3, "hi\n", "oops\n")
+
+
+def test_a_command_that_outlives_the_deadline_is_killed_and_says_so(smoke: ModuleType) -> None:
+    rc, _, err = smoke.run_bounded(["sleep", "300"], deadline=1)
+    assert rc == -signal.SIGKILL
+    assert "deadline" in err


### PR DESCRIPTION
## What was measured

The Parrot GUI smoke run from PR #37's lane hung twice on the night of 2026-09-05/06:

1. **gpredict.** `timeout 12 xvfb-run … gpredict` had exited 124 as designed and was a zombie under the lane; gpredict had been reparented to PID 1 still holding the lane's stderr pipe; `subprocess.run(capture_output=True)` was waiting for EOF. Twenty-four hours. A hand TERM to gpredict ended it and the lane resumed.
2. **satdump-ui**, same mechanism, after the resume. It ignored TERM and needed SIGKILL by hand.

`timeout(1)` bounds the child. It does not bound the pipe.

## The fix

`run_bounded` in `scripts/vm_gui_smoke.py`: each entry runs as its own session; at `--timeout` plus five seconds' grace the lane SIGKILLs the whole session (SIGKILL because satdump-ui ignored TERM) and reports what it had read. A process that leaves the session (`setsid`) is beyond that reach — the lane names it in the tail and stops waiting rather than trade a verdict for a hang.

## Falsified first

`tests/test_gui_smoke.py` runs four new tests against real orphans — a backgrounded `sleep` holding stderr, the same under `setsid`, a plain finish, a plain overrun. The pre-fix call blocked on the first fixture and was killed by an outer timeout after eight seconds on the dev machine; with the fix all four pass (15 in the file).

## Verified on the VM

The fixed lane ran the same 52 entries on the same Parrot VM unattended: **9.5 minutes, no hand kills, no orphans left behind** (`ps` on the guest afterward shows no gpredict/satdump/Xvfb/timeout survivors), and the identical **45 alive / 2 exited clean / 0 suspect / 5 failed** verdicts the old lane took a day and two kills to reach. Host evidence: `~/.local/state/hammunition-campaigns/gui-smoke-parrot-fixed-lane-2026-09-06.txt`.

The five failures are the old lane's and unchanged, for a human eye: `ais-catcher` web launcher (`cannot open display :99` — the launcher opens a browser), `nec2c` (prints usage: a CLI with a desktop entry), `pcsc-tools` gscriptor (no `pcscd` on the VM), `psk31lx` and `qrq` (curses programs, no terminal under Xvfb). None is a catalog defect on its face; each is a question of whether the entry belongs in a menu at all.

Documented under the GUI step of `docs/contributing/vm-testing.md`.

## Gates

ruff format/check, `mypy --strict`, pytest, doc links, commit-claims hook ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)