### PR TITLE
packet core is userspace-primary; z8530-utils2 retired; out-of-tree AX.25 module measured, not built (D-045, Q-019)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,7 @@ Do not re-litigate these without being asked:
 | Kernel subsystems | `requires_kernel` on the manifest; the plan reads `/lib/modules/<uname -r>` and refuses or defers by name; never in the capability matrix, never a module we build | Linux 7.1 removed AX.25; Kali and the maintainer's own laptop have no `ax25.ko`, and `packet` had "installed whole" on Pop!_OS (**D-041**) |
 | Installed trees | Handed to the operator by an explicit `chown -R -h` step the plan prints and the log records; root keeps the tree when there is no operator; the parent stays root's | MSHV and radiosonde-auto-rx write beside their executables and ran only because `cp -a` under root preserved whoever unpacked the build (**D-043**) |
 | apt lists | `apt-get update` opens every transaction with apt work, disclosed in the plan; `--no-refresh` opts out; nothing to resolve means no update | Six of fifteen Parrot profiles passed the plan and died at the first fetch on four-day-old lists, and staleness is not measurable on Debian (**D-044**) |
+| Packet core | Userspace-primary: Direwolf/QtSoundModem over KISS or AGW to pat, LinBPQ, YAAC, Xastir; the kernel stack is the fuller station where the kernel has it; `z8530-utils2` retired; the out-of-tree module (`mod-orphan`) measured — it builds against 7.1 — and not built by us until a distribution packages it | The whole station installs on Kali 7.1.5 without `ax25.ko`; the module has no tags and no packager, and `ax25-tools` is leaving the archives anyway (**D-045**) |
 
 Full reasoning and evidence in `docs/DECISIONS.md`, which is authoritative.
 
@@ -499,8 +500,6 @@ longer a design question in the abstract; a shipped manifest depends on it. See
 `DESIGN.md` §15.3 and the D-004 amendment.
 
 **Open questions awaiting the maintainer** are in `docs/QUESTIONS.md`.
-**Q-019** (retire `z8530-utils2`;
-is the packet core userspace-primary now that Linux 7.1 has no AX.25) and
 **Q-020** (the two post-1.0 tracks — trunked/digital-voice listening and
 repeater/hotspot — their order, profile placement, the G4KLX pin source and
 ASL3 under D-040; `docs/SCOPE.md` stages 9 and 10) are open.

--- a/catalog/packages/z8530-utils2.yaml
+++ b/catalog/packages/z8530-utils2.yaml
@@ -7,6 +7,22 @@ summary: Configures Z8530-based HDLC cards for high-speed packet
 categories: [packet, hardware]
 requires_kernel: [ax25]
 
+# Retired, and the catalog still carries it, so an operator who goes
+# looking finds the reason rather than silence (D-045, Q-019).
+status: retired
+retire_reason: world_changed
+status_reason: >-
+  The `scc` driver these tools configure left the kernel with the rest of
+  drivers/net/hamradio in Linux 7.1 (merge 64edfa65, 2026-04-24), and the
+  cards it drove are ISA and early PCI with no modern host. Verified by us:
+  the merge's --stat, and the module trees of seven machines read on
+  2026-09-04 (docs/reference/kernel-ax25.md). Not inherited from anyone's
+  shell comment. A 6.12 kernel on a machine with an ISA slot can still
+  `apt install z8530-utils2` by hand.
+status_date: 2026-04-24
+status_verdict: tested
+recommended_default: false
+
 install:
   - install:
       method: apt
@@ -34,7 +50,7 @@ documentation:
     Needs the kernel AX.25 stack and the `scc` driver, both of which Linux 7.1
     removed with the rest of drivers/net/hamradio (merge 64edfa65,
     2026-04-24); the plan refuses or defers this unit by name on a 7.1 or
-    newer kernel, and Q-019 asks whether to retire it. See
+    newer kernel. Retired on that evidence (D-045). See
     `docs/reference/kernel-ax25.md`.
     The hardware predates PCI Express and most of it is ISA, so a modern
     machine cannot host it at all. Carried for completeness and for anyone

--- a/catalog/profiles/packet.yaml
+++ b/catalog/profiles/packet.yaml
@@ -54,11 +54,20 @@ suggests_one_of:
 
 documentation:
   what_it_installs: >-
-    Two soundcard TNCs — one headless and one with a scope — the kernel AX.25
-    stack's configuration and user tools, two packet terminals, a node front
-    end, a BBS and Winlink gateway, the Winlink client, an HF data modem, the
-    full-featured APRS client, a digipeater and an internet gateway, mail
-    tools, AMPRnet routing, and a GRIB weather viewer.
+    Two soundcard TNCs — one headless and one with a scope — two packet
+    terminals, a node front end, a BBS and Winlink gateway, the Winlink
+    client, an HF data modem, the full-featured APRS client, a digipeater and
+    an internet gateway, mail tools, AMPRnet routing, a GRIB weather viewer,
+    and, where the running kernel still carries it, the kernel AX.25 stack's
+    configuration and user tools.
+
+    **The station is userspace-primary (D-045).** Direwolf or QtSoundModem
+    turns the radio into a modem; pat, LinBPQ, YAAC and Xastir talk to it
+    over KISS or AGW and never touch the kernel. That is the whole station on
+    every kernel, and the path a new operator should learn first. The kernel
+    stack — `axports`, `kissattach`, `ax25d`, NET/ROM, and packet
+    connections as sockets — is the fuller station where the kernel has it,
+    and a bonus rather than the foundation.
 
     **On a kernel without AX.25 the kernel-side members are withheld, by
     name.** Linux 7.1 removed the AX.25 stack (2026-04-24); Kali rolling and
@@ -72,8 +81,9 @@ documentation:
     has the measurements.
   why_together: >-
     This is a network, not a set of programs. Direwolf turns a radio into a
-    modem, ax25-tools brings the port up, and everything above that speaks over
-    it. Installing half of it gives you something that connects to nothing.
+    modem, the applications speak to it over KISS or AGW, and ax25-tools
+    brings a kernel port up where there is a kernel to bring it up on.
+    Installing half of it gives you something that connects to nothing.
 
     **The weather viewer belongs here and looks like it does not.** A GRIB file
     for one region is small enough to move over HF where a weather website is

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -287,6 +287,21 @@ belong together.
 filename. The `.bapp` `Comment=` field carried the correct answer the whole time
 and cost one HTTP request to read.
 
+### Amendment, 2026-09-10 — the packet core is userspace-primary (D-045)
+
+The resolution above names "the AX.25 stack" as a member of the packet core
+and the profile prose described the station as the kernel stack with Direwolf
+feeding it. Linux 7.1 removed the kernel stack (**D-041**), and on every 7.1
+kernel — Kali today, the maintainer's own laptop, Ubuntu 24.04 the day its
+HWE kernel moves — the userspace half is the whole station: Direwolf or
+QtSoundModem as the modem, pat, LinBPQ, YAAC and Xastir over KISS or AGW.
+**The packet core is that userspace path.** The kernel stack — `ax25-tools`
+and what sits on it: `axports`, `kissattach`, `ax25d`, NET/ROM, packet
+connections as sockets — is the fuller station where the kernel carries it,
+and is planned or deferred by name per D-041. The eight units are unchanged;
+what changed is which of them is the foundation. `z8530-utils2`, never a
+core member, is retired by the same record.
+
 ---
 
 ## D-009 — Community side-loading, with review tiers, from day one
@@ -3148,3 +3163,88 @@ already-configured-repository remedy say what is now true; five tests
 cover the default, the opt-out, the no-apt-work skip, and both empty-lists
 paths through `main()`. `docs/reference/cli.md` documents `--no-refresh`
 and the step order. Q-018 is closed by this record.
+## D-045 — The packet core is userspace-primary; `z8530-utils2` is retired on tested evidence; the out-of-tree AX.25 module is measured, named, and not built until a distribution packages it
+
+**Date:** 2026-09-10. **Status:** accepted (maintainer, Q-019: both
+recommendations taken, with the module question asked and answered).
+**Depends on:** D-041 (the plan reads the running kernel; never a module we
+build), D-024 (carry what a distribution packages), D-018 (external claims
+tested before published), D-032 (liveness is the head commit, never
+`updated_at`), `PARITY-POLICY.md` (every unit gets a verdict we tested).
+**Amends:** D-008 (the packet-core statement; amendment recorded there).
+
+**What was measured.** Two things Q-019 rested on and one it did not ask.
+
+1. `z8530-utils2` configures the `scc` driver for Z8530 HDLC cards. The
+   driver left the kernel in the same merge as `net/ax25`
+   (`64edfa65`, 2026-04-24; `git show --stat` lists
+   `drivers/net/hamradio/scc.c`), the cards are ISA and early PCI, and the
+   manifest already called both \"museum conditions\". Seven machines' module
+   trees were read on 2026-09-04 (`docs/reference/kernel-ax25.md`). That is
+   a verdict tested by us, not an AHRL comment inherited.
+2. On every kernel this project has that is 7.1 or newer, the userspace
+   packet path — Direwolf or QtSoundModem as the modem; pat, LinBPQ, YAAC
+   and Xastir over KISS or AGW — installs and is the whole station. The
+   `packet` profile was installed whole on Kali 7.1.5 and Debian 13 6.12 on
+   2026-09-05 with that result (D-041's table). D-008 and the profile prose
+   still described the core as the kernel stack fed by Direwolf.
+3. The maintainer asked whether the kernel stack can be added back as a
+   module. **It can, and it was measured on 2026-09-10** rather than
+   assumed either way. The netdev maintainer who removed the subsystem
+   publishes it as an out-of-tree tree, `linux-netdev/mod-orphan`, created
+   2026-04-20: one `Kbuild` covering `net/ax25`, `net/netrom`, `net/rose`,
+   `drivers/net/hamradio` and the merge's other orphans; `make` against
+   the running kernel's headers with a force-included compatibility header;
+   sources keep their kernel SPDX headers (GPL-2.0-or-later on `af_ax25.c`);
+   **no tags, no releases, no README, no top-level licence file**; head
+   commit 2026-06-16, last AX.25-family change 2026-06-01 (two ROSE fixes,
+   Bernard Pidoux); **packaged by no distribution** — not Debian, not
+   Ubuntu, not the AUR, on that date. **Built here, not loaded:** against
+   the maintainer's laptop's 7.1.1 headers, `ax25.ko`, `netrom.ko` and all
+   ten `drivers/net/hamradio` modules — `mkiss`, `6pack`, `bpqether`,
+   `scc` among them — compile and link with a matching `vermagic`; the
+   whole tree's `make` fails, because `net/rose` calls a kernel function
+   whose signature changed and `net/atm` needs a header 7.1 no longer
+   ships. Nothing was `insmod`ed and no socket was opened; the measurement
+   is that the code compiles, not that it works.
+
+**Decision.**
+
+1. **`z8530-utils2` is retired**, `retire_reason: world_changed`,
+   `status_verdict: tested`, with the merge as the evidence. The manifest
+   stays in the catalog so an operator who looks finds the reason (D-005's
+   shape, as `noaa-apt`); a 6.12 machine with an ISA slot can still install
+   it by hand, and the manifest says so. That `scc.ko` compiles out of tree
+   (point 3) does not move this: the driver is packaged by nobody and the
+   cards have no modern host.
+2. **D-008 is amended: the packet core is userspace-primary.** The kernel
+   stack is the fuller station where the kernel carries it, planned or
+   deferred by name per D-041, and a bonus rather than the foundation. The
+   getting-started packet guide, when written, teaches Direwolf-to-pat first
+   and `kissattach` second.
+3. **The out-of-tree module is noted, not carried.** D-041's \"never a
+   module we build\" stands, for three reasons that survive the module
+   existing: a kernel module is the one artefact this project has said it
+   will never build, and building one that has to be rebuilt for every
+   kernel the machine boots means a DKMS wrapper that would be *our*
+   packaging of code nobody else packages — precisely what D-024 refuses,
+   and the tree's own `make` already fails on 7.1.1 without a `Kbuild` we
+   would have to edit, which is the first patch of a fork;
+   the code's own maintainers removed it for lack of maintenance, and a
+   tree with no tags and no releases offers nothing to pin (D-024's review
+   signal is absent by construction); and `ax25-tools` is leaving the
+   archives regardless (#1143282), so the module would restore the sockets
+   and not the tools that use them. **The condition that reopens this** is
+   a distribution packaging the module — a `-dkms` package in Debian is the
+   obvious shape. That is the signal D-024 asks for, and the day it exists
+   the `requires_kernel` refusal gains a third remedy and this record is
+   amended. Nobody watches GitHub for it; `kernel-ax25.md` says where to
+   look.
+
+**Consequences.** `z8530-utils2.yaml` carries the retired status block;
+`catalog/profiles/packet.yaml` describes the station userspace-first;
+`docs/reference/kernel-ax25.md` carries the module measurement and the
+reopening condition; generated pages regenerated. Q-019 is closed by this
+record. The remaining kernel-side question — the `scc`/`netrom`/`rose`
+vocabulary — stays closed by D-041 until a manifest needs an entry `ax25`
+does not settle.

--- a/docs/QUESTIONS.md
+++ b/docs/QUESTIONS.md
@@ -953,7 +953,20 @@ taken.
 
 ---
 
-## Q-019 🟡 — Kernel AX.25 is gone from Linux 7.1: retire `z8530-utils2`, and does the packet core become userspace-primary?
+## Q-019 ✅ — Kernel AX.25 is gone from Linux 7.1: retire `z8530-utils2`, and does the packet core become userspace-primary? — **RESOLVED 2026-09-10**
+
+**A and A, as recommended, recorded as D-045.** `z8530-utils2` is retired
+(`world_changed`, verdict tested against merge 64edfa65 and seven module
+trees); D-008 is amended to say the packet core is the userspace path, with
+the kernel stack the fuller station where the kernel carries it. The
+maintainer also asked whether the stack can come back as a module: it can —
+`linux-netdev/mod-orphan`, published by the maintainer who removed it, builds
+out of tree — and it is measured in `docs/reference/kernel-ax25.md` and not
+carried, because no distribution packages it, it has no tags to pin, and
+`ax25-tools` is leaving the archives regardless. A distribution packaging it
+reopens the question; D-045 says so.
+
+## Q-019 (original) — Kernel AX.25 is gone from Linux 7.1: retire `z8530-utils2`, and does the packet core become userspace-primary?
 
 **Raised 2026-09-04**, from the Kali campaign's `ax25-tools` gap, which
 turned out to be a kernel removal rather than an archive accident

--- a/docs/packages/z8530-utils2.md
+++ b/docs/packages/z8530-utils2.md
@@ -4,10 +4,13 @@
 
 **Configures Z8530-based HDLC cards for high-speed packet**
 
+> **Status: retired.** The `scc` driver these tools configure left the kernel with the rest of drivers/net/hamradio in Linux 7.1 (merge 64edfa65, 2026-04-24), and the cards it drove are ISA and early PCI with no modern host. Verified by us: the merge's --stat, and the module trees of seven machines read on 2026-09-04 (docs/reference/kernel-ax25.md). Not inherited from anyone's shell comment. A 6.12 kernel on a machine with an ISA slot can still `apt install z8530-utils2` by hand. Recorded 2026-04-24. Verdict tested by us.
+
 - **Version recorded:** 3.0-1
 - **Categories:** `hardware`, `packet`
 - **Upstream:** <https://tracker.debian.org/pkg/z8530-utils2>
 - **Needs from the kernel:** `ax25` — checked against the running kernel at plan time; see [kernel-ax25](../reference/kernel-ax25.md)
+- **Not a recommended default** — installed only when asked for.
 
 ## What it does
 
@@ -27,7 +30,7 @@ A Z8530-based card in an ISA or PCI slot, and a kernel with the matching driver.
 
 ## Known problems
 
-Needs the kernel AX.25 stack and the `scc` driver, both of which Linux 7.1 removed with the rest of drivers/net/hamradio (merge 64edfa65, 2026-04-24); the plan refuses or defers this unit by name on a 7.1 or newer kernel, and Q-019 asks whether to retire it. See `docs/reference/kernel-ax25.md`. The hardware predates PCI Express and most of it is ISA, so a modern machine cannot host it at all. Carried for completeness and for anyone maintaining an existing installation, not as a route to build a new one. Suggests rather than Recommends in the Blend, marked hardware-specific.
+Needs the kernel AX.25 stack and the `scc` driver, both of which Linux 7.1 removed with the rest of drivers/net/hamradio (merge 64edfa65, 2026-04-24); the plan refuses or defers this unit by name on a 7.1 or newer kernel. Retired on that evidence (D-045). See `docs/reference/kernel-ax25.md`. The hardware predates PCI Express and most of it is ISA, so a modern machine cannot host it at all. Carried for completeness and for anyone maintaining an existing installation, not as a route to build a new one. Suggests rather than Recommends in the Blend, marked hardware-specific.
 
 ## Keeping it current
 

--- a/docs/profiles/packet.md
+++ b/docs/profiles/packet.md
@@ -8,14 +8,15 @@
 
 ## What it installs
 
-Two soundcard TNCs — one headless and one with a scope — the kernel AX.25 stack's configuration and user tools, two packet terminals, a node front end, a BBS and Winlink gateway, the Winlink client, an HF data modem, the full-featured APRS client, a digipeater and an internet gateway, mail tools, AMPRnet routing, and a GRIB weather viewer.
+Two soundcard TNCs — one headless and one with a scope — two packet terminals, a node front end, a BBS and Winlink gateway, the Winlink client, an HF data modem, the full-featured APRS client, a digipeater and an internet gateway, mail tools, AMPRnet routing, a GRIB weather viewer, and, where the running kernel still carries it, the kernel AX.25 stack's configuration and user tools.
+**The station is userspace-primary (D-045).** Direwolf or QtSoundModem turns the radio into a modem; pat, LinBPQ, YAAC and Xastir talk to it over KISS or AGW and never touch the kernel. That is the whole station on every kernel, and the path a new operator should learn first. The kernel stack — `axports`, `kissattach`, `ax25d`, NET/ROM, and packet connections as sockets — is the fuller station where the kernel has it, and a bonus rather than the foundation.
 **On a kernel without AX.25 the kernel-side members are withheld, by name.** Linux 7.1 removed the AX.25 stack (2026-04-24); Kali rolling and Pop!_OS on their 7.1 kernels no longer have it, measured 2026-09-04. The plan reads the running kernel and defers `ax25-tools`, `ax25-apps`, `ax25-xtools`, `ax25mail-utils`, `axmail`, `aprsdigi`, `linpac` and `uronode` with the reason, and the rest installs: Direwolf, pat over `ax25+agwpe`, LinBPQ, YAAC and Xastir's AGWPE interface work with no kernel stack. What such a machine cannot have is a kernel port — no `axports`, `kissattach`, `ax25d` or NET/ROM. `docs/reference/kernel-ax25.md` has the measurements.
 
 **Disk footprint:** Around 500 MB. LinBPQ and ardopcf are source builds from pinned upstream tags; everything else is apt.
 
 ## Why these belong together
 
-This is a network, not a set of programs. Direwolf turns a radio into a modem, ax25-tools brings the port up, and everything above that speaks over it. Installing half of it gives you something that connects to nothing.
+This is a network, not a set of programs. Direwolf turns a radio into a modem, the applications speak to it over KISS or AGW, and ax25-tools brings a kernel port up where there is a kernel to bring it up on. Installing half of it gives you something that connects to nothing.
 **The weather viewer belongs here and looks like it does not.** A GRIB file for one region is small enough to move over HF where a weather website is not, which is why sailors and emergency operators request them over Winlink. It is the thing the link is often carrying.
 Most of the 73Linux delta lands in this profile whole, and AHRL has none of it — this is the clearest example of what the five-source union bought.
 

--- a/docs/reference/kernel-ax25.md
+++ b/docs/reference/kernel-ax25.md
@@ -29,10 +29,38 @@ Two consequences follow for a Debian-family machine:
   archive gap is the symptom the Kali campaign reported; the kernel is the
   cause, and it reaches machines whose archives are untouched.
 
-An out-of-tree module (`mod-orphan`) was suggested upstream when the
-subsystem was removed. **No distribution packages it**, and Hammunition
-never builds a kernel module of its own: a custom kernel is on the rejected
-list, and **D-024** carries only what a distribution already packages.
+## The out-of-tree module, measured
+
+The removed code did not vanish. The netdev maintainer who removed it
+published it the same week as an out-of-tree tree,
+<https://github.com/linux-netdev/mod-orphan> (created 2026-04-20,
+description: *"Linux networking modules removed from the kernel due to
+lack of maintenance and high bug count"*). Read on **2026-09-10**:
+
+| What | Measured |
+|---|---|
+| Contents | `net/ax25`, `net/netrom`, `net/rose`, `drivers/net/hamradio`, and the other orphans of the same merge — ATM, ISDN/mISDN, CAPI, Bluetooth CMTP, AppleTalk — under one `Kbuild` |
+| Build | `make` against `/lib/modules/$(uname -r)/build`; `make install` is `modules_install`. A compatibility header (`include/hamradio_compat.h`) is force-included, which is how it builds against a kernel whose headers no longer know it |
+| Licence | no top-level `LICENSE`; every source keeps its kernel SPDX header (`af_ax25.c`: GPL-2.0-or-later, Alan Cox GW4PTS and the G4KLX-era authors) |
+| Releases | **no tags, no releases, no README** |
+| Head commit | 2026-06-16, Jakub Kicinski, importing AppleTalk. The last AX.25-family change is 2026-06-01, two ROSE fixes by Bernard Pidoux |
+| Packaged by | **nobody.** Not in Debian (`packages.debian.org`, all suites), not in Ubuntu, not in the AUR, on the date above |
+| Builds against 7.1? | **Partly, and not as shipped.** On the maintainer's laptop (`7.1.1-76070101-generic`, its own `linux-headers`), the tree's `make` fails: `net/rose/rose_in.c` calls `sk_filter_trim_cap` with an argument count 7.1 no longer accepts, and `net/atm/clip.c` includes `net/atmclip.h`, which 7.1 does not ship. With `Kbuild` cut to `net/ax25`, `net/netrom` and `drivers/net/hamradio`, **`ax25.ko`, `netrom.ko` and all ten drivers — `mkiss`, `6pack`, `bpqether`, `baycom_*`, `hdlcdrv`, `scc`, `yam` — compile and link** with `vermagic: 7.1.1-76070101-generic`. Nothing was loaded; no `AF_AX25` socket was opened. A compile is not a test |
+
+So "add it back as a module" is technically possible on a 7.1 machine
+with its kernel headers installed, the maintainer of the removal is the one
+keeping the code buildable, and on the one machine it was tried the AX.25
+half built only after the `Kbuild` was edited to leave ROSE and ATM out. Hammunition still does not build it,
+for the reasons **D-041** and **D-045** record: a kernel module is the one
+artefact this project has said it will never build, it has to be rebuilt
+for every kernel the machine boots (a DKMS wrapper would be *our* packaging
+of code nobody else packages, the thing **D-024** exists to refuse), and
+`ax25-tools` is leaving the archives regardless — the module would bring
+back the sockets and not the tools. **What would change the answer** is a
+distribution packaging it, a `-dkms` package in Debian being the obvious
+shape: that is the review signal D-024 asks for, and the day it exists the
+`requires_kernel` refusal gains a third remedy. Until then the userspace
+path below is the packet core (**D-045**).
 
 ## What was measured
 
@@ -104,7 +132,7 @@ kernel stack and have no other mode:
 
 `ax25-tools`, `ax25-apps`, `ax25-xtools`, `ax25mail-utils`, `axmail`,
 `aprsdigi`, `fbb`, `linpac`, `uronode`, and `z8530-utils2` (whose `scc`
-driver left in the same merge; **Q-019** asks whether to retire it outright).
+driver left in the same merge; **retired** on that evidence, **D-045**).
 
 **Unaffected, and their manifests say so** — the userspace packet path,
 which is most of what an operator actually runs:
@@ -120,8 +148,9 @@ which is most of what an operator actually runs:
 So on a 7.1 kernel `packet` still installs a working Direwolf–pat–APRS
 station. What it cannot give you is a kernel port: no `axports`, no
 `kissattach`, no `ax25d`, no `listen`, no NET/ROM. The profile page and
-**D-008**'s packet-core statement both said "kernel AX.25 stack"; **Q-019**
-asks whether that statement should now read userspace-primary.
+**D-008**'s packet-core statement both said "kernel AX.25 stack"; since
+**D-045** both say userspace-primary, with the kernel stack the fuller
+station where the kernel carries it.
 
 ## Reproducing the measurement
 


### PR DESCRIPTION
Resolves **Q-019** as A and A, recorded as **D-045**. **Stacked on #54** (base `refresh-default`); GitHub retargets it to `main` when #54 merges.

- **`z8530-utils2` is retired**, `world_changed`, verdict tested by us: the `scc` driver left in merge 64edfa65 with the rest of `drivers/net/hamradio`, the cards are ISA and early PCI. The manifest stays so an operator who looks finds the reason.
- **D-008 amended: the packet core is userspace-primary.** Direwolf or QtSoundModem over KISS or AGW to pat, LinBPQ, YAAC and Xastir is the whole station on every kernel. The kernel stack is the fuller station where the kernel carries it, planned or deferred by name per D-041. The `packet` profile prose says so.
- **The out-of-tree module, measured** (the maintainer's question). `linux-netdev/mod-orphan`, published by the netdev maintainer who removed the subsystem: no tags, no releases, no README, no top-level licence file (sources keep GPL-2.0-or-later headers), head commit 2026-06-16, packaged by nobody (Debian, Ubuntu, AUR checked 2026-09-10). Its `make` fails against this laptop's 7.1.1 (`net/rose` signature change, `net/atm` missing header); with `Kbuild` cut to ax25, netrom and the hamradio drivers, `ax25.ko`, `netrom.ko` and all ten drivers — `scc` included — compile with a matching `vermagic`. **Nothing was loaded.** Not carried, per D-041 and D-024; **a distribution packaging it reopens the question**, and `kernel-ax25.md` records the condition.

Not done here, and worth naming: `not-carried.md` lists retirements from the dispositions index, and Blend-sourced units like this one are not in that index, so the retirement is visible on the package page and in D-045 but not on that page. `gen_programmer_class.py --check` still rewrites its output's date line (pre-existing; reverted before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
