### PR TITLE
install refreshes the apt lists by default; --no-refresh opts out (D-044, Q-018)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,7 @@ Do not re-litigate these without being asked:
 | Profile members a target lacks | Deferred by name, the rest installs; a name the operator typed, an engine gap or a manifest defect still refuses | `listening` withheld nineteen units on Ubuntu 24.04 over four the archive lacks (**D-039**) |
 | Kernel subsystems | `requires_kernel` on the manifest; the plan reads `/lib/modules/<uname -r>` and refuses or defers by name; never in the capability matrix, never a module we build | Linux 7.1 removed AX.25; Kali and the maintainer's own laptop have no `ax25.ko`, and `packet` had "installed whole" on Pop!_OS (**D-041**) |
 | Installed trees | Handed to the operator by an explicit `chown -R -h` step the plan prints and the log records; root keeps the tree when there is no operator; the parent stays root's | MSHV and radiosonde-auto-rx write beside their executables and ran only because `cp -a` under root preserved whoever unpacked the build (**D-043**) |
+| apt lists | `apt-get update` opens every transaction with apt work, disclosed in the plan; `--no-refresh` opts out; nothing to resolve means no update | Six of fifteen Parrot profiles passed the plan and died at the first fetch on four-day-old lists, and staleness is not measurable on Debian (**D-044**) |
 
 Full reasoning and evidence in `docs/DECISIONS.md`, which is authoritative.
 
@@ -498,7 +499,7 @@ longer a design question in the abstract; a shipped manifest depends on it. See
 `DESIGN.md` §15.3 and the D-004 amendment.
 
 **Open questions awaiting the maintainer** are in `docs/QUESTIONS.md`.
-**Q-018** (refresh apt lists by default), **Q-019** (retire `z8530-utils2`;
+**Q-019** (retire `z8530-utils2`;
 is the packet core userspace-primary now that Linux 7.1 has no AX.25) and
 **Q-020** (the two post-1.0 tracks — trunked/digital-voice listening and
 repeater/hotspot — their order, profile placement, the G4KLX pin source and

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3079,3 +3079,72 @@ deployment ever becomes a target. It is not one now.
 the step, its absence, and all four backends; `docs/packages/` is
 regenerated; `source-build-gaps.md` #6 records the closure. Issue #38 is
 closed by this record.
+
+## D-044 — `install` refreshes the apt lists by default, when the transaction has apt work; `--no-refresh` is the opt-out
+
+**Date:** 2026-09-10. **Status:** accepted (maintainer, Q-018, option A as
+recommended). **Depends on:** D-016 (the plan resolves before anything runs),
+D-038 (one automatic retry of the *plan* is the precedent; a retry of a
+*command* the dry run never printed is not), D-010 (install-once-and-rot is
+the pattern to refuse, at every scale). **Amends:** nothing. `--refresh`
+existed; this makes it the default.
+
+**What was measured.** On the Parrot whole-profile campaign of 2026-09-03
+(`docs/reference/vm-campaign-profiles.md`), the guest's `clean-baseline`
+was four days old. Its lists named `glib2.0 2.84.4-3~deb13u3`; the pool
+had moved to the next revision; and six of fifteen profiles — `digital-modes`,
+`electronics`, `listening`, `logging`, `packet`, `propagation` — passed
+the plan and died four commands in with `404 Not Found` on the pool. The
+catalog was right and the machine was unchanged, because apt fetches every
+archive before it unpacks any. Four days is an ordinary age for an
+operator's lists. AHRL and 73Linux both run `apt update` unconditionally
+before anything else, which is why neither has ever reported this failure.
+
+Whether the lists are stale is **not measurable on Debian**: list files
+carry the archive's own `Last-Modified` as their mtime, an `apt-get update`
+that finds nothing changed touches nothing, and the
+`/var/lib/apt/periodic/update-success-stamp` that Ubuntu writes comes from
+a conf.d snippet Debian does not ship. So "refresh when old" (Q-018 option
+B) was rejected on the evidence, and "retry on 404" (option C) was rejected
+because it would run a command `--dry-run` never printed.
+
+**Decision.**
+
+1. **The refresh is the default.** `hammunition install` puts `apt-get
+   update` at the head of the transaction. It is disclosed in the plan
+   like every other command, so `--dry-run` shows it and the real run
+   cannot differ.
+2. **Only when apt will be asked to resolve something.** The update runs
+   when the plan has an apt step or a vendor `.deb` (whose dependencies apt
+   resolves from the lists). A re-run with everything already installed
+   stays a no-op, and a source-only plan on a station with no uplink never
+   opens with a network command. A just-added third-party repository
+   (D-040) always gets the update, whatever the flag says — apt has no
+   index for it until one runs.
+3. **`--no-refresh` turns it off.** For a local mirror, or a field station
+   with no uplink that knows its lists are current. `--refresh` still
+   parses, so every documented example from before this record still runs.
+4. **Empty lists under `--no-refresh` still refuse**, and the blocker
+   names the flag to drop rather than one to add. Without the flag, empty
+   lists are a sequencing fact: the plan says the candidate check cannot
+   be done before the update, and proceeds.
+
+**What this does not do.** The plan's candidate check still resolves
+against the lists as they are when the plan is built; the refresh runs
+after the plan is shown and confirmed. A package the fresh lists would
+newly offer is still refused at plan time, and one they would newly lack
+still fails at the fetch, one step later, with the stale-lists diagnosis
+that already exists. Re-planning against the fresh lists — a second,
+better plan, disclosed as such — is the follow-on Q-018 named, and it is
+worth doing; it is not this record. The stale-lists diagnosis keeps the
+two cases it can still reach: a `--no-refresh` run, and a mirror that
+moved between the run's own update and the fetch.
+
+**Consequences.** `--refresh` became `argparse.BooleanOptionalAction`
+defaulting to true; `commands_for` emits the update only when
+`apt_to_install` or a `.deb` is present, or a repository is added; the
+empty-lists blocker and note, the stale-lists diagnosis and the
+already-configured-repository remedy say what is now true; five tests
+cover the default, the opt-out, the no-apt-work skip, and both empty-lists
+paths through `main()`. `docs/reference/cli.md` documents `--no-refresh`
+and the step order. Q-018 is closed by this record.

--- a/docs/QUESTIONS.md
+++ b/docs/QUESTIONS.md
@@ -889,7 +889,18 @@ and refuses the pairing by name, and the profile no longer lists
 
 ---
 
-## Q-018 🟡 — Should `install` refresh the apt lists by default?
+## Q-018 ✅ — Should `install` refresh the apt lists by default? — **RESOLVED 2026-09-10**
+
+**A, as recommended, recorded as D-044.** `apt-get update` opens every
+transaction that has apt work — an apt step or a vendor `.deb` — and is
+shown in the plan like every other command; `--no-refresh` is the opt-out
+for a local mirror or a station with no uplink; a plan with nothing for apt
+to resolve stays a no-op; a just-added repository always gets the update.
+The candidate check still resolves against the lists as found — re-planning
+after the refresh is the follow-on the recommendation named, and it is still
+open. `--refresh` still parses.
+
+## Q-018 (original) — Should `install` refresh the apt lists by default?
 
 **Raised 2026-09-04**, from the whole-profile campaign on Parrot
 (`~/.local/state/hammunition-campaigns/profiles-parrot-2026-09-03.md`, the

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -84,3 +84,8 @@ Read `hammunition install <profile> --dry-run` before every real install. It
 prints every command, every group you will join, every config file that will
 be written, and every consent gate you will meet — the same text the real run
 shows, so nothing about the real run is a surprise.
+
+The first command of any run that installs from apt is `apt-get update`.
+Stale package lists are the commonest way a correct plan fails — apt asks
+the mirror for a file the pool has replaced — so the refresh is on by
+default. Pass `--no-refresh` on a local mirror or a station with no uplink.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -75,7 +75,7 @@ A profile's documentation, its package list, and — for a gated profile — the
 full consent disclosure, printed without installing anything. This is how an
 operator reads a disclosure before deciding, rather than while being asked.
 
-### `hammunition install NAME... [--dry-run] [--yes] [--refresh] [--user NAME] [--callsign CALL] [--grid-square LOC] [--node-alias NAME]`
+### `hammunition install NAME... [--dry-run] [--yes] [--no-refresh] [--user NAME] [--callsign CALL] [--grid-square LOC] [--node-alias NAME]`
 
 Names may be packages or profiles, mixed freely.
 
@@ -83,7 +83,7 @@ Names may be packages or profiles, mixed freely.
 |---|---|
 | `--dry-run` | Resolve everything, print exactly what would run, change nothing |
 | `--yes` | Skip the confirmation. **Does not satisfy a consent gate** (D-021). Also suppresses the station prompt |
-| `--refresh` | Run `apt-get update` as the transaction's first command |
+| `--no-refresh` | Skip the `apt-get update` that otherwise opens every transaction with apt work (**D-044**). For a local mirror, or a station with no uplink. `--refresh` is the default and still parses |
 | `--user NAME` | Who to add to groups. Defaults to `$SUDO_USER`, then `$USER` |
 | `--callsign CALL` | Station callsign for this run. Overrides the saved value |
 | `--grid-square LOC` | Maidenhead locator, four or six characters |
@@ -354,7 +354,9 @@ Resolution is a distinct phase that finishes before anything is executed
    downloads, verified against the manifest's pinned fingerprint instead of
    a sha256 (**D-040**); then, when the plan adds a repository, its two
    files are written as root (`install -D -m 0644`); then `apt-get update`
-   if `--refresh` was given or a repository was added; then, when the plan
+   when the transaction has apt work — an apt step or a vendor `.deb` — and
+   `--no-refresh` was not given, or whenever a repository was added
+   (**D-044**); then, when the plan
    holds a vendor `.deb` or added a repository, one more `apt-get install
    --simulate` over the apt packages and the downloaded file together,
    because apt can only resolve a `.deb` from its file and can only see a
@@ -391,7 +393,7 @@ capability matrix that reports coverage the engine does not have is the shim
 | A package whose status is `broken` or `retired` | the recorded reason, verdict and date |
 | A dependency apt has no candidate for | which name, and whether it came from `install` or `depends`. A *profile* member whose own `install` packages are the ones missing is deferred instead (**D-039**), and the row above still applies to its `depends` |
 | A profile every member of which this target cannot install | the profile by name, with each member's reason — installing nothing and reporting success is not an outcome (**D-039**) |
-| No apt package lists at all | that this is a stale-lists problem, with `--refresh` as the remedy |
+| No apt package lists at all, and `--no-refresh` | that this is a stale-lists problem, and that dropping `--no-refresh` lets this run fix it. Without the flag, the run's own `apt-get update` comes first and the plan says instead that the candidate check cannot be done before it |
 | A group membership with no identifiable operator | that `--user` is needed |
 | A unit whose `requires_kernel` names a subsystem the running kernel's module tree lacks | the unit, the kernel release and the merge that removed the subsystem, with the remedies that exist: a distribution kernel that still carries it, or the userspace path (Direwolf's KISS/AGW ports serve pat, LinBPQ, YAAC and Xastir without kernel AX.25). Never an offer to build the module — no distribution packages one, and Hammunition builds no kernel modules (**D-041**). A *profile* member is deferred instead, the D-039 shape. No module tree for the running kernel at all — a container — is disclosed as *cannot be checked* and the unit plans |
 
@@ -639,10 +641,13 @@ fails with `404 Not Found` on files in the pool, the package lists on the
 machine are older than the archive: the plan resolved against those lists,
 so the catalog is not at fault, and apt downloads every archive before it
 unpacks any, so the command installed nothing. The message says so, names
-the files by version, and gives the remedy — `sudo apt-get update`, or
-`--refresh` on the same run. Six of fifteen profiles on a four-day-old Parrot
-guest died this way (2026-09-03), each report ending in seven URLs and
-apt's own hint under them. A `5xx` or a timeout is a mirror problem and gets
+the files by version, and gives the remedy — `sudo apt-get update`, or the
+same run without `--no-refresh`. Six of fifteen profiles on a four-day-old
+Parrot guest died this way (2026-09-03), each report ending in seven URLs and
+apt's own hint under them; that campaign is why the refresh became the
+default (**D-044**). The diagnosis still exists for the two runs it can
+reach: one under `--no-refresh`, and one where the mirror moved between the
+run's own update and the fetch. A `5xx` or a timeout is a mirror problem and gets
 no such diagnosis; sending an operator to refresh lists that are fine would
 be a wrong answer with a confident tone.
 

--- a/scripts/vm_campaign.py
+++ b/scripts/vm_campaign.py
@@ -292,7 +292,7 @@ class Provenance:
 # lists still named glib2.0 2.84.4-3~deb13u3 and the pool had moved on, and
 # six of fifteen profiles failed at the first fetch with a 404 (2026-09-03).
 # So the lists are refreshed here, once per prepare, before anything is
-# measured -- the engine's own ``--refresh`` would do it per unit, and the
+# measured -- the engine's own default refresh would do it per unit, and the
 # campaign is measuring the catalog, not the age of a snapshot. The retry
 # loop is for a guest that runs its own apt at boot: Pop!_OS 24.04's did,
 # and a prepare that started 30 s after the restore lost the lists lock to

--- a/src/hammunition/cli/main.py
+++ b/src/hammunition/cli/main.py
@@ -937,8 +937,9 @@ def stale_lists_diagnosis(failed: Command | Action, stderr: str) -> str | None:
         f"{len(missing)} file(s) the mirror no longer has ({shown}). The plan resolved "
         f"against those lists, so the catalog is not at fault, and apt downloads every "
         f"archive before unpacking any, so this command installed nothing. Refresh the "
-        f"lists and run the same install again: `sudo apt-get update`, or add --refresh "
-        f"to do it as the first step of the run."
+        f"lists and run the same install again: `sudo apt-get update`, or run without "
+        f"--no-refresh so the transaction's own refresh does it first. If the refresh "
+        f"did run, the mirror moved between the update and this fetch; run it again."
     )
 
 
@@ -1587,8 +1588,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_install.add_argument(
         "--refresh",
-        action="store_true",
-        help="run `apt-get update` as the first command of the transaction",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "run `apt-get update` as the first command of the transaction, when the "
+            "transaction has apt work (the default; D-044). --no-refresh skips it: a "
+            "local mirror, or a station with no uplink"
+        ),
     )
     p_install.add_argument(
         "--user",

--- a/src/hammunition/execute.py
+++ b/src/hammunition/execute.py
@@ -374,16 +374,14 @@ def commands_for(
         commands.extend(s for s in repo_steps if isinstance(s, Action) and s.kind == "fetch")
         commands.extend(s for s in repo_steps if not (isinstance(s, Action) and s.kind == "fetch"))
 
-    if refresh or plan.apt_repos:
-        commands.append(apt.refresh_command())
-
     # A vendor .deb is resolved by apt from its file, and the file does not
     # exist until its fetch has run -- so the plan's own simulate (D-038)
-    # could not include it. This one can: it runs after every fetch and
-    # before the apt step, over the apt packages and the downloaded .debs
-    # together, and a refusal here is a refusal on an untouched machine.
-    # `apt-get install ./file.deb` is what the binary backend runs later;
-    # asking the same resolver the same question first is the whole idea.
+    # could not include it. The simulate below can: it runs after every
+    # fetch and before the apt step, over the apt packages and the downloaded
+    # .debs together, and a refusal there is a refusal on an untouched
+    # machine. `apt-get install ./file.deb` is what the binary backend runs
+    # later; asking the same resolver the same question first is the whole
+    # idea.
     debs = [
         str(binary.fetcher.path_for(planned.block.install.artifact))
         for planned in plan.packages
@@ -391,6 +389,18 @@ def commands_for(
         and isinstance(planned.block.install, BinaryInstall)
         and planned.block.install.format == "deb"
     ]
+
+    # The refresh is the default (D-044): six of fifteen profiles on a
+    # four-day-old Parrot guest passed the plan and died at the first fetch
+    # because the pool had moved past the lists. It runs only when apt will
+    # be asked to resolve something -- the apt step, or a vendor .deb whose
+    # dependencies apt resolves from the lists -- so a re-run with nothing
+    # to install stays a no-op, and a source-only plan on a station with no
+    # uplink never starts with a network command. A just-added repository
+    # always needs it, whatever the flag says: apt has no index for it yet.
+    needs_lists = bool(plan.apt_to_install) or bool(debs)
+    if (refresh and needs_lists) or plan.apt_repos:
+        commands.append(apt.refresh_command())
     # The same question again for a just-added repository: the plan-time
     # simulate left its packages out because apt had no index for them.
     # After the update, the resolver is asked about the whole apt step.

--- a/src/hammunition/plan.py
+++ b/src/hammunition/plan.py
@@ -781,7 +781,7 @@ def _plan_repos(
       cannot see a repository apt does not have yet;
     * ours -- both files carry exactly what this engine writes, so the
       candidate should exist and does not: the archive index is stale, and
-      the fix is ``--refresh``, never a second copy of the file;
+      the fix is a refresh of the lists, never a second copy of the file;
     * foreign -- a file of the same name with anybody else's content, which
       is never overwritten.
     """
@@ -819,8 +819,9 @@ def _plan_repos(
                 ),
                 remedy=(
                     "the package index is stale or the repository does not carry the "
-                    "package for this release; run `hammunition install --refresh` "
-                    "(apt-get update) and read what apt says about the source"
+                    "package for this release; run `sudo apt-get update`, read what apt "
+                    "says about the source, and plan again (this run's own refresh comes "
+                    "after the plan, so it cannot answer this)"
                 ),
             )
         additions.append(
@@ -998,16 +999,17 @@ def resolve(
     if all_apt or all_conflicts:
         if not apt.lists_populated():
             if refresh:
-                # --refresh puts `apt-get update` at the head of this same run,
-                # so empty lists are a sequencing fact, not a blocker -- refusing
-                # here would tell the operator to pass the flag they just passed.
+                # The refresh (the default, D-044) puts `apt-get update` at the
+                # head of this same run, so empty lists are a sequencing fact, not
+                # a blocker -- refusing here would tell the operator to pass a
+                # flag that is already on.
                 # What is genuinely lost is the pre-flight candidate check:
                 # nothing can know what apt will offer until update has run, so
                 # the plan discloses the gap instead of silently skipping the
                 # check (D-016 wants the resolution honest, not decorative).
                 notes.append(
-                    "apt has no package lists yet; --refresh runs apt-get update "
-                    "first, so which packages actually have candidates cannot be "
+                    "apt has no package lists yet; this run's refresh runs apt-get "
+                    "update first, so which packages actually have candidates cannot be "
                     "known before this plan executes. A package apt does not "
                     "offer will fail the apt-get install step rather than being "
                     "caught here."
@@ -1020,7 +1022,7 @@ def resolve(
                             "has no package lists, so every package would resolve as unknown. "
                             "Reporting them all as unobtainable would be a confident lie"
                         ),
-                        remedy="run `sudo apt-get update`, or pass --refresh to do it as part of this run",
+                        remedy="run `sudo apt-get update`, or drop --no-refresh so this run does it first",
                     )
                 )
         else:

--- a/tests/test_apt_repos.py
+++ b/tests/test_apt_repos.py
@@ -442,7 +442,7 @@ def test_our_repository_with_no_candidate_points_at_refresh(tmp_path: Path) -> N
     with pytest.raises(PlanError) as excinfo:
         _plan(tmp_path, backend)
     assert "already configured" in excinfo.value.blockers[0].reason
-    assert "--refresh" in (excinfo.value.blockers[0].remedy or "")
+    assert "apt-get update" in (excinfo.value.blockers[0].remedy or "")
 
 
 def test_a_missing_dependency_is_never_a_reason_to_add_a_repository(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,6 +162,22 @@ def test_refresh_runs_before_anything_else() -> None:
     assert _argv(commands[0]) == ("apt-get", "update")
 
 
+def test_refresh_is_skipped_when_nothing_asks_apt_to_resolve() -> None:
+    """The refresh is the default (D-044), and a default that starts every
+    run with a privileged network command would make the idempotent re-run
+    -- everything already installed, nothing to do -- a network operation.
+    No apt step and no vendor .deb means no lists are consulted, so no
+    update runs, whatever the flag says."""
+    empty = InstallPlan(target=TARGET, packages=())
+    commands = commands_for(empty, AptBackend(RecordingRunner()), refresh=True)
+    assert all(_argv(c)[:2] != ("apt-get", "update") for c in commands)
+
+
+def test_no_refresh_leaves_the_update_out() -> None:
+    commands = commands_for(_plan(), AptBackend(RecordingRunner()), refresh=False)
+    assert all(_argv(c)[:2] != ("apt-get", "update") for c in commands)
+
+
 # ---------------------------------------------------------------------------
 # Execution
 # ---------------------------------------------------------------------------
@@ -841,6 +857,28 @@ def test_install_dry_run_prints_the_plan_and_executes_nothing(
     assert "transaction log written to" in out
 
 
+def test_install_refreshes_the_lists_by_default_and_no_refresh_turns_it_off(
+    monkeypatch: pytest.MonkeyPatch, capsys: Any
+) -> None:
+    """Q-018, D-044: six of fifteen profiles on a four-day-old Parrot guest
+    passed the plan and died at the first fetch with a 404 (2026-09-03).
+    AHRL and 73Linux both run apt update unconditionally; so does this, by
+    default, disclosed in the dry run like every other command. The opt-out
+    is for a local mirror or a station with no uplink."""
+    _mock_apt(monkeypatch, populated=True)
+    rc = main(["--catalog", str(CATALOG), "install", "--dry-run", "git"])
+    out = capsys.readouterr().out
+    assert rc == EXIT_OK
+    assert "apt-get update" in out
+    assert out.index("apt-get update") < out.index("apt-get install")
+
+    rc = main(["--catalog", str(CATALOG), "install", "--dry-run", "--no-refresh", "git"])
+    out = capsys.readouterr().out
+    assert rc == EXIT_OK
+    assert "apt-get update" not in out
+    assert "apt-get install" in out
+
+
 def test_install_reads_the_running_kernel_and_refuses_ax25_tools_without_ax25(
     monkeypatch: pytest.MonkeyPatch, capsys: Any, tmp_path: Path
 ) -> None:
@@ -861,13 +899,16 @@ def test_install_reads_the_running_kernel_and_refuses_ax25_tools_without_ax25(
     assert "Nothing was changed" in err
 
 
-def test_install_refresh_on_empty_lists_is_plannable_through_main(
-    monkeypatch: pytest.MonkeyPatch, capsys: Any
+@pytest.mark.parametrize("flags", [(), ("--refresh",)])
+def test_install_on_empty_lists_is_plannable_through_main(
+    monkeypatch: pytest.MonkeyPatch, capsys: Any, flags: tuple[str, ...]
 ) -> None:
-    """--refresh on a fresh machine must produce a plan, not the blocker that
-    tells you to pass the flag you just passed. End to end, the bug #1 shape."""
+    """A fresh machine must produce a plan, not the blocker that tells you to
+    pass a flag that is already on. End to end, the bug #1 shape; the
+    explicit --refresh spelling still parses after the default flipped
+    (D-044), so a documented example from before it does not break."""
     _mock_apt(monkeypatch, populated=False)
-    rc = main(["--catalog", str(CATALOG), "install", "--dry-run", "--refresh", "git"])
+    rc = main(["--catalog", str(CATALOG), "install", "--dry-run", *flags, "git"])
     out = capsys.readouterr().out
     assert rc == EXIT_OK
     assert "apt-get update" in out  # the refresh command is in the plan
@@ -875,15 +916,16 @@ def test_install_refresh_on_empty_lists_is_plannable_through_main(
     assert "Dry run: nothing above was executed." in out
 
 
-def test_install_without_refresh_on_empty_lists_is_blocked_through_main(
+def test_install_no_refresh_on_empty_lists_is_blocked_through_main(
     monkeypatch: pytest.MonkeyPatch, capsys: Any
 ) -> None:
-    """The other side: no --refresh on empty lists is still a blocker."""
+    """The other side: --no-refresh on empty lists is still a blocker, and the
+    blocker names the flag to drop rather than one to add."""
     _mock_apt(monkeypatch, populated=False)
-    rc = main(["--catalog", str(CATALOG), "install", "--dry-run", "git"])
+    rc = main(["--catalog", str(CATALOG), "install", "--dry-run", "--no-refresh", "git"])
     err = capsys.readouterr().err
     assert rc == EXIT_UNPLANNABLE
-    assert "apt-get update" in err
+    assert "apt-get update" in err and "--no-refresh" in err
 
 
 def test_the_log_destination_is_disclosed_and_a_bad_owner_is_not_silent(

--- a/tests/test_target_release.py
+++ b/tests/test_target_release.py
@@ -254,7 +254,7 @@ def test_the_install_failure_says_stale_lists_installed_nothing_and_names_the_fi
     assert "girepository-tools_2.84.4-3~deb13u3_amd64.deb" in text and "and 1 more" in text
     assert "libglib2.0-dev_2.84.4-3~deb13u3_amd64.deb" not in text  # the elided fourth
     assert "installed nothing" in text
-    assert "sudo apt-get update" in text and "--refresh" in text
+    assert "sudo apt-get update" in text and "--no-refresh" in text
     # Not every apt-get failure is this one, and not every 404 is apt's.
     assert stale_lists_diagnosis(install, PARROT_REFUSAL) is None
     remove = Command(argv=("apt-get", "remove", "--yes", "foo"), description="")


### PR DESCRIPTION
Resolves **Q-018** as option A, recorded as **D-044**.

- `apt-get update` opens every transaction that has apt work — an apt step or a vendor `.deb` — and is shown in the plan like every other command, so `--dry-run` cannot differ from the real run.
- A plan with nothing for apt to resolve gets no update, so the idempotent re-run stays a no-op and a source-only run on a station with no uplink never opens with a network command. A just-added repository (D-040) always gets the update.
- `--no-refresh` is the opt-out (local mirror, no uplink). `--refresh` still parses.
- Empty lists under `--no-refresh` still refuse; the blocker names the flag to drop.

**Not in this PR**, recorded as the open follow-on in D-044: the candidate check still resolves against the lists as found, because the refresh runs after the plan is shown. Re-planning against the fresh lists is the next step if the maintainer wants it.

Touches: `cli/main.py`, `execute.py`, `plan.py`, five tests, `docs/reference/cli.md`, `docs/getting-started/install.md`, `DECISIONS.md` (D-044), `QUESTIONS.md`, `CLAUDE.md`.

Gates run locally: ruff, ruff format, mypy --strict, pytest, check_doc_links.py. The one probe-guarded test failing on my machine (`test_every_swept_target_measured_every_apt_name_the_catalog_references`) predates this PR — the local sweep is older than `wsjtx-improved` from #50 — and CI skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
