### PR TITLE
docs: post-1.0 tracks for trunked/DV listening and repeater/hotspot; Q-020

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -491,8 +491,11 @@ longer a design question in the abstract; a shipped manifest depends on it. See
 `DESIGN.md` §15.3 and the D-004 amendment.
 
 **Open questions awaiting the maintainer** are in `docs/QUESTIONS.md`.
-**Q-018** (refresh apt lists by default) and **Q-019** (retire `z8530-utils2`;
-is the packet core userspace-primary now that Linux 7.1 has no AX.25) are open.
+**Q-018** (refresh apt lists by default), **Q-019** (retire `z8530-utils2`;
+is the packet core userspace-primary now that Linux 7.1 has no AX.25) and
+**Q-020** (the two post-1.0 tracks — trunked/digital-voice listening and
+repeater/hotspot — their order, profile placement, the G4KLX pin source and
+ASL3 under D-040; `docs/SCOPE.md` stages 9 and 10) are open.
 **Q-001 through Q-016 are all resolved.** Q-006, Q-007 and Q-008 closed on
 2026-08-29: HamClock carries both clients defaulting to `openhamclock` with
 `ohb.works` as the backend; SuperSDR is carried under **D-033**; cellular

--- a/docs/QUESTIONS.md
+++ b/docs/QUESTIONS.md
@@ -982,3 +982,59 @@ has it?
 **Recommendation: A.** The amendment is a paragraph; the guide reorder is
 the real work and belongs to the getting-started packet page whenever it
 is written.
+
+## Q-020 🟢 — Trunking, digital voice and repeaters: the order of the two post-1.0 tracks, and three calls inside them
+
+**Raised 2026-09-07**, from the maintainer asking whether trunking, DMR and
+repeater setups are on the roadmap. They were not written anywhere; they are
+now, as stages 9 and 10 of `docs/SCOPE.md` ("Post-1.0 tracks"), with the
+archive measured: of seventeen names swept across all seven targets, only
+`dsdcc` and `svxlink-server` exist in any archive, and both are already
+carried. Nothing here is 1.0 work; 🟢 because the answer shapes post-1.0
+manifests, not a release.
+
+**1. Ordering.** Track A (trunked and digital-voice *listening*: OP25,
+Trunk Recorder, SDRTrunk, DSD-FME — receive-only) before Track B (repeater
+and hotspot: SvxLink config, AllStarLink ASL3, the G4KLX MMDVM suite)?
+
+| Option | For | Against |
+|---|---|---|
+| **A. Listening first** ⭐ | Four units on three backends 1.0 ships; profiles that already exist; no station-config dependency; no transmit, so no new disclosure prose beyond the D-021 half. Answers "does it do trunking" soonest. | Two of the four build against GNU Radio and inherit the Tier 3 pin-and-re-verify burden. |
+| B. Repeater first | The SvxLink half is apt everywhere and is the more *ham* of the two tracks. | Every sub-stack waits on something: station config (D-004) for SvxLink, a D-040 manifest for ASL3, a D-024 pin decision plus hardware for MMDVM. |
+| C. Interleave: SvxLink config alongside Track A | The cheapest piece of B rides on the station-config work whenever that lands. | Two tracks in flight at once; the packet core already owns the station-config schedule. |
+
+**Recommendation: A**, with C's SvxLink piece taken the day station config
+exists, because at that point it is one `config_files` block.
+
+**2. Profile placement for Track A.** `listening`, `rf-security`, or both?
+
+| Option | For | Against |
+|---|---|---|
+| **A. Decoders in `listening`; OP25 and Trunk Recorder in `rf-security`** ⭐ | Matches what each profile is *for*: an operator with one dongle who wants to hear the local P25 system lands in `listening`; whole-system recording of trunked networks is the SIGINT posture `rf-security` already frames. Flat tags with overlap (D-003) allow a unit in both where it fits both. | Trunk Recorder and SDRTrunk do the same job on different stacks; splitting them by profile splits an overlap `overlaps.md` should decide once. |
+| B. Everything in `listening` | One place. | Puts a whole-network recorder in the on-ramp profile for people who own no hardware yet. |
+| C. Everything in `rf-security` | Opt-in by construction. | Hides "hear the local DMR repeater" behind a profile most hams will not open. |
+
+**3. The D-024 pin source for the G4KLX suite.** MMDVMHost and its gateways
+are untagged and in no archive. D-024 says pin the commit a distribution
+already packages, and our own only when nothing does. Pi-Star (GPL-2.0,
+V4.3.7 2026-05-01) packages them — as a Pi image, not an archive.
+
+| Option | For | Against |
+|---|---|---|
+| **A. Pi-Star's binary set counts; pin the commits it ships** ⭐ | It is the review signal D-024 is after: a maintained project that chose those commits, built them, and shipped them to the largest installed base of hotspots. Its successor Pi-Star_OS is CI-built and PR-able (`prior-art.md`), so the choice is reviewable. | Reading commit hashes out of an image is a measurement to script, not a metadata field to cite; and the image tracks ARM builds where our x86 targets need their own. |
+| B. Our own pins, D-024's fallback | No dependence on an image. | Nothing reviews our choice but us — the situation D-024 exists to avoid. |
+| C. Defer the suite entirely; SvxLink and ASL3 only | No pin question. | Leaves DMR, D-STAR, YSF and P25 hotspots — the thing most people mean by "hotspot" — out of the track. |
+
+**4. ASL3 under D-040.** Confirm that AllStarLink's own apt repository is the
+D-040 case — the distribution offers nothing, so the archive is admitted
+with its key fingerprint pinned in the manifest, added only on the operator
+typing that fingerprint — and that this does not conflict with the
+landscape-survey line "never add a third-party APT archive." CLAUDE.md
+already reads that line through D-040; this is the second manifest after
+`code`/`codium` to rely on the reading, and the first with a transmit
+capability behind it.
+
+**Recommendation: yes**, and no consent gate beyond the fingerprint: a
+node on the amateur bands is licensed operation, and D-021 discloses
+coordination and unattended-station conditions rather than adjudicating
+them.

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -250,9 +250,140 @@ Ordered by coverage-per-effort, not by source.
 3. **73Linux packet core** — closes the Winlink gap
 4. **Skywave listening delta** — cheap, and an on-ramp for users without hardware
 5. **DragonOS Tier 1** — the 1.0 SIGINT profile
-6. **DragonOS Tier 2** — post-1.0
-7. **DragonOS Tier 3** — post-1.0, experimental, only where upstream is alive
+6. **EmComm Tools OS delta** — the software delta only, mostly apt (**D-042**)
+7. **DragonOS Tier 2** — post-1.0
+8. **DragonOS Tier 3** — post-1.0, experimental, only where upstream is alive
+9. **Trunked and digital-voice listening** — post-1.0, receive-only; see below
+10. **Repeater and hotspot** — post-1.0, transmit infrastructure; waits on
+    station config; see below
 
-**1.0 = stages 1 through 5.** That is already more coverage than any single
-existing project, and it is achievable. Stages 6 and 7 are where "one stop shop"
-becomes literally true, and they should not hold up a release.
+**1.0 = stages 1 through 6.** That is already more coverage than any single
+existing project, and it is achievable. Stages 7 through 10 are where "one stop
+shop" becomes literally true, and they should not hold up a release.
+
+---
+
+## Post-1.0 tracks — trunking, digital voice, repeaters
+
+Two tracks the six sources touch only at the edges, written down on
+2026-09-07 so that "does Hammunition do DMR, trunking, repeaters?" has an
+answer in the record rather than in a chat log. Neither is 1.0. Their ordering
+and the open calls in each are **Q-020**.
+
+**What the catalog already has**, so the tracks are measured against it and
+not against a blank page: DMR *radio programming* is covered by `qdmr` and
+`dmrconfig` (category `dmr`); DMR, D-STAR, P25 and NXDN *decoding* by `dsdcc`
+in the `listening` profile; the Blend's `digitalvoice` task is carried whole —
+`svxlink-server`, `svxreflector`, `remotetrx`, `svxlink-gpio`,
+`svxlink-calibration-tools` and the `qtel` EchoLink client — and the
+`digital-modes` profile deliberately includes only `qtel`, because a repeater
+controller "is operating infrastructure other people depend on, not a mode you
+work, and it wants a considered install." That considered install is track B.
+M17 is **D-007**, ours to build, and crosses both tracks.
+
+**Measured 2026-09-07**, `scripts/apt-policy-sweep.sh --all` over the seven
+targets of `containers/targets.yaml` (the arm64 row by
+`HAMMUNITION_FOREIGN_ARCH=arm64`, which asks the archive index rather than
+emulating), seventeen names: OP25, Trunk Recorder, SDRTrunk, DSD, DSD-FME,
+`dsdcc`, the seven G4KLX hotspot daemons (`mmdvmhost`, `dmrgateway`,
+`ysfgateway`, `p25gateway`, `nxdngateway`, `ircddbgateway`, `dstarrepeater`),
+`svxlink-server`, `asl3-asterisk`, `allstarlink` and `asterisk`. **Two of the
+seventeen exist in any archive, and both are already in the catalog:**
+
+| Target | `dsdcc` | `svxlink-server` | `asterisk` | The other fourteen |
+|---|---|---|---|---|
+| Debian 13, Parrot, Debian 13 arm64 | 1.9.3 | 24.02 | — | — |
+| Kali rolling | 1.9.6 | 26.05.1 | 22.10.1 | — |
+| Ubuntu 26.04 | 1.9.6 | 25.05.1 | 22.5.2 | — |
+| Ubuntu 24.04, Linux Mint 22.3 | 1.9.3 | 19.09.2 | 20.6.0 | — |
+
+The archive's `asterisk` is listed for completeness and is not a route:
+AllStarLink is Asterisk *with app_rpt*, distributed as its own packages from
+its own repository (`docs/reference/prior-art.md`), and it is absent from the
+two Debian-13-based targets anyway. Everything else in both tracks is a
+source build, a pinned upstream binary, or a third-party archive — the
+backends 1.0 already has, under the rules 1.0 already made.
+
+### Track A — trunked and digital-voice listening (stage 9)
+
+Receive-only: P25 and DMR trunked systems, NXDN, D-STAR, YSF, M17, as heard on
+an SDR. This is the "does it do trunking" answer and it is the cheaper track,
+because nothing in it transmits and nothing in it needs station config.
+
+- **OP25**, the boatbod fork — the live P25 decoder; the Osmocom original is
+  dead (`prior-art.md`, head commit 2026-08-23). A CMake build against GNU
+  Radio, so it carries the **Tier 3 caveat**: pinned to the GNU Radio the
+  targets ship (`3.10.12.0` on all four x86 targets, measured above) and
+  re-verified when that moves.
+- **Trunk Recorder** (2026-09-01) — records every talkgroup on a trunked
+  system; the same CMake-against-GNU-Radio shape and the same caveat.
+- **SDRTrunk** — the mature Java decoder. Repo alive (2026-08-01), last release
+  v0.6.1 from 2024-12-03; no Debian packaging, so it is a **binary backend**
+  unit: a pinned release archive with a hash we record, and whatever runtime
+  it needs comes from the archive's own JDK packages, never bundled.
+- **DSD-FME** (release 20260715, ISC) — the maintained line of the DSD
+  decoder family; a CMake build. `dsdcc` stays. The two overlap, and
+  `docs/reference/overlaps.md` has no row for that collision yet — the
+  manifest that adds DSD-FME writes one.
+
+Profiles: `listening` for the decoders, `rf-security` for OP25 and Trunk
+Recorder, or both in both — the split is a Q-020 call. **No consent gate.**
+D-034 drew the line at *transmit, not topic*, and every unit here receives.
+What the profile prose owes the operator is the D-021 half: disclose plainly
+that these decode public-safety and commercial traffic and that what may be
+listened to, recorded, or disclosed is the operator's law to know — never
+adjudicated by the engine, never gated by a question.
+
+### Track B — repeater and hotspot (stage 10)
+
+Transmit infrastructure: a repeater controller, an EchoLink or AllStar node, a
+DMR/D-STAR/YSF/P25/NXDN/M17 hotspot. Three sub-stacks, each on a different
+rule the record already has:
+
+- **SvxLink** — apt on every target (versions above) and in the catalog
+  already. What it lacks is not a package but a **station config**: callsign,
+  EchoLink credentials, audio and PTT device, in `svxlink.conf`. That is the
+  D-004 / **D-035** mechanism `linbpq.yaml` already exercises with
+  `config_files`, and it is why this track waits — a missing value defers the
+  file, never the transaction, and nothing is invented.
+- **AllStarLink ASL3** — Debian 13 based, AGPL-3.0 / GPL-3.0, very active
+  (`prior-art.md`), and only from its own apt repository. That is the
+  **D-040** gate exactly as `code` and `codium` exercise it: the manifest pins
+  the signing-key fingerprint, the archive is added only on the operator
+  typing that fingerprint, never on `--yes`, and both files come out on
+  uninstall. It also means ASL3 resolves only where its Debian 13 packages
+  install — Debian 13 and Parrot first; the Ubuntu targets are a measurement,
+  not an assumption.
+- **The G4KLX hotspot suite** — MMDVMHost and the per-mode gateways. In no
+  archive, and the upstreams are untagged, which makes them a **D-024**
+  question: pin the commit a distribution already packages. The candidate
+  distribution is Pi-Star (GPL-2.0, V4.3.7 2026-05-01), which is an image
+  rather than an archive; WPSD is image-only and fork-hostile, so it is not a
+  pin source. Whether a Pi image's binary set counts as "a distribution
+  packages it" for D-024 is a Q-020 call. The modem side — ZUMspot,
+  MMDVM_HS hats, USB MMDVM boards — is a hardware class under **D-026**
+  (install the means of talking to the device) and **D-028** (a generic
+  CP2102 or CH340 identifier does not get a `/dev/mmdvm` symlink).
+
+**Not carried, with the reason:** OpenRepeater has no LICENSE file
+(all-rights-reserved, `prior-art.md`); HamVoIP is dead and its users are
+migrating to ASL3; Pi-Star and WPSD are *images*, and an image is the thing
+this project augments, not a thing it installs — an operator who wants a
+turnkey hotspot on a Pi should run one, and this track does not compete with
+them. RepeaterSTART is a post-1.0 candidate by **Q-015**, not part of this
+track.
+
+**Consent.** A hotspot on the amateur bands is ordinary licensed operation,
+the same thing `flrig` keying a transceiver is, and gets no gate. What the
+profile prose owes — again the D-021 half, disclosed and never adjudicated —
+is that a repeater is infrastructure others depend on, that frequency
+coordination is a matter between the operator and their coordinating body,
+and that the licence conditions for an unattended station are the operator's
+to know. The profile is opt-in by construction: nothing in it belongs to
+`station` or `digital-modes`.
+
+**Ordering.** Track A first, on the numbers: four units, three backends 1.0
+already ships, profiles that already exist, and no dependency on station
+config. Track B's SvxLink sub-stack is one `config_files` block away once
+D-004's station config lands; ASL3 is a D-040 manifest; the G4KLX suite is
+last, because it needs the pin decision and hardware nobody here owns yet.


### PR DESCRIPTION
## What

Writes the answer to "do we have trunking, DMR and repeater setups on the roadmap" into the record instead of a chat log.

- `docs/SCOPE.md` — new **Post-1.0 tracks** section: **Track A, trunked and digital-voice listening** (OP25 boatbod fork, Trunk Recorder, SDRTrunk, DSD-FME; receive-only, no consent gate per D-034's transmit line, D-021 disclosure in the profile prose) and **Track B, repeater and hotspot** (SvxLink station config under D-035, AllStarLink ASL3 under the D-040 fingerprint gate, the G4KLX MMDVM suite under D-024 with the modem side a D-026/D-028 hardware class). What the catalog already has is stated first (`qdmr`, `dmrconfig`, `dsdcc`, the whole Blend `digitalvoice` task). Not carried, with reasons: OpenRepeater (no LICENSE), HamVoIP (dead), Pi-Star/WPSD (images — the thing we augment, not install).
- `docs/QUESTIONS.md` — **Q-020** 🟢: track ordering (rec. A first), profile placement, whether Pi-Star's binary set counts as a D-024 pin source, and ASL3 under D-040.
- `CLAUDE.md` — Q-020 added to the open list.
- **Staging fix:** the numbered list had 6 = DragonOS Tier 2 and "1.0 = stages 1 through 5", while D-042, CLAUDE.md and SCOPE's own ETC section put the ETC delta in 1.0 as "stage 6". Now 6 = ETC delta, 1.0 = 1–6, Tier 2/3 = 7/8, the new tracks 9/10.

## Measured

`scripts/apt-policy-sweep.sh --all` over all seven targets in `containers/targets.yaml`, seventeen names. **Two exist in any archive — `dsdcc` and `svxlink-server` — and both are already carried.** Per-target versions are in the section's table. `asterisk` is in Kali/Ubuntu/Mint and absent from Debian 13 and Parrot, and is not a route anyway (ASL3 ships its own app_rpt build).

The arm64 row needed `HAMMUNITION_FOREIGN_ARCH=arm64`: the `--platform linux/arm64` path pulled an arm64 image over the local `debian:13` tag on a host without qemu-user-static and answered 0 of 17. The script's D-031 row count caught it and refused the empty file.

## Gates

`scripts/check_doc_links.py` clean (1882 references); full pytest suite green. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
