### PR TITLE
venv: build a unit's virtualenv with the resolved interpreter, not the engine venv's own symlink

### DIFF
--- a/src/hammunition/backends/venv.py
+++ b/src/hammunition/backends/venv.py
@@ -114,7 +114,12 @@ class VenvBackend:
                 # built on 3.10 cannot install a modern hash-pinned tree
                 # (numpy 2.5 dropped 3.10). Found deploying to a Pop 22.04
                 # laptop, where nanovna-saver's numpy pin had no 3.10 wheel.
-                argv=(sys.executable, "-m", "venv", str(venv)),
+                # Resolved, not the engine venv's own symlink: on the field
+                # laptop (2026-09-12) the engine ran from a worktree's .venv
+                # that was removed mid-transaction, and 118 steps later this
+                # spawned `<gone>/.venv/bin/python3 -m venv` and the run died.
+                # The symlink pointed at /usr/bin/python3.13 the whole time.
+                argv=(str(Path(sys.executable).resolve()), "-m", "venv", str(venv)),
                 description=f"Create (or reuse) {manifest.name}'s virtualenv",
                 requires_root=False,
             ),

--- a/tests/test_venv_backend.py
+++ b/tests/test_venv_backend.py
@@ -66,7 +66,7 @@ def test_the_steps_are_staged_venv_pip_wrapper_in_that_order(tmp_path: Path) -> 
     assert kinds[0] == "requirements"
     # The venv is built with the engine's own interpreter (>=3.11 guaranteed),
     # never bare python3 which is 3.10 on Ubuntu/Pop 22.04.
-    assert kinds[1] == (sys.executable, "-m", "venv")
+    assert kinds[1] == (str(Path(sys.executable).resolve()), "-m", "venv")
     assert "--require-hashes" in steps[2].argv  # type: ignore[union-attr]
     assert kinds[3] == "wrapper"
     assert all(not getattr(s, "requires_root", False) for s in steps), (
@@ -190,7 +190,7 @@ def test_payload_plans_fetch_extract_build_and_tree_install(tmp_path: Path) -> N
     kinds = [s.kind if isinstance(s, Action) else s.argv[0] for s in steps]
     assert kinds[:3] == [
         "requirements",
-        sys.executable,
+        str(Path(sys.executable).resolve()),
         str(tmp_path / "venvs" / "hybridunit" / "bin" / "pip"),
     ]
     assert "fetch" in kinds and "extract" in kinds


### PR DESCRIPTION
From the field laptop's resume run: the engine was started from a worktree's `.venv`, the worktree was removed while the transaction ran, and 118 commands later the venv backend spawned `<gone>/.venv/bin/python3 -m venv` and the run failed. The symlink resolved to `/usr/bin/python3.13` all along.

`Path(sys.executable).resolve()` before spawning. The two test assertions that pinned the symlink path were changed first and failed; `make check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)