### PR TITLE
catalog: declare the binaries five builds install, so the effect check and a re-run can see them

### DIFF
--- a/catalog/packages/acarsdec.yaml
+++ b/catalog/packages/acarsdec.yaml
@@ -47,6 +47,14 @@ install:
       input source or an output format, so the summary is the thing to read
       rather than the exit status (D-031).
 
+# What the install rule puts on PATH, measured on the field laptop after the
+# full install (2026-09-12). Declared so the post-run effect check has
+# something to confirm and a re-run can see the build is already installed
+# at its pin (D-051); without it the unit rebuilt on every run.
+binaries:
+  - produced: acarsdec
+    install_as: acarsdec
+
 update:
   probe:
     method: github_tags

--- a/catalog/packages/dumphfdl.yaml
+++ b/catalog/packages/dumphfdl.yaml
@@ -66,6 +66,14 @@ install:
       from every target's apt, measured in containers. It is a source build, and
       that correction is recorded in dragonos-tier1-inventory.md.
 
+# What the install rule puts on PATH, measured on the field laptop after the
+# full install (2026-09-12). Declared so the post-run effect check has
+# something to confirm and a re-run can see the build is already installed
+# at its pin (D-051); without it the unit rebuilt on every run.
+binaries:
+  - produced: src/dumphfdl
+    install_as: dumphfdl
+
 update:
   probe:
     method: github_tags

--- a/catalog/packages/dumpvdl2.yaml
+++ b/catalog/packages/dumpvdl2.yaml
@@ -48,6 +48,14 @@ install:
       a capability without failing the build, so the cmake summary is the thing
       to check.
 
+# What the install rule puts on PATH, measured on the field laptop after the
+# full install (2026-09-12). Declared so the post-run effect check has
+# something to confirm and a re-run can see the build is already installed
+# at its pin (D-051); without it the unit rebuilt on every run.
+binaries:
+  - produced: src/dumpvdl2
+    install_as: dumpvdl2
+
 update:
   probe:
     method: github_tags

--- a/catalog/packages/proxmark3.yaml
+++ b/catalog/packages/proxmark3.yaml
@@ -51,6 +51,16 @@ install:
       backend, which is NOT WRITTEN -- see the engine status in README.md. The
       manifest is data and is correct today; nothing can act on it yet.
 
+# What the install rule puts on PATH, measured on the field laptop after the
+# full install (2026-09-12). Declared so the post-run effect check has
+# something to confirm and a re-run can see the build is already installed
+# at its pin (D-051); without it the unit rebuilt on every run.
+binaries:
+  - produced: client/proxmark3
+    install_as: proxmark3
+  - produced: pm3
+    install_as: pm3
+
 update:
   probe:
     method: github_tags

--- a/catalog/packages/rtlsdr-airband.yaml
+++ b/catalog/packages/rtlsdr-airband.yaml
@@ -41,6 +41,14 @@ install:
       distribution package instead; if a V4 dongle is the target, see the
       `rtl_sdr_v4` disposition, which is a separate decision from this build.
 
+# What the install rule puts on PATH, measured on the field laptop after the
+# full install (2026-09-12). Declared so the post-run effect check has
+# something to confirm and a re-run can see the build is already installed
+# at its pin (D-051); without it the unit rebuilt on every run.
+binaries:
+  - produced: rtl_airband
+    install_as: rtl_airband
+
 update:
   probe:
     method: github_tags

--- a/docs/packages/acarsdec.md
+++ b/docs/packages/acarsdec.md
@@ -28,6 +28,10 @@ An SDR (RTL-SDR, Airspy or anything SoapySDR reaches) and a VHF antenna. Install
   - build dependencies: `build-essential`, `cmake`, `pkg-config`, `librtlsdr-dev`, `libsoapysdr-dev`, `libairspy-dev`, `libsndfile1-dev`, `libasound2-dev`, `libcjson-dev`
   - Upstream autodetects each optional library and prints a summary of what was enabled. Missing one does not fail the build — it silently removes an input source or an output format, so the summary is the thing to read rather than the exit status (D-031).
 
+Binaries this produces:
+
+- `acarsdec`
+
 ## Known problems
 
 Optional libraries are autodetected and their absence is silent: without libsndfile there is no file input, without libasound no ALSA input, without libcjson no JSON output. The build prints which were enabled. SDRplay support is deliberately not built here because the vendor API cannot be fetched non-interactively and therefore cannot be verified against a checksum.

--- a/docs/packages/dumphfdl.md
+++ b/docs/packages/dumphfdl.md
@@ -28,6 +28,10 @@ An HF-capable SDR — an RTL dongle alone will not do, since HFDL lives between 
   - build dependencies: `patch`, `build-essential`, `cmake`, `pkg-config`, `libglib2.0-dev`, `libconfig++-dev`, `libliquid-dev`, `libfftw3-dev`, `libsoapysdr-dev`, `libsqlite3-dev`
   - `SCOPE.md` listed dumphfdl as DragonOS Tier 1 — "apt-installable or an upstream .deb". It is neither: absent from Debian stable and unstable and from every target's apt, measured in containers. It is a source build, and that correction is recorded in dragonos-tier1-inventory.md.
 
+Binaries this produces:
+
+- `src/dumphfdl`
+
 ## Known problems
 
 liquid-dsp is a hard requirement and the version matters — upstream needs 1.3.0 or newer. Skywave ships dumphfdl in its ISO but its published installer scripts do not build it at all, which is one of the clearest signs that those scripts and that image have diverged.

--- a/docs/packages/dumpvdl2.md
+++ b/docs/packages/dumpvdl2.md
@@ -29,6 +29,10 @@ An SDR and a VHF antenna. libacars must be installed first for application decod
   - build dependencies: `build-essential`, `cmake`, `git`, `pkg-config`, `libglib2.0-dev`, `librtlsdr-dev`, `libsoapysdr-dev`, `libsqlite3-dev`, `libprotobuf-c-dev`
   - Upstream lists librtlsdr, SoapySDR, sqlite3 and protobuf-c as optional and autodetects each. As with the rest of this cluster, a missing one removes a capability without failing the build, so the cmake summary is the thing to check.
 
+Binaries this produces:
+
+- `src/dumpvdl2`
+
 ## Known problems
 
 Skywave ships the archived `vdlm2dec` instead of this, and its published `decoders.sh` carries an `update_dumpvdl2` function with a missing leading slash in a `cd` path, so that build runs in whatever directory the previous job left. Neither affects us — we carry the maintained decoder and have no `cd` to get wrong — but it is why the version Skywave documents and the one it ships differ.

--- a/docs/packages/proxmark3.md
+++ b/docs/packages/proxmark3.md
@@ -28,6 +28,11 @@ Proxmark3 hardware, membership of `dialout` and `plugdev`, and firmware matching
   - build dependencies: `build-essential`, `pkg-config`, `libreadline-dev`, `libpcsclite-dev`, `libssl-dev`, `libbz2-dev`, `liblz4-dev`, `libbluetooth-dev`, `libpython3-dev`, `libqt5svg5-dev`, `qtbase5-dev`, `gcc-arm-none-eabi`, `libnewlib-dev`
   - Pinned to the same release Kali packages so a client built here and a client installed there are the same version. This needs the source-from-git backend, which is NOT WRITTEN -- see the engine status in README.md. The manifest is data and is correct today; nothing can act on it yet.
 
+Binaries this produces:
+
+- `client/proxmark3`
+- `pm3`
+
 ## Known problems
 
 Client and firmware are version-locked and a mismatch produces confusing behaviour rather than a clear error. Several incompatible hardware generations share the name -- the original design, RDV4 and RDV5 -- and they differ in USB identifier and in what the firmware supports. Packaged only on Kali; the other three targets need a source build, and the ARM cross-compiler in the build dependencies is required even to build the client, because the client ships the firmware images it flashes.

--- a/docs/packages/rtlsdr-airband.md
+++ b/docs/packages/rtlsdr-airband.md
@@ -26,6 +26,10 @@ An SDR and an antenna for the band of interest. A configuration file is required
   - build dependencies: `build-essential`, `cmake`, `pkg-config`, `librtlsdr-dev`, `libsoapysdr-dev`, `libairspy-dev`, `libmp3lame-dev`, `libshout3-dev`, `libconfig-dev`, `libfftw3-dev`, `libusb-1.0-0-dev`, `libpulse-dev`
   - Upstream's container build compiles rtl-sdr-blog from source for RTL-SDR V4 support rather than using the distribution's librtlsdr. We take the distribution package instead; if a V4 dongle is the target, see the `rtl_sdr_v4` disposition, which is a separate decision from this build.
 
+Binaries this produces:
+
+- `rtl_airband`
+
 ## Known problems
 
 CPU use scales with the number of channels and the sample rate; on a Pi this is the limiting factor rather than the radio. Upstream builds against rtl-sdr-blog rather than the distribution's librtlsdr in order to support RTL-SDR V4 dongles — with the distribution library a V4 may not tune correctly.


### PR DESCRIPTION
Follow-up to #75's measurement on the field laptop: seven of the 21 units still planned as `will build` after a verified full install declared no `binaries` and no tree marker, so the engine had no effect to check — and `verify_effects` had had nothing to confirm for them either (the class issue #27 named).

Declares what the install rule actually put under `/usr/local/bin`, measured on the laptop: proxmark3 (`proxmark3`, `pm3`), rtlsdr-airband (`rtl_airband`), acarsdec, dumphfdl, dumpvdl2. Their next verified run confirms those checks, and every run after that plans nothing for them. libacars is a library and declares nothing; openhamclock is a node unit and outside the rule by design.

Catalog data plus regenerated pages; `make check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)