### PR TITLE
ci: the arm64 target runs natively on ubuntu-24.04-arm instead of under QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,8 @@ jobs:
   # -------------------------------------------------------------------------
   targets:
     name: ${{ matrix.target.name }}
-    runs-on: ubuntu-latest
+    # The arm64 target names its own runner; everything else takes the default.
+    runs-on: ${{ matrix.target.runner || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -127,16 +128,20 @@ jobs:
           # Mint's own from its own repo so os-release reads linuxmint (Q-014).
           - { name: linuxmint-22.3, image: "linuxmintd/mint22.3-amd64:latest", platform: linux/amd64, identity_package: "base-files/zena" }
           # NOT Raspberry Pi OS — exercises aarch64 selectors only (Q-003).
-          - { name: debian-13-arm64, image: "debian:13",                    platform: linux/arm64 }
+          # Runs natively on GitHub's hosted arm64 runner (ubuntu-24.04-arm,
+          # free for public repositories; Podman 4.9.3 on its image, verified
+          # against actions/runner-images 2026-09-12). Under QEMU user-mode
+          # emulation on an x64 runner this job took 13-16 min against 1 min
+          # for every amd64 target, every run.
+          - { name: debian-13-arm64, image: "debian:13",                    platform: linux/arm64, runner: ubuntu-24.04-arm }
     steps:
       - uses: actions/checkout@v7
 
       # Rootless Podman, not Docker. Docker group membership is
       # root-equivalent host access; a security-adjacent project should not
-      # require it to run its own CI. See containers/targets.yaml.
-      - name: Set up QEMU (arm64 targets only)
-        if: matrix.target.platform == 'linux/arm64'
-        uses: docker/setup-qemu-action@v4
+      # require it to run its own CI. See containers/targets.yaml. No QEMU:
+      # the one foreign-architecture target runs on a runner of that
+      # architecture (above), so every build here is native.
 
       - name: Build target container
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,7 @@ head.
   first workflow was a real commit and two major versions stale, and one failed
   outright against the runner's newer CLI. `git ls-remote --tags` is the check.
   This repository's pins were resolved the same way (e5c8260): `checkout`,
-  `setup-python` and `setup-qemu-action` sit on their current majors as of
+  `setup-python` sit on their current majors as of
   2026-09-05, and the check is worth re-running whenever a workflow is touched.
 
 ## Conventions


### PR DESCRIPTION
The `debian-13-arm64` job ran the arm64 container under QEMU user-mode emulation on an x64 runner: **13 and 16 minutes** on the last two runs of `main`, against **1 minute** for every amd64 target, the long pole of every CI run.

GitHub's hosted arm64 runner (`ubuntu-24.04-arm`) is free for public repositories, and its image carries Podman 4.9.3, verified against `actions/runner-images` (`Ubuntu2404-Arm64-Readme.md`, image 20260907.118.1) on 2026-09-12 rather than from memory. The matrix entry names its runner, `runs-on` takes it or the default, and the QEMU step is removed; every build in the job is now native.

The run on this PR is the measurement: compare the arm64 job's duration here with the 13-16 minutes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
