### PR TITLE
plan: a vendor .deb this engine installed is already installed while dpkg still holds it (#63)

### DIFF
--- a/src/hammunition/cli/main.py
+++ b/src/hammunition/cli/main.py
@@ -171,11 +171,15 @@ def _plan_state(planned: PlannedPackage) -> str:
     package the block names is present. A source or binary unit's apt list is
     its build dependencies, or nothing at all, so for those it was saying
     "already installed" one line above a build -- sdrangel's .deb block on
-    the Ubuntu 26.04 VM read that way (2026-09-02).
+    the Ubuntu 26.04 VM read that way (2026-09-02). The one carve-out is a
+    vendor .deb the plan has attributed to this engine and dpkg still holds
+    (#63): nothing is planned for it, and the line says so.
     """
     method = planned.block.install
     if isinstance(method, AptInstall):
         return "already installed" if not planned.outstanding else "will install"
+    if isinstance(method, BinaryInstall) and planned.deb_installed:
+        return "already installed"
     if isinstance(method, SourceInstall | GitInstall):
         return "will build"
     if isinstance(method, VenvInstall):
@@ -722,6 +726,9 @@ def cmd_install(args: argparse.Namespace) -> int:
             # The running kernel is a fact about this machine, not the target
             # (one Pop!_OS 24.04 VM has AX.25 under 7.0.11 and not under 7.1.5).
             kernel=KernelProbe.detect(),
+            # Read-only here: whether a vendor .deb already on the machine is
+            # ours to skip (#63). The same log is written to after the plan.
+            log=TransactionLog(owner=user or None),
         )
     except PlanError as exc:
         print(str(exc), file=sys.stderr)

--- a/src/hammunition/execute.py
+++ b/src/hammunition/execute.py
@@ -325,6 +325,11 @@ def commands_for(
                 )
             builds.extend(git.steps(planned.manifest, block))
         elif isinstance(block, BinaryInstall):
+            if planned.deb_installed:
+                # The plan attributed this .deb to us and dpkg still holds it
+                # (#63): the fetch would be a cache hit and the root apt-get
+                # a no-op. Nothing to do is nothing planned.
+                continue
             if binary is None:
                 raise BackendError(
                     f"{planned.name} installs a prebuilt artifact and no binary backend "
@@ -399,6 +404,7 @@ def commands_for(
         if binary is not None
         and isinstance(planned.block.install, BinaryInstall)
         and planned.block.install.format == "deb"
+        and not planned.deb_installed  # ours and still installed: nothing to ask (#63)
     ]
 
     # The refresh is the default (D-044): six of fifteen profiles on a

--- a/src/hammunition/plan.py
+++ b/src/hammunition/plan.py
@@ -70,6 +70,8 @@ from hammunition.manifest.schema import (
     SourceInstall,
     Status,
 )
+from hammunition.state.log import TransactionLog
+from hammunition.state.uninstall import deb_attributed
 from hammunition.station import Station
 
 __all__ = [
@@ -196,6 +198,12 @@ class PlannedPackage:
     .deb that would collide at the dpkg file level is refused before anything
     runs -- that split is decided at planning, from the same probe as
     everything else."""
+
+    deb_installed: bool = False
+    """A vendor .deb unit whose package dpkg still holds AND whose digest the
+    transaction log attributes to this engine (#63). Nothing is planned for
+    it. Installed but not ours is left to apt, which no-ops or upgrades as
+    it sees fit; ours but removed by hand is installed again."""
 
     @property
     def name(self) -> str:
@@ -836,6 +844,19 @@ def _plan_repos(
     return additions
 
 
+def _deb_installed(
+    block: InstallBlock, states: Mapping[str, AptPackageState], log: TransactionLog | None
+) -> bool:
+    """dpkg holds the package now, and the log says this digest put it there."""
+    method = block.install
+    if not isinstance(method, BinaryInstall) or method.format != "deb" or not method.deb_package:
+        return False
+    state = states.get(method.deb_package)
+    if state is None or not state.is_installed or log is None:
+        return False
+    return deb_attributed(log, sha256=method.artifact.sha256, deb_package=method.deb_package)
+
+
 def resolve(
     names: Sequence[str],
     *,
@@ -848,6 +869,7 @@ def resolve(
     station: Station | None = None,
     repos: AptRepoBackend | None = None,
     kernel: KernelProbe | None = None,
+    log: TransactionLog | None = None,
 ) -> InstallPlan:
     """Build a complete plan, or raise :class:`PlanError` listing every blocker.
 
@@ -859,6 +881,10 @@ def resolve(
     ``kernel`` is the running kernel's module tree, consulted only for units
     that declare ``requires_kernel``; ``None`` means it was not read, which is
     disclosed on those units rather than assumed either way.
+
+    ``log`` is the transaction log, consulted only to attribute an installed
+    vendor .deb to this engine (#63); ``None`` means no unit can be already
+    installed that way, which is the conservative reading.
     """
     blockers: list[Blocker] = []
     deferrals: list[Deferral] = []
@@ -990,13 +1016,23 @@ def resolve(
         {c for manifest, _, _, _ in resolved for c in manifest.conflicts_with_repo_package}
     )
     all_apt = sorted({p for _, _, packages, _ in resolved for p in packages})
+    # Vendor .deb package names ride the same probe: whether each is installed
+    # NOW is half of "already installed" for that unit (#63). They are not in
+    # `all_apt`, so the no-candidate check never asks the archive for them.
+    all_debs = sorted(
+        {
+            block.install.deb_package
+            for _, block, _, _ in resolved
+            if isinstance(block.install, BinaryInstall) and block.install.deb_package
+        }
+    )
     states = {}
     notes: list[str] = []
     # `or all_conflicts`: a unit with nothing to apt-install (a pure vendor
     # .deb) still needs the probe to know whether its declared conflicts are
     # installed -- the gate that skipped it left the wsjtx-improved refusal
     # untested until this line existed.
-    if all_apt or all_conflicts:
+    if all_apt or all_conflicts or all_debs:
         if not apt.lists_populated():
             if refresh:
                 # The refresh (the default, D-044) puts `apt-get update` at the
@@ -1026,7 +1062,7 @@ def resolve(
                     )
                 )
         else:
-            states = apt.probe(sorted({*all_apt, *all_conflicts}))
+            states = apt.probe(sorted({*all_apt, *all_conflicts, *all_debs}))
             for manifest, block, packages, _ in resolved:
                 missing = [p for p in packages if p not in states or not states[p].known]
                 own = (
@@ -1360,6 +1396,7 @@ def resolve(
                 for c in manifest.conflicts_with_repo_package
                 if c in states and states[c].is_installed
             ),
+            deb_installed=_deb_installed(block, states, log),
         )
         for manifest, block, packages, build_only in resolved
     )

--- a/tests/test_binary_backend.py
+++ b/tests/test_binary_backend.py
@@ -389,3 +389,27 @@ def test_the_binary_backend_passes_the_operator_to_the_tree_install(tmp_path: Pa
     last = backend.steps(manifest, block)[-1]
     assert isinstance(last, Command)
     assert last.argv[:5] == ("chown", "-R", "-h", "--", "alice:")
+
+
+def test_a_deb_this_engine_already_installed_plans_no_fetch_and_no_install(tmp_path: Path) -> None:
+    """Issue #63: the plan has decided the vendor .deb is already installed
+    (dpkg still has it, and the transaction log attributes this digest to
+    us). The executor must then emit nothing for it -- not a cached fetch,
+    not a root apt-get that apt turns into 'already the newest version'."""
+    from hammunition.backends import AptBackend
+    from hammunition.execute import commands_for
+
+    manifest = _manifest("https://example.invalid/x.deb", "0" * 64, "deb", binaries=[])
+    plan = InstallPlan(
+        target=TARGET,
+        packages=(
+            PlannedPackage(
+                manifest=manifest,
+                block=manifest.install[0],
+                apt_packages=(),
+                deb_installed=True,
+            ),
+        ),
+    )
+    steps = commands_for(plan, AptBackend(RecordingRunner()), binary=_backend(tmp_path))
+    assert steps == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1267,3 +1267,45 @@ def test_main_line_buffers_stdout_so_a_redirected_install_log_is_not_empty_until
             proc.stdin.write("\n")
             proc.stdin.close()
         proc.wait(timeout=10)
+
+
+def test_plan_state_says_already_installed_for_a_deb_this_engine_installed() -> None:
+    """Issue #63: the deb carve-out to "already installed is apt's answer and
+    only apt's". A vendor .deb the log attributes to us and dpkg still holds
+    is planned as nothing, and the summary line must say so rather than
+    'will fetch+install' above an empty command list."""
+    manifest = PackageManifest.model_validate(
+        {
+            "name": "hill",
+            "version": "1.0",
+            "summary": "A vendor .deb",
+            "categories": ["station"],
+            "install": [
+                {
+                    "install": {
+                        "method": "binary",
+                        "artifact": {"url": "https://example.invalid/h.deb", "sha256": "a" * 64},
+                        "format": "deb",
+                        "deb_package": "hill",
+                    }
+                }
+            ],
+            "update": {"probe": {"method": "none"}},
+            "documentation": {
+                "what_it_does": "Stands in for hammunition-hill.",
+                "why_you_want_it": "To prove the summary line follows the plan.",
+                "upstream_url": "https://example.invalid/",
+            },
+        }
+    )
+    plan = InstallPlan(
+        target=Target(distro="debian", version="13", arch="x86_64"),
+        packages=(
+            PlannedPackage(
+                manifest=manifest, block=manifest.install[0], apt_packages=(), deb_installed=True
+            ),
+        ),
+    )
+    text = "\n".join(render_plan(plan, (), euid=1000))
+    assert "already installed" in text
+    assert "will fetch+install" not in text

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -100,6 +100,7 @@ def _resolve(tmp_path: Path, names: list[str], **kwargs: Any) -> Any:
         apt=kwargs.pop("apt", None) or _apt(tmp_path, known),
         user=kwargs.pop("user", "operator"),
         kernel=kwargs.pop("kernel", None),
+        log=kwargs.pop("log", None),
     )
 
 
@@ -754,3 +755,93 @@ def test_a_compiled_build_pulls_its_toolchain_into_the_apt_set(tmp_path: Path) -
     plan = _resolve(tmp_path, ["makeunit"], catalog={"makeunit": make}, known=known)
     assert "cmake" not in plan.apt_to_install
     assert "build-essential" in plan.apt_to_install
+
+
+# ---------------------------------------------------------------------------
+# Issue #63: a vendor .deb this engine installed is "already installed" on the
+# next run, the way its apt siblings are -- field laptop, 2026-09-12, where
+# `install station --dry-run` re-planned hammunition-hill's fetch and a root
+# apt-get install minutes after both had completed and verified.
+# ---------------------------------------------------------------------------
+
+DEB_SHA = "a" * 64
+
+
+def _deb_manifest(name: str = "hill") -> PackageManifest:
+    return _manifest(
+        name=name,
+        install=[
+            {
+                "install": {
+                    "method": "binary",
+                    "artifact": {"url": f"https://example.invalid/{name}.deb", "sha256": DEB_SHA},
+                    "format": "deb",
+                    "deb_package": name,
+                }
+            }
+        ],
+    )
+
+
+def _log_that_installed(tmp_path: Path, sha256: str) -> Any:
+    from hammunition.state.log import TransactionLog
+
+    log = TransactionLog(path=tmp_path / "transactions.jsonl")
+    log.append(
+        {
+            "event": "action_end",
+            "kind": "install-deb",
+            "outcome": f"installed {sha256}-hill_1.0.0_all.deb through apt",
+        }
+    )
+    return log
+
+
+def test_a_vendor_deb_this_engine_installed_is_already_installed_while_dpkg_still_has_it(
+    tmp_path: Path,
+) -> None:
+    plan = _resolve(
+        tmp_path,
+        ["hill"],
+        catalog={"hill": _deb_manifest()},
+        known={"hill": "1.0.0"},
+        log=_log_that_installed(tmp_path, DEB_SHA),
+    )
+    [planned] = plan.packages
+    assert planned.deb_installed is True
+
+
+def test_a_vendor_deb_installed_by_someone_else_is_planned_again(tmp_path: Path) -> None:
+    """Installed, but the log never saw this digest go in: the operator's own
+    copy. Leave it to apt, which no-ops or upgrades as it sees fit (D-022)."""
+    from hammunition.state.log import TransactionLog
+
+    plan = _resolve(
+        tmp_path,
+        ["hill"],
+        catalog={"hill": _deb_manifest()},
+        known={"hill": "1.0.0"},
+        log=TransactionLog(path=tmp_path / "empty.jsonl"),
+    )
+    [planned] = plan.packages
+    assert planned.deb_installed is False
+
+
+def test_a_vendor_deb_removed_by_hand_is_planned_again_whatever_the_log_says(
+    tmp_path: Path,
+) -> None:
+    plan = _resolve(
+        tmp_path,
+        ["hill"],
+        catalog={"hill": _deb_manifest()},
+        known={"hill": None},
+        log=_log_that_installed(tmp_path, DEB_SHA),
+    )
+    [planned] = plan.packages
+    assert planned.deb_installed is False
+
+
+def test_a_vendor_deb_with_no_log_to_consult_is_planned_again(tmp_path: Path) -> None:
+    plan = _resolve(tmp_path, ["hill"], catalog={"hill": _deb_manifest()}, known={"hill": "1.0.0"})
+    [planned] = plan.packages
+    assert planned.deb_installed is False


### PR DESCRIPTION
Closes #63.

## What

A vendor `.deb` unit is `already installed` — nothing fetched, nothing simulated, no root apt-get — when **both** hold: dpkg has `deb_package` installed now, and the transaction log attributes the manifest's digest to this engine (`state.uninstall.deb_attributed`, the same replay `uninstall` trusts). Installed but not ours stays with apt, which no-ops or upgrades as it sees fit (D-022). Ours but removed by hand is installed again.

- `plan.py`: `resolve(..., log=)`; .deb package names ride the existing apt probe and are never put through the no-candidate check; `PlannedPackage.deb_installed`.
- `execute.py`: no build steps and no pre-flight simulate for such a unit.
- `cli/main.py`: `_plan_state` renders `already installed` for it — the one carve-out to "already installed is apt's answer and only apt's" — and `cmd_install` passes the log.

## Tests, written first and watched fail

`test_plan.py`: ours-and-present → `deb_installed`; installed by someone else → planned again; removed by hand → planned again; no log → planned again. `test_binary_backend.py`: the executor emits nothing. `test_cli.py`: the summary line.

## Measured on the field laptop

```
$ hammunition install station --dry-run --no-refresh
  hammunition-hill             already installed  [profile station]
Commands (0):
$ hammunition install wsjtx-improved --dry-run --no-refresh     # never installed here
  wsjtx-improved               will fetch+install [requested]
Commands (3):
```

`make check` exit 0: 1743 passed, 21 skipped. The git/source/venv halves of the same gap stay queued as before; they need a marker to consult, not a dpkg lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)