### PR TITLE
binary: a single prebuilt executable is installed by a privileged install command, not an in-process copy

### DIFF
--- a/src/hammunition/backends/binary.py
+++ b/src/hammunition/backends/binary.py
@@ -39,7 +39,6 @@ refused by name so the gap stays visible (D-014).
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -226,9 +225,21 @@ class BinaryBackend:
         path = fetched.get("path")
         if path is None:  # pragma: no cover
             raise BackendError("the executable was not fetched before the install step")
-        target.parent.mkdir(parents=True, exist_ok=True)
-        # Copy rather than move: the fetch cache is content-addressed and shared,
-        # and moving out of it would make the next run re-download.
-        target.write_bytes(path.read_bytes())
-        os.chmod(target, 0o755)
+        # `install -D` copies (the fetch cache is content-addressed and shared;
+        # moving out of it would make the next run re-download), creates the
+        # parent, and sets the mode -- and it runs through the runner, which
+        # elevates it for a root-owned prefix. The in-process copy this
+        # replaced wrote /usr/local/bin/paracon as the operator and failed
+        # with EACCES 165 steps into the field laptop's first full install
+        # (2026-09-12); every other install form already went through a
+        # privileged command.
+        result = self.runner.run(
+            Command(
+                argv=("install", "-D", "-m", "0755", str(path), str(target)),
+                description=f"Install {target.name} as {target}",
+                requires_root=needs_root_for(self.prefix),
+            )
+        )
+        if not result.ok:
+            raise BackendError(f"could not install {target}: {result.stderr.strip()[:400]}")
         return f"installed {target} (mode 0755)"

--- a/tests/test_binary_backend.py
+++ b/tests/test_binary_backend.py
@@ -413,3 +413,56 @@ def test_a_deb_this_engine_already_installed_plans_no_fetch_and_no_install(tmp_p
     )
     steps = commands_for(plan, AptBackend(RecordingRunner()), binary=_backend(tmp_path))
     assert steps == []
+
+
+# ---------------------------------------------------------------------------
+# Field laptop, 2026-09-12: the full-catalog install failed at paracon --
+# `[install-binary] /usr/local/bin/paracon: Permission denied`. A single
+# prebuilt executable was copied into the prefix in-process, as the operator;
+# every other install form goes through a privileged command. 165 steps in,
+# the transaction stopped there.
+# ---------------------------------------------------------------------------
+
+
+def test_a_single_executable_into_a_root_prefix_is_installed_by_a_privileged_command(
+    tmp_path: Path,
+) -> None:
+    from hammunition.backends import RecordingRunner as _RR
+
+    runner = _RR()
+    backend = BinaryBackend(
+        fetcher=Fetcher(tmp_path / "cache"),
+        runner=runner,
+        build_root=tmp_path / "build",
+        prefix=Path("/usr/local"),
+    )
+    fetched_file = tmp_path / "paracon"
+    fetched_file.write_bytes(b"#!/bin/sh\n")
+    backend._install_executable({"path": fetched_file}, Path("/usr/local/bin/paracon"))
+    command = runner.commands[-1]
+    assert command.argv == (
+        "install",
+        "-D",
+        "-m",
+        "0755",
+        str(fetched_file),
+        "/usr/local/bin/paracon",
+    )
+    assert command.requires_root, "a root-owned prefix is written by a privileged command"
+
+
+def test_a_single_executable_into_a_user_prefix_lands_executable(tmp_path: Path) -> None:
+    from hammunition.backends.base import SubprocessRunner
+
+    backend = BinaryBackend(
+        fetcher=Fetcher(tmp_path / "cache"),
+        runner=SubprocessRunner(),
+        build_root=tmp_path / "build",
+        prefix=tmp_path / "prefix",
+    )
+    fetched_file = tmp_path / "tool"
+    fetched_file.write_bytes(b"#!/bin/sh\necho ok\n")
+    target = tmp_path / "prefix" / "bin" / "tool"
+    outcome = backend._install_executable({"path": fetched_file}, target)
+    assert target.exists() and target.stat().st_mode & 0o755 == 0o755
+    assert str(target) in outcome


### PR DESCRIPTION
Found by the field laptop's first full-catalog install, 165 steps in:

```
  $ [install-binary] /usr/local/bin/paracon
Failed: [install-binary] /usr/local/bin/paracon
[Errno 13] Permission denied: '/usr/local/bin/paracon'
```

The `executable` binary format copied the file into the prefix in-process as the operator. Every other install form already went through a privileged command. Now `install -D -m 0755 <fetched> <target>` runs through the runner, elevated for a root-owned prefix, exactly as the .deb path runs its apt-get.

Test first: the root-prefix case reproduced the `PermissionError`; it now pins the argv and `requires_root`. The user-prefix case lands a 0755 file through a real runner. `make check` exit 0.

Blocks resuming the laptop install; merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)