### PR TITLE
docs: Hammunition is the one-stop shop for everything radio — nothing is out of scope, and what cannot work yet is a documented gap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,17 @@ Debian, Ubuntu, Kali, Raspberry Pi OS.
 
 Binary: `hammunition`. Python package: `hammunition`.
 
+**It is a one-stop shop for everything radio** (maintainer, 2026-09-12). Nothing
+radio is too odd or out of scope — ham, SDR, packet, satellites, mesh, RFID,
+cellular, IMSI-catcher detection, whatever comes next. What varies is *how* a
+thing is carried, never *whether*: transmit-capable and interception-capable
+tooling sits behind a consent gate (**D-021**, **D-034** — the line is transmit,
+not topic), a thing nobody has measured is marked unmeasured, and a thing that
+cannot work yet is carried as a documented gap with the reason and the route to
+it named (Rayhunter on the laptop's own modem, issue #69, is the model). The
+project is broad on purpose, so problems are expected; the rule is that each one
+is written down and worked out, never dropped because it was awkward.
+
 ## Document authority
 
 `docs/DECISIONS.md` is authoritative. Where this file or `docs/DESIGN.md`

--- a/docs/why-hammunition.md
+++ b/docs/why-hammunition.md
@@ -76,6 +76,17 @@ needs configured. A Python engine reads those files and does the work. The catal
 is plain data — you can read it, diff it, validate it, or write your own tool that
 consumes it without asking us.
 
+It is meant to be **the one place for everything radio**. Ham radio, SDR,
+packet and Winlink, satellites, mesh networking, RFID, cellular, detecting the
+people surveilling cellular — if it is radio, it belongs here, and nothing is
+too odd to ask for. What changes from one thing to the next is how it is
+carried: the tools that can transmit or intercept sit behind a consent gate
+that tells you what they can do before you say yes; the things nobody here has
+run yet say so; and the things that cannot work yet are still in the record,
+with the reason they cannot and the route to making them work. A project this
+broad will hit problems. The commitment is that every one gets written down and
+worked through rather than quietly dropped.
+
 ---
 
 ## What makes it different


### PR DESCRIPTION
The maintainer's framing of the project, written where the project defines itself: CLAUDE.md's opening section and `docs/why-hammunition.md`'s *What Hammunition is*.

Nothing radio is too odd or out of scope. What varies is how a thing is carried: consent gates for transmit- and interception-capable tooling (D-021, D-034), unmeasured marked as unmeasured, and what cannot work yet carried as a documented gap with the reason and the route named — Rayhunter on the laptop's own modem (#69) is the model. A broad project's problems are written down and worked out, never dropped.

Docs only; link check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)