### PR TITLE
catalog: morse-classic leaves the morse profile and declares its pipewire-alsa conflict (#61)

### DIFF
--- a/catalog/packages/morse-classic.yaml
+++ b/catalog/packages/morse-classic.yaml
@@ -14,6 +14,14 @@ summary: Text-to-Morse sounder and trainer, Eric Raymond's morse-classic
 # The apt package below is unchanged — Debian's name is Debian's to choose.
 categories: [cw, training]
 
+# Debian's `morse` Recommends pulseaudio; pulseaudio Conflicts pipewire-alsa.
+# On a PipeWire desktop apt resolves that by removing pipewire-alsa (measured:
+# `apt-get install -s morse` on Parrot 7.3 + KDE, 2026-09-12, #61). Declared
+# so the plan names this unit as the reason rather than the whole
+# transaction; the engine never removes it (D-022). Not a member of the
+# `morse` profile for the same reason.
+conflicts_with_repo_package: [pipewire-alsa]
+
 install:
   - install:
       method: apt

--- a/catalog/profiles/morse.yaml
+++ b/catalog/profiles/morse.yaml
@@ -11,7 +11,11 @@ packages:
   - cwcp
   - xcwcp
   - qrq
-  - morse-classic
+  # morse-classic is deliberately not a member: Debian's `morse` Recommends
+  # pulseaudio, which Conflicts with pipewire-alsa, so apt would remove a
+  # PipeWire desktop's audio routing to install it and the engine refuses the
+  # whole transaction (field laptop, Parrot 7.3 + KDE, 2026-09-12, #61). It
+  # stays installable by name; the dry run discloses the conflict.
   - ebook2cw
   - ebook2cwgui
   - cwwav
@@ -44,8 +48,12 @@ documentation:
   deliberately_excludes: >-
     fldigi, which decodes CW among twenty other modes and belongs in
     `digital-modes`. Contest loggers, which key CW through `cwdaemon` and live
-    in `logging`. Nothing here needs a radio: every trainer generates its own
-    audio, which is the point.
+    in `logging`. morse-classic, the long-lived Unix `morse` sounder: Debian's
+    package Recommends pulseaudio, which cannot coexist with pipewire-alsa, so
+    on a PipeWire desktop apt would remove your audio routing to install it
+    and the engine refuses the whole profile (#61). Install it by name if you
+    want it and are not on PipeWire. Nothing here needs a radio: every trainer
+    generates its own audio, which is the point.
   manual_configuration: >-
     **`cwdaemon` needs a keying interface and a group you are not in.** Serial
     keying needs `dialout`, parallel needs `lp`, and this profile adds neither

--- a/docs/packages/morse-classic.md
+++ b/docs/packages/morse-classic.md
@@ -24,6 +24,8 @@ A sound device for audio output; it can also print the dots and dashes, which is
 
 - apt: `morse`
 
+This displaces the distribution's own `pipewire-alsa` (**D-022**: coexist, disclose, never remove silently).
+
 ## Known problems
 
 Its teaching model is the plain speed-up approach rather than Koch, so as a learning tool it is weaker than aldo. As a converter and a sounder it is fine, and that is the use to keep it for.

--- a/docs/profiles/index.md
+++ b/docs/profiles/index.md
@@ -12,7 +12,7 @@ Named bundles of software that belong together. Flat tags with overlap, never ne
 | [electronics](electronics.md) | 1.0 | 11 | Bench electronics, instruments and device programmers |
 | [listening](listening.md) | 1.0 | 24 | Shortwave, utility and aeronautical listening — no licence, no transmitter |
 | [logging](logging.md) | 1.0 | 11 | Station logs, contest logging and award tracking |
-| [morse](morse.md) | 1.0 | 17 | Morse code — sending, decoding, learning, and licence exam practice |
+| [morse](morse.md) | 1.0 | 16 | Morse code — sending, decoding, learning, and licence exam practice |
 | [packet](packet.md) | 1.0 | 22 | AX.25, APRS, Winlink and the EMCOMM stack |
 | [propagation](propagation.md) | 1.0 | 12 | Band conditions, grey line, beacons and DX spotting |
 | [rf-research](rf-research.md) 🔒 | post-1.0 | 2 | Transmit-capable and interception-capable RF tooling — affirmative opt-in required |

--- a/docs/profiles/morse.md
+++ b/docs/profiles/morse.md
@@ -16,13 +16,13 @@ Four ways to learn — Koch method training, high-speed callsign drilling, the t
 
 Morse is a skill before it is a mode, and everything here is either practice, sending or copying. The licence exam tools are here because the Debian Hamradio Blend groups its `morse` and `training` tasks together and the same person wants both at the same stage — this is the profile someone installs while they are still learning. If the exam tools look out of place in something called `morse`, that is a fair reading and they are three packages you can remove.
 
-## Packages (17)
+## Packages (16)
 
-[`aldo`](../packages/aldo.md), [`cw`](../packages/cw.md), [`cwcp`](../packages/cwcp.md), [`xcwcp`](../packages/xcwcp.md), [`qrq`](../packages/qrq.md), [`morse-classic`](../packages/morse-classic.md), [`ebook2cw`](../packages/ebook2cw.md), [`ebook2cwgui`](../packages/ebook2cwgui.md), [`cwwav`](../packages/cwwav.md), [`cwdaemon`](../packages/cwdaemon.md), [`flwkey`](../packages/flwkey.md), [`morse2ascii`](../packages/morse2ascii.md), [`xdemorse`](../packages/xdemorse.md), [`ibp`](../packages/ibp.md), [`hamexam`](../packages/hamexam.md), [`canadian-ham-exam`](../packages/canadian-ham-exam.md), [`fccexam`](../packages/fccexam.md)
+[`aldo`](../packages/aldo.md), [`cw`](../packages/cw.md), [`cwcp`](../packages/cwcp.md), [`xcwcp`](../packages/xcwcp.md), [`qrq`](../packages/qrq.md), [`ebook2cw`](../packages/ebook2cw.md), [`ebook2cwgui`](../packages/ebook2cwgui.md), [`cwwav`](../packages/cwwav.md), [`cwdaemon`](../packages/cwdaemon.md), [`flwkey`](../packages/flwkey.md), [`morse2ascii`](../packages/morse2ascii.md), [`xdemorse`](../packages/xdemorse.md), [`ibp`](../packages/ibp.md), [`hamexam`](../packages/hamexam.md), [`canadian-ham-exam`](../packages/canadian-ham-exam.md), [`fccexam`](../packages/fccexam.md)
 
 ## What it deliberately excludes
 
-fldigi, which decodes CW among twenty other modes and belongs in `digital-modes`. Contest loggers, which key CW through `cwdaemon` and live in `logging`. Nothing here needs a radio: every trainer generates its own audio, which is the point.
+fldigi, which decodes CW among twenty other modes and belongs in `digital-modes`. Contest loggers, which key CW through `cwdaemon` and live in `logging`. morse-classic, the long-lived Unix `morse` sounder: Debian's package Recommends pulseaudio, which cannot coexist with pipewire-alsa, so on a PipeWire desktop apt would remove your audio routing to install it and the engine refuses the whole profile (#61). Install it by name if you want it and are not on PipeWire. Nothing here needs a radio: every trainer generates its own audio, which is the point.
 
 ## What you configure by hand afterward
 


### PR DESCRIPTION
Closes the field-laptop half of #61; the engine-side per-unit Recommends switch stays open there.

## What

- `catalog/profiles/morse.yaml`: `morse-classic` is no longer a member. Debian's `morse` Recommends `pulseaudio`, which Conflicts with `pipewire-alsa`; on a PipeWire desktop apt resolves that by removing the audio routing, and the engine correctly refuses the whole transaction. The reason is in the file and in the profile's `deliberately_excludes` prose.
- `catalog/packages/morse-classic.yaml`: declares `conflicts_with_repo_package: [pipewire-alsa]`, so a by-name install on such a machine refuses with the unit as the subject instead of naming all seventeen.
- `docs/profiles/` regenerated.

## Measured on the field laptop (Parrot 7.3, KDE, pipewire-alsa 1.4.9-1~bpo13+2)

```
$ hammunition install morse --dry-run --no-refresh
Packages (16):  ...  Commands (19):  Dry run: nothing above was executed.

$ hammunition install morse-classic --dry-run --no-refresh
1 problem block this transaction:
  morse-classic: installing it means apt removes installed distribution package(s): pipewire-alsa (1.4.9-1~bpo13+2) (a declared conflicts_with_repo_package that cannot coexist -- the archive package Breaks it)
```

Catalog data only; the declared-conflict plan path is already under test (`tests/test_displacement.py`). `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)