### PR TITLE
menus: place only desktop entries that exist on disk, and Parrot's replacement when the packaged one is gone (#64)

### DIFF
--- a/src/hammunition/cli/main.py
+++ b/src/hammunition/cli/main.py
@@ -1128,12 +1128,14 @@ def cmd_menus_apply(args: argparse.Namespace) -> int:
     import yaml
 
     from hammunition.menus import (
+        APPLICATIONS_DIR,
         Category,
         MenuPaths,
         MenuPrefixError,
         gnome_commands,
         menu_steps,
         place_installed_entries,
+        placement_summary,
         resolve_menu_prefix,
     )
 
@@ -1143,7 +1145,7 @@ def cmd_menus_apply(args: argparse.Namespace) -> int:
         Category(name=c["name"], summary=c["summary"], title=c.get("title", "")) for c in vocabulary
     ]
     manifests, _ = load_all(catalog_root)
-    placement = place_installed_entries(manifests.values())
+    placement = place_installed_entries(manifests.values(), applications_dir=APPLICATIONS_DIR)
 
     home = Path.home()
     paths = MenuPaths(
@@ -1169,8 +1171,10 @@ def cmd_menus_apply(args: argparse.Namespace) -> int:
     print(
         f"Menu tree: {len(categories)} categories, menu prefix {prefix!r}; "
         f"{len(placement.claimed)} desktop entries from installed catalog packages "
-        f"placed {placed} times by their manifests' categories (dpkg -L, this machine)"
+        f"placed {placed} times by their manifests' categories (dpkg -L, checked on disk)"
     )
+    for line in placement_summary(placement):
+        print(line)
     for step in steps:
         print(f"  {step.display()}")
         outcome = step.perform()

--- a/src/hammunition/menus.py
+++ b/src/hammunition/menus.py
@@ -168,6 +168,9 @@ class Placement:
 
 
 DesktopIdLister = Callable[[str], list[str]]
+"""Given an installed package name, the desktop-file ids it ships (empty if
+the package is not installed). Injected so the placement is testable without
+dpkg; :func:`dpkg_desktop_ids` is the real one."""
 
 APPLICATIONS_DIR = Path("/usr/share/applications")
 
@@ -221,9 +224,6 @@ def placement_summary(placement: Placement) -> list[str]:
         for package, shipped in placement.missing
     )
     return lines
-"""Given an installed package name, the desktop-file ids it ships (empty if
-the package is not installed). Injected so the placement is testable without
-dpkg; :func:`dpkg_desktop_ids` is the real one."""
 
 
 def dpkg_desktop_ids(package: str) -> list[str]:

--- a/src/hammunition/menus.py
+++ b/src/hammunition/menus.py
@@ -154,12 +154,73 @@ class Placement:
     by_category: dict[str, tuple[str, ...]]
     claimed: tuple[str, ...]
 
+    replaced: tuple[tuple[str, str, str], ...] = ()
+    """``(package, shipped id, id placed instead)`` — a packaged entry that is
+    gone from disk and was placed by the distribution's own copy (#64)."""
+
+    missing: tuple[tuple[str, str], ...] = ()
+    """``(package, shipped id)`` — gone from disk with nothing to place; the
+    summary names it rather than counting it as placed."""
+
     @classmethod
     def empty(cls) -> Placement:
         return cls(by_category={}, claimed=())
 
 
 DesktopIdLister = Callable[[str], list[str]]
+
+APPLICATIONS_DIR = Path("/usr/share/applications")
+
+
+@dataclass(frozen=True)
+class OnDisk:
+    """What a package's shipped desktop entries look like on *this* disk."""
+
+    ids: tuple[str, ...]
+    replaced: tuple[tuple[str, str], ...]
+    missing: tuple[str, ...]
+
+
+def on_disk(package: str, shipped: Iterable[str], applications_dir: Path) -> OnDisk:
+    """Reconcile ``dpkg -L``'s list with the files that exist.
+
+    ``dpkg -L`` is what the package *shipped*; it is not what is on disk after
+    a distribution has had its say. Parrot's ``parrot-menu`` runs from an apt
+    ``DPkg::Post-Invoke`` hook after every apt run and rewrites the launcher
+    set — removing the packaged ``chirp.desktop`` and writing
+    ``parrot-chirp.desktop`` in its place (field laptop, 2026-09-12, #64).
+    A ``<Filename>`` for a file that is not there places nothing and the
+    summary counted it anyway. So: an entry that exists is placed as shipped;
+    one that is gone is placed by ``parrot-<package>.desktop`` when that
+    exists; otherwise it is reported as missing, never counted.
+    """
+    ids: list[str] = []
+    replaced: list[tuple[str, str]] = []
+    missing: list[str] = []
+    replacement = f"parrot-{package}.desktop"
+    for desktop_id in shipped:
+        if (applications_dir / desktop_id).exists():
+            ids.append(desktop_id)
+        elif (applications_dir / replacement).exists():
+            if replacement not in ids:
+                ids.append(replacement)
+            replaced.append((desktop_id, replacement))
+        else:
+            missing.append(desktop_id)
+    return OnDisk(ids=tuple(ids), replaced=tuple(replaced), missing=tuple(missing))
+
+
+def placement_summary(placement: Placement) -> list[str]:
+    """The lines after the count, so the count cannot stand alone as a lie."""
+    lines = [
+        f"  {package}: {shipped} is not on disk; placed the distribution's {instead} instead"
+        for package, shipped, instead in placement.replaced
+    ]
+    lines.extend(
+        f"  {package}: {shipped} is not on disk and nothing replaces it -- not placed"
+        for package, shipped in placement.missing
+    )
+    return lines
 """Given an installed package name, the desktop-file ids it ships (empty if
 the package is not installed). Injected so the placement is testable without
 dpkg; :func:`dpkg_desktop_ids` is the real one."""
@@ -185,7 +246,10 @@ def dpkg_desktop_ids(package: str) -> list[str]:
 
 
 def place_installed_entries(
-    manifests: Iterable[PackageManifest], lister: DesktopIdLister = dpkg_desktop_ids
+    manifests: Iterable[PackageManifest],
+    lister: DesktopIdLister = dpkg_desktop_ids,
+    *,
+    applications_dir: Path | None = None,
 ) -> Placement:
     """Map each installed catalog package's own desktop entries to its
     manifest's categories.
@@ -195,9 +259,15 @@ def place_installed_entries(
     operator who installed ``fldigi`` with apt last year is served by the
     same submenu. A package that is not installed lists nothing, so the
     result describes this machine.
+
+    ``applications_dir`` is where the entries must actually exist; ``None``
+    trusts the lister (the fixtures' case). The CLI passes the real directory,
+    because ``dpkg -L`` alone was wrong on Parrot (#64, :func:`on_disk`).
     """
     by_category: dict[str, set[str]] = {}
     claimed: set[str] = set()
+    replaced: list[tuple[str, str, str]] = []
+    missing: list[tuple[str, str]] = []
     for manifest in manifests:
         for launcher in manifest.launchers:
             claimed.add(f"hammunition-{launcher.name}.desktop")
@@ -208,7 +278,16 @@ def place_installed_entries(
                 packages.update(p for p in method.packages if not p.startswith("-"))
             elif isinstance(method, BinaryInstall) and method.deb_package:
                 packages.add(method.deb_package)
-        ids = {desktop_id for package in sorted(packages) for desktop_id in lister(package)}
+        ids: set[str] = set()
+        for package in sorted(packages):
+            shipped = lister(package)
+            if applications_dir is None:
+                ids.update(shipped)
+                continue
+            found = on_disk(package, shipped, applications_dir)
+            ids.update(found.ids)
+            replaced.extend((package, was, now) for was, now in found.replaced)
+            missing.extend((package, was) for was in found.missing)
         if not ids:
             continue
         claimed.update(ids)
@@ -217,6 +296,8 @@ def place_installed_entries(
     return Placement(
         by_category={k: tuple(sorted(v)) for k, v in sorted(by_category.items())},
         claimed=tuple(sorted(claimed)),
+        replaced=tuple(replaced),
+        missing=tuple(missing),
     )
 
 

--- a/tests/test_menus.py
+++ b/tests/test_menus.py
@@ -288,3 +288,97 @@ def test_no_root_menu_at_all_is_a_refusal(tmp_path: Path) -> None:
 
 def test_a_bare_root_menu_means_the_empty_prefix(tmp_path: Path) -> None:
     assert resolve_menu_prefix(None, None, [_roots(tmp_path, "")]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Issue #64: Parrot's `parrot-menu` rewrites the launcher set from an apt
+# DPkg::Post-Invoke hook after every apt run, removing the packaged entry and
+# writing `parrot-<package>.desktop` in its place. `dpkg -L` still lists the
+# shipped file, so placing by that list put two filenames in the Plasma tree
+# that did not exist on the field laptop (chirp, wireshark; 2026-09-12).
+# ---------------------------------------------------------------------------
+
+
+def _entry(directory: Path, name: str) -> None:
+    (directory / name).write_text("[Desktop Entry]\nType=Application\n")
+
+
+def test_a_shipped_entry_absent_on_disk_is_placed_by_the_distribution_replacement(
+    tmp_path: Path,
+) -> None:
+    from hammunition.menus import on_disk
+
+    _entry(tmp_path, "parrot-chirp.desktop")
+    found = on_disk("chirp", ["chirp.desktop"], tmp_path)
+    assert found.ids == ("parrot-chirp.desktop",)
+    assert found.replaced == (("chirp.desktop", "parrot-chirp.desktop"),)
+    assert found.missing == ()
+
+
+def test_a_shipped_entry_absent_with_no_replacement_is_reported_not_placed(
+    tmp_path: Path,
+) -> None:
+    from hammunition.menus import on_disk
+
+    found = on_disk("chirp", ["chirp.desktop"], tmp_path)
+    assert found.ids == ()
+    assert found.replaced == ()
+    assert found.missing == ("chirp.desktop",)
+
+
+def test_entries_present_on_disk_pass_through_unchanged(tmp_path: Path) -> None:
+    from hammunition.menus import on_disk
+
+    _entry(tmp_path, "flrig.desktop")
+    _entry(tmp_path, "parrot-flrig.desktop")  # a replacement is irrelevant when the original exists
+    found = on_disk("flrig", ["flrig.desktop"], tmp_path)
+    assert found.ids == ("flrig.desktop",)
+    assert found.replaced == ()
+    assert found.missing == ()
+
+
+def test_placement_places_the_replacement_and_carries_what_happened(tmp_path: Path) -> None:
+    _entry(tmp_path, "parrot-chirp.desktop")
+    _entry(tmp_path, "flrig.desktop")
+    manifests = [
+        _manifest("chirp", ["rig-control"]),
+        _manifest("flrig", ["rig-control"]),
+        _manifest("gone", ["sdr"]),
+    ]
+    placement = place_installed_entries(
+        manifests,
+        _lister(
+            {
+                "chirp": ["chirp.desktop"],
+                "flrig": ["flrig.desktop"],
+                "gone": ["gone.desktop"],
+            }
+        ),
+        applications_dir=tmp_path,
+    )
+    assert placement.by_category == {"rig-control": ("flrig.desktop", "parrot-chirp.desktop")}
+    assert placement.claimed == ("flrig.desktop", "parrot-chirp.desktop")
+    assert placement.replaced == (("chirp", "chirp.desktop", "parrot-chirp.desktop"),)
+    assert placement.missing == (("gone", "gone.desktop"),)
+
+
+def test_the_summary_names_replacements_and_missing_entries_so_a_count_cannot_lie() -> None:
+    from hammunition.menus import placement_summary
+
+    placement = Placement(
+        by_category={"rig-control": ("flrig.desktop", "parrot-chirp.desktop")},
+        claimed=("flrig.desktop", "parrot-chirp.desktop"),
+        replaced=(("chirp", "chirp.desktop", "parrot-chirp.desktop"),),
+        missing=(("gone", "gone.desktop"),),
+    )
+    lines = placement_summary(placement)
+    assert any("chirp.desktop" in line and "parrot-chirp.desktop" in line for line in lines)
+    assert any("gone.desktop" in line and "not placed" in line for line in lines)
+
+
+def test_a_placement_without_a_disk_check_reports_nothing_replaced_or_missing() -> None:
+    placement = place_installed_entries(
+        [_manifest("flrig", ["rig-control"])], _lister({"flrig": ["flrig.desktop"]})
+    )
+    assert placement.replaced == ()
+    assert placement.missing == ()


### PR DESCRIPTION
Closes #64.

## What

`dpkg -L` lists what a package shipped, not what is on disk after Parrot's `parrot-menu` hook has run: it rewrites the launcher set from an apt `DPkg::Post-Invoke` after every apt run, removing the packaged `chirp.desktop` and `org.wireshark.Wireshark.desktop` and writing `parrot-chirp.desktop` / `parrot-wireshark.desktop` (no `HamRadio` category). The tree placed the dead filenames and the summary counted them; CHIRP was not under *Ham Radio* on the primary target.

- `menus.py::on_disk()` reconciles the shipped list with the directory: present → placed as shipped; gone with `parrot-<package>.desktop` present → placed by that; gone otherwise → reported as missing, never counted.
- `Placement` gains `replaced` and `missing`; `placement_summary()` prints them under the count.
- `place_installed_entries(..., applications_dir=)` — `None` trusts the lister (fixtures); the CLI passes `/usr/share/applications`.

## Measured on the field laptop after the fix

```
Menu tree: 27 categories, menu prefix 'plasma-'; 19 desktop entries from installed catalog packages placed 18 times by their manifests' categories (dpkg -L, checked on disk)
  chirp: chirp.desktop is not on disk; placed the distribution's parrot-chirp.desktop instead
  wireshark: org.wireshark.Wireshark.desktop is not on disk; placed the distribution's parrot-wireshark.desktop instead
```

`grep -c` on the written `.menu`: 6 references to the `parrot-*` entries, 0 to the dead ones. Tests first (six, all failed for the missing pieces), then the code; `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)