### PR TITLE
execute: a build already installed at its pin is already installed — effect on disk plus the log's attribution (D-051)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3690,3 +3690,57 @@ entry should open. Whether every terminal entry *makes sense* to open
 entries; it is revisited only with a measurement of what operators
 actually open. COSMIC stays unmeasured. The GNOME app-folder is unchanged:
 it cannot nest, and one folder populated by `HamRadio` is what it can do.
+
+## D-051 — A build already installed at its pin is already installed: the effect on disk plus the log's attribution, never one without the other
+
+**Date:** 2026-09-12. **Status:** accepted (maintainer: "focus on delivering
+more features"; this was the gap that had just cost him two rebuild rounds).
+**Depends on:** D-031 (the effect, not the exit status), D-004 (the
+transaction log is the record), the #67 rule for vendor .debs, which this
+generalises. **Amends:** the Parrot VM page's finding 4 (2026-08-29), which
+queued exactly this as engine work.
+
+**What was measured.** The field laptop's first full-catalog install
+(2026-09-12) ran 21 source and git builds, then failed at paracon (#72). The
+resume rebuilt all 21, then failed at a virtualenv step (#74). The second
+resume rebuilt them a third time. apt units reported *already installed*
+throughout; every build unit reported *will build*, because
+`_plan_state`'s rule was "already installed is apt's answer and only apt's"
+and the executor had no way to know a build had happened.
+
+**Rule.** `execute.already_built()` names the units whose build steps are
+skipped, and it requires both halves:
+
+1. **The effect is present.** Every declared `binaries` entry is executable
+   at `<prefix>/bin/<install_as>`; where the block installs a tree, its
+   `tree_marker` exists under the tree destination. A unit declaring neither
+   cannot be checked and is never decided here -- it rebuilds.
+2. **The log attributes it, at this pin.** A `verify-pin` or `extract`
+   action whose detail names *exactly this build directory* -- the
+   backends' `layout()` puts the ref or the digest prefix in that
+   directory's name, so a moved ref or a re-pinned artifact is a different
+   path and does not match -- followed, in the same transaction, by a
+   `transaction_end` with `verified: true` that confirmed one of this unit's
+   checks. A transaction that failed after the build steps attributes
+   nothing: the paracon run's 21 builds are on disk and were still rebuilt
+   once more, correctly, because nothing ever verified them.
+
+Both halves come from what already existed: the effect checks are
+`verify_effects`'s own probes, and the log entries are the ones every build
+already writes. No log format change; the laptop's log from before this
+rule attributes builds the moment a verified transaction has covered them.
+
+A skipped unit keeps its launcher and config steps -- those are cheap,
+idempotent, and the reason a profile is re-run in the first place. The plan
+line reads *already installed*, the executor plans no fetch, unpack, build
+or install for it, and `verify_effects` still checks the binary at the end,
+so a unit deleted by hand between plan and run is caught there.
+
+**Not decided here.** apt has `already_installed`; a .deb has #67; venv and
+node units keep pip's and npm's own cheap idempotency. A unit whose pin
+moved rebuilds, and that is the point: *at its pin*, not *at some pin*.
+
+**Measured after the rule** (to be recorded on
+`docs/reference/bench-verification-5430.md` once the laptop's second
+resume ends with a verified transaction): a dry run of the profiles that
+carry the 21 builds should plan launcher steps only.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -77,6 +77,13 @@ operator reads a disclosure before deciding, rather than while being asked.
 
 ### `hammunition install NAME... [--dry-run] [--yes] [--no-refresh] [--user NAME] [--callsign CALL] [--grid-square LOC] [--node-alias NAME]`
 
+**A re-run rebuilds nothing it has already built** (**D-051**): a source, git
+or prebuilt-archive unit whose binaries are on the machine *and* whose build
+the transaction log attributes to this engine at the manifest's current pin
+reads `already installed`, and only its launcher and config steps are
+planned. A build whose transaction never verified -- it failed after the
+build steps -- is rebuilt, because nothing confirmed it.
+
 Names may be packages or profiles, mixed freely.
 
 | Flag | Effect |

--- a/src/hammunition/cli/main.py
+++ b/src/hammunition/cli/main.py
@@ -65,6 +65,7 @@ from hammunition.consent import (
 from hammunition.distro import DetectionError, Target
 from hammunition.execute import (
     Step,
+    already_built,
     artifact_removal_steps,
     commands_for,
     execute,
@@ -164,7 +165,7 @@ def load_all(
 # ---------------------------------------------------------------------------
 
 
-def _plan_state(planned: PlannedPackage) -> str:
+def _plan_state(planned: PlannedPackage, built: frozenset[str] = frozenset()) -> str:
     """What the plan will do to this unit, in two words.
 
     "already installed" is apt's answer and only apt's: it means every apt
@@ -180,6 +181,8 @@ def _plan_state(planned: PlannedPackage) -> str:
         return "already installed" if not planned.outstanding else "will install"
     if isinstance(method, BinaryInstall) and planned.deb_installed:
         return "already installed"
+    if planned.name in built:
+        return "already installed"  # built at this pin, D-051
     if isinstance(method, SourceInstall | GitInstall):
         return "will build"
     if isinstance(method, VenvInstall):
@@ -196,6 +199,7 @@ def render_plan(
     euid: int,
     log_destination: Path | None = None,
     hands_log_to: str | None = None,
+    built: frozenset[str] = frozenset(),
 ) -> list[str]:
     """The complete account of what will happen. Printed for every run.
 
@@ -218,7 +222,7 @@ def render_plan(
         lines.append(f"Packages ({len(plan.packages)}):")
         for planned in plan.packages:
             why = ", ".join(planned.requested_by)
-            lines.append(f"  {planned.name:<28} {_plan_state(planned):<18} [{why}]")
+            lines.append(f"  {planned.name:<28} {_plan_state(planned, built):<18} [{why}]")
             for apt_package in planned.apt_packages:
                 mark = "+" if apt_package in planned.outstanding else "="
                 # A build dependency is installed like any other apt package but
@@ -712,6 +716,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     # before resolve; its cache is the operator's, like every other fetch.
     repos = AptRepoBackend(owner=user or None)
 
+    read_log = TransactionLog(owner=user or None)  # read-only until the plan is confirmed
     try:
         plan = resolve(
             [*args.names, *suggested],
@@ -728,7 +733,7 @@ def cmd_install(args: argparse.Namespace) -> int:
             kernel=KernelProbe.detect(),
             # Read-only here: whether a vendor .deb already on the machine is
             # ours to skip (#63). The same log is written to after the plan.
-            log=TransactionLog(owner=user or None),
+            log=read_log,
         )
     except PlanError as exc:
         print(str(exc), file=sys.stderr)
@@ -781,10 +786,16 @@ def cmd_install(args: argparse.Namespace) -> int:
         bin_dir=user_bin_dir(user or None),
     )
     data = DataBackend(fetcher=source.fetcher, prefix=source.prefix)
+    # D-051: a build present on disk that the log attributes to this engine
+    # at the manifest's pin is already installed; its build steps are skipped.
+    built = already_built(
+        plan, log=read_log, prefix=source.prefix, source=source, git=git, binary=binary
+    )
     commands = commands_for(
         plan,
         apt,
         refresh=args.refresh,
+        skip_builds=built,
         source=source,
         git=git,
         binary=binary,
@@ -813,6 +824,7 @@ def cmd_install(args: argparse.Namespace) -> int:
         plan,
         commands,
         euid=euid,
+        built=built,
         log_destination=log_destination,
         hands_log_to=hands_log_to,
     ):

--- a/src/hammunition/execute.py
+++ b/src/hammunition/execute.py
@@ -267,6 +267,82 @@ def config_steps(plan: InstallPlan, *, staging_root: Path | None = None) -> list
     return steps
 
 
+def already_built(
+    plan: InstallPlan,
+    *,
+    log: TransactionLog | None,
+    prefix: Path,
+    source: SourceBackend | None = None,
+    git: GitBackend | None = None,
+    binary: BinaryBackend | None = None,
+) -> frozenset[str]:
+    """Units whose build is already installed at the manifest's pin. D-051.
+
+    Two halves, both required, mirroring the vendor-.deb rule (#67):
+
+    * **The effect is present.** Every declared binary is executable at
+      ``<prefix>/bin/<install_as>``; where a tree is installed, its marker
+      exists under the tree destination. A unit that declares neither cannot
+      be checked and is never decided here.
+    * **The log attributes it, at this pin.** A ``verify-pin`` or ``extract``
+      action for *exactly this build directory* -- whose name encodes the
+      pin, so a moved ref or a re-pinned digest is a different path --
+      followed in the same transaction by a verified ``transaction_end``
+      that confirmed one of this unit's checks. A transaction that failed
+      after the build steps (paracon, 2026-09-12) attributes nothing.
+
+    apt has its own answer and a .deb has #67's; venv and node units keep
+    their cheap idempotency (``pip`` over a satisfied venv verifies and
+    exits). Everything else was rebuilt on every re-run until this existed:
+    the field laptop rebuilt 21 units twice in one afternoon.
+    """
+    if log is None:
+        return frozenset()
+    wanted: dict[str, str] = {}
+    for planned in plan.packages:
+        method = planned.block.install
+        if isinstance(method, SourceInstall) and source is not None:
+            src = source.layout(planned.manifest, method).src
+        elif isinstance(method, GitInstall) and git is not None:
+            src = git.layout(planned.manifest, method).src
+        elif isinstance(method, BinaryInstall) and method.format != "deb" and binary is not None:
+            src = binary.layout(planned.manifest, method).src
+        else:
+            continue
+        present: list[bool] = []
+        for declared in planned.manifest.binaries:
+            path = prefix / "bin" / declared.install_as
+            present.append(path.is_file() and os.access(path, os.X_OK))
+        marker = _tree_marker(planned.block)
+        if marker is not None:
+            present.append((tree_destination(prefix, planned.name) / marker).exists())
+        if present and all(present):
+            wanted[planned.name] = str(src)
+    if not wanted:
+        return frozenset()
+    attributed: set[str] = set()
+    pending: set[str] = set()
+    for entry in log.read():
+        event = entry.get("event")
+        if event == "transaction_begin":
+            pending.clear()
+        elif event == "action_end" and entry.get("kind") in ("verify-pin", "extract"):
+            detail = str(entry.get("detail", ""))
+            pending.update(name for name, src in wanted.items() if src in detail)
+        elif event == "transaction_end":
+            if entry.get("verified") is True:
+                confirmed = {
+                    str(check.get("subject", "")).split(":", 1)[0]
+                    for check in entry.get("checks", ())
+                    if isinstance(check, dict) and check.get("confirmed")
+                }
+                attributed.update(name for name in pending if name in confirmed)
+            pending.clear()
+        elif event == "transaction_failed":
+            pending.clear()
+    return frozenset(attributed)
+
+
 def commands_for(
     plan: InstallPlan,
     apt: AptBackend,
@@ -283,6 +359,7 @@ def commands_for(
     config_staging: Path | None = None,
     launcher_bin: Path | None = None,
     launcher_applications: Path | None = None,
+    skip_builds: frozenset[str] = frozenset(),
 ) -> list[Step]:
     """Every step this plan implies, in the order it will run.
 
@@ -310,6 +387,12 @@ def commands_for(
     builds: list[Step] = []
     for planned in plan.packages:
         block = planned.block.install
+        if planned.name in skip_builds and isinstance(
+            block, SourceInstall | GitInstall | BinaryInstall
+        ):
+            # Already built at this pin (D-051, already_built): no fetch, no
+            # build, no install. Its launchers and config still run below.
+            continue
         if isinstance(block, SourceInstall):
             if source is None:
                 raise BackendError(

--- a/tests/test_already_built.py
+++ b/tests/test_already_built.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""A build already installed at its pin is already installed. D-051.
+
+Field laptop, 2026-09-12: the full-catalog install failed twice after its
+builds (paracon's EACCES, then a removed worktree), and each resume rebuilt
+every source unit -- 21 builds, twice -- because the engine knew "already
+installed" only for apt packages and, since #67, vendor .debs. The Parrot VM
+page had queued this as engine work on 2026-08-29.
+
+The rule mirrors #67: the *effect* must be present (every declared binary at
+<prefix>/bin/<install_as>, the tree marker where a tree is installed) AND the
+transaction log must attribute it to this engine at the manifest's current
+pin -- a verify-pin or extract action for exactly this build directory, whose
+path encodes the pin, followed by a verified transaction end that confirmed
+this unit's checks. Either half alone is a guess.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from hammunition.backends import GitBackend, RecordingRunner  # noqa: E402
+from hammunition.distro import Target  # noqa: E402
+from hammunition.execute import already_built  # noqa: E402
+from hammunition.manifest.schema import GitInstall, PackageManifest  # noqa: E402
+from hammunition.plan import InstallPlan, PlannedPackage  # noqa: E402
+from hammunition.state.log import TransactionLog  # noqa: E402
+
+TARGET = Target(distro="debian", version="13", arch="x86_64")
+
+
+def _git_manifest(ref: str = "v1.0") -> PackageManifest:
+    return PackageManifest.model_validate(
+        {
+            "name": "thing",
+            "version": "1.0",
+            "summary": "Fixture",
+            "categories": ["sdr"],
+            "install": [
+                {
+                    "install": {
+                        "method": "git",
+                        "repo": "https://example.invalid/thing",
+                        "ref": ref,
+                        "build_system": "cmake",
+                    }
+                }
+            ],
+            "binaries": [{"produced": "thing", "install_as": "thing"}],
+            "update": {"probe": {"method": "none"}},
+            "documentation": {
+                "what_it_does": "Stands in for a git build.",
+                "why_you_want_it": "To prove a finished build is not redone.",
+                "upstream_url": "https://example.invalid/",
+            },
+        }
+    )
+
+
+def _git_block(manifest: PackageManifest) -> GitInstall:
+    block = manifest.install[0].install
+    assert isinstance(block, GitInstall)
+    return block
+
+
+def _plan(manifest: PackageManifest) -> InstallPlan:
+    return InstallPlan(
+        target=TARGET,
+        packages=(PlannedPackage(manifest=manifest, block=manifest.install[0], apt_packages=()),),
+    )
+
+
+def _log(tmp_path: Path, entries: list[dict[str, Any]]) -> TransactionLog:
+    log = TransactionLog(path=tmp_path / "transactions.jsonl")
+    for entry in entries:
+        log.append(entry)
+    return log
+
+
+def _built_entries(src: Path, unit: str = "thing") -> list[dict[str, Any]]:
+    return [
+        {"event": "transaction_begin", "version": 2, "packages": [unit]},
+        {
+            "event": "action_end",
+            "kind": "verify-pin",
+            "detail": f"git rev-parse HEAD in {src} must be v1.0",
+            "outcome": "tag v1.0 resolved to 0123abcd",
+        },
+        {
+            "event": "transaction_end",
+            "version": 2,
+            "verified": True,
+            "checks": [{"kind": "binary", "subject": f"{unit}:thing", "confirmed": True}],
+        },
+    ]
+
+
+def _setup(tmp_path: Path, *, binary_present: bool = True) -> tuple[GitBackend, Path]:
+    prefix = tmp_path / "prefix"
+    if binary_present:
+        (prefix / "bin").mkdir(parents=True)
+        (prefix / "bin" / "thing").write_text("#!/bin/sh\n")
+        (prefix / "bin" / "thing").chmod(0o755)
+    git = GitBackend(runner=RecordingRunner(), build_root=tmp_path / "build", prefix=prefix, jobs=2)
+    return git, prefix
+
+
+def test_a_build_present_on_disk_and_attributed_at_its_pin_is_already_built(
+    tmp_path: Path,
+) -> None:
+    m = _git_manifest()
+    git, prefix = _setup(tmp_path)
+    src = git.layout(m, _git_block(m)).src
+    log = _log(tmp_path, _built_entries(src))
+    assert already_built(_plan(m), log=log, prefix=prefix, git=git) == frozenset({"thing"})
+
+
+def test_a_build_whose_binary_is_gone_is_not_already_built(tmp_path: Path) -> None:
+    m = _git_manifest()
+    git, prefix = _setup(tmp_path, binary_present=False)
+    src = git.layout(m, _git_block(m)).src
+    log = _log(tmp_path, _built_entries(src))
+    assert already_built(_plan(m), log=log, prefix=prefix, git=git) == frozenset()
+
+
+def test_a_build_whose_transaction_never_verified_is_not_already_built(tmp_path: Path) -> None:
+    """The paracon run: the build steps completed and the transaction
+    failed after them. Present on disk, never confirmed -- rebuild."""
+    m = _git_manifest()
+    git, prefix = _setup(tmp_path)
+    src = git.layout(m, _git_block(m)).src
+    entries = [*_built_entries(src)[:-1], {"event": "transaction_failed"}]
+    log = _log(tmp_path, entries)
+    assert already_built(_plan(m), log=log, prefix=prefix, git=git) == frozenset()
+
+
+def test_a_build_at_a_previous_pin_is_not_already_built(tmp_path: Path) -> None:
+    """The manifest moved to v1.1; the log attributes v1.0's build directory.
+    The binary on disk is the old one -- rebuild."""
+    old = _git_manifest("v1.0")
+    git, prefix = _setup(tmp_path)
+    old_src = git.layout(old, _git_block(old)).src
+    log = _log(tmp_path, _built_entries(old_src))
+    new = _git_manifest("v1.1")
+    assert already_built(_plan(new), log=log, prefix=prefix, git=git) == frozenset()
+
+
+def test_apt_and_deb_units_are_never_decided_here(tmp_path: Path) -> None:
+    """apt has its own answer (already_installed) and a .deb has #67's."""
+    apt_unit = PackageManifest.model_validate(
+        {
+            "name": "aptish",
+            "version": "1",
+            "summary": "Fixture",
+            "categories": ["sdr"],
+            "install": [{"install": {"method": "apt", "packages": ["aptish"]}}],
+            "update": {"probe": {"method": "none"}},
+            "documentation": {
+                "what_it_does": "Stands in for an apt package.",
+                "why_you_want_it": "To prove apt units are not decided here.",
+                "upstream_url": "https://example.invalid/",
+            },
+        }
+    )
+    git, prefix = _setup(tmp_path)
+    log = _log(tmp_path, [])
+    assert already_built(_plan(apt_unit), log=log, prefix=prefix, git=git) == frozenset()
+
+
+def test_without_a_log_nothing_is_already_built(tmp_path: Path) -> None:
+    m = _git_manifest()
+    git, prefix = _setup(tmp_path)
+    assert already_built(_plan(m), log=None, prefix=prefix, git=git) == frozenset()
+
+
+def test_the_executor_plans_no_build_steps_for_an_already_built_unit(tmp_path: Path) -> None:
+    from hammunition.backends import AptBackend
+    from hammunition.execute import commands_for
+
+    m = _git_manifest()
+    git, _ = _setup(tmp_path)
+    steps = commands_for(
+        _plan(m), AptBackend(RecordingRunner()), git=git, skip_builds=frozenset({"thing"})
+    )
+    assert steps == []
+    assert commands_for(_plan(m), AptBackend(RecordingRunner()), git=git) != []
+
+
+def test_the_plan_renders_an_already_built_unit_as_already_installed() -> None:
+    from hammunition.cli.main import render_plan
+
+    m = _git_manifest()
+    text = "\n".join(render_plan(_plan(m), (), euid=1000, built=frozenset({"thing"})))
+    assert "already installed" in text and "will build" not in text


### PR DESCRIPTION
Closes the already-installed-at-pin gap the Parrot VM page queued on 2026-08-29, after it cost the field laptop two full rebuild rounds today.

## Rule (D-051)

`execute.already_built()` skips a source, git or prebuilt-archive unit's build steps when **both** hold:

1. **The effect is present** — every declared binary executable at `<prefix>/bin/<install_as>`, a tree's marker present. Neither declared → never decided here.
2. **The log attributes it at this pin** — a `verify-pin`/`extract` action naming *exactly this build directory* (its name encodes the ref or digest, so a moved pin does not match), followed in the same transaction by a verified `transaction_end` confirming one of the unit's checks. A transaction that failed after the builds attributes nothing.

Launchers and config still run for skipped units; `verify_effects` still checks the binary at the end. No log format change.

## Tests, written first

Present-and-attributed → skipped; binary gone; transaction never verified (the paracon run); pin moved; apt and .deb units never decided here; no log; the executor emits nothing; the plan renders `already installed`.

`make check` exit 0: 1794 passed. The on-laptop measurement (a dry run of the built profiles planning launcher steps only) goes on the bench page once the running resume ends with a verified transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)