### PR TITLE
Launchers round 2: nine multi-tool units get an entry, ten record why they have none; wrappers named like their tool no longer call themselves

### DIFF
--- a/catalog/packages/ampr-ripd.yaml
+++ b/catalog/packages/ampr-ripd.yaml
@@ -11,6 +11,8 @@ install:
       method: apt
       packages: [ampr-ripd]
 
+# D-050: no menu entry, deliberately. The unit's only executable is
+# /usr/sbin/ampr-ripd, a daemon systemd runs; there is nothing to open.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/aprsdigi.yaml
+++ b/catalog/packages/aprsdigi.yaml
@@ -14,6 +14,9 @@ install:
       method: apt
       packages: [aprsdigi]
 
+# D-050: no menu entry, deliberately. Both executables are under /usr/sbin:
+# aprsdigi is a digipeater daemon and aprsmon its monitor, run on a
+# configured port from a shell or a unit file, not opened from a menu.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/aprx.yaml
+++ b/catalog/packages/aprx.yaml
@@ -11,6 +11,8 @@ install:
       method: apt
       packages: [aprx]
 
+# D-050: no menu entry, deliberately. /usr/sbin/aprx is a daemon systemd
+# runs and aprx-stat reads its counters; neither is an application to open.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/ax25-apps.yaml
+++ b/catalog/packages/ax25-apps.yaml
@@ -16,6 +16,15 @@ install:
       method: apt
       packages: [ax25-apps]
 
+# D-050: the unit ships several command-line tools and no desktop entry, so
+# `menus apply` could not pick one without guessing. This is the pick: the
+# entry an operator opens first. Terminal launchers hold their window.
+launchers:
+  - name: axlisten
+    exec: axlisten -a
+    terminal: true
+    # What is on the air: raw AX.25 frames on every configured port, outgoing as well as incoming
+
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/ax25-tools.yaml
+++ b/catalog/packages/ax25-tools.yaml
@@ -12,6 +12,15 @@ install:
       method: apt
       packages: [ax25-tools]
 
+# D-050: the unit ships several command-line tools and no desktop entry, so
+# `menus apply` could not pick one without guessing. This is the pick: the
+# entry an operator opens first. Terminal launchers hold their window.
+launchers:
+  - name: mheard
+    exec: mheard
+    terminal: true
+    # Who has been heard: the stations mheardd logged on each port. The rest of the unit is per-port configuration (kissattach, axparms, sethdlc) typed at a shell, not opened from a menu
+
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/ax25mail-utils.yaml
+++ b/catalog/packages/ax25mail-utils.yaml
@@ -14,6 +14,9 @@ install:
       method: apt
       packages: [ax25mail-utils]
 
+# D-050: no menu entry, deliberately. Forwarding tools (axgetlist, axgetmail,
+# axgetmsg and the rest) that run against a configured BBS session from
+# ax25d or a schedule; none opens usefully on its own.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/axmail.yaml
+++ b/catalog/packages/axmail.yaml
@@ -14,6 +14,8 @@ install:
       method: apt
       packages: [axmail]
 
+# D-050: no menu entry, deliberately. /usr/sbin/axmail is what the node
+# spawns for a connecting caller; the operator never opens it.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/bladerf.yaml
+++ b/catalog/packages/bladerf.yaml
@@ -11,6 +11,15 @@ install:
       method: apt
       packages: [bladerf]
 
+# D-050: the unit ships several command-line tools and no desktop entry, so
+# `menus apply` could not pick one without guessing. This is the pick: the
+# entry an operator opens first. Terminal launchers hold their window.
+launchers:
+  - name: bladeRF-cli
+    exec: bladeRF-cli -i
+    terminal: true
+    # The bladeRF at the keyboard: an interactive session; `probe` and `info` inside it answer whether the board is seen before any FPGA is loaded
+
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/cwdaemon.yaml
+++ b/catalog/packages/cwdaemon.yaml
@@ -18,6 +18,8 @@ install:
       tracker and Kali's archive on 2026-09-04; this is a packaging bug, not
       a dead upstream, and `tlf`'s keying still expects it.
 
+# D-050: no menu entry, deliberately. /usr/sbin/cwdaemon is a network
+# service other programs (tlf) key through, not an application to open.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/flashrom.yaml
+++ b/catalog/packages/flashrom.yaml
@@ -11,6 +11,9 @@ install:
       method: apt
       packages: [flashrom]
 
+# D-050: no menu entry, deliberately. /usr/sbin/flashrom needs a programmer
+# argument, a chip on the bus and usually root; opened bare it can only
+# print usage, and a flasher is not a thing to reach for from a menu.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/gpsd.yaml
+++ b/catalog/packages/gpsd.yaml
@@ -11,6 +11,15 @@ install:
       method: apt
       packages: [gpsd]
 
+# D-050: the unit ships several command-line tools and no desktop entry, so
+# `menus apply` could not pick one without guessing. This is the pick: the
+# entry an operator opens first. Terminal launchers hold their window.
+launchers:
+  - name: gpsctl
+    exec: gpsctl
+    terminal: true
+    # Which receiver gpsd owns: with no arguments gpsctl asks the running daemon and names the device, or reports that none is connected. The live fix itself is cgps, gpsd-tools' launcher
+
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/gr-gsm.yaml
+++ b/catalog/packages/gr-gsm.yaml
@@ -18,6 +18,15 @@ install:
 
 depends: [gnuradio]
 
+# D-050: the unit ships several command-line tools and no desktop entry, so
+# `menus apply` could not pick one without guessing. This is the pick: the
+# entry an operator opens first. Terminal launchers hold their window.
+launchers:
+  - name: grgsm_livemon
+    exec: grgsm_livemon
+    terminal: true
+    # The live GSM monitor: grgsm_livemon's own window, tuned from its controls; the terminal behind it keeps the GNU Radio log, where a missing device or an unlocked RTL-SDR is reported
+
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/gr-osmosdr.yaml
+++ b/catalog/packages/gr-osmosdr.yaml
@@ -13,6 +13,15 @@ install:
       method: apt
       packages: [gr-osmosdr]
 
+# D-050: the unit ships several command-line tools and no desktop entry, so
+# `menus apply` could not pick one without guessing. This is the pick: the
+# entry an operator opens first. Terminal launchers hold their window.
+launchers:
+  - name: osmocom_fft
+    exec: osmocom_fft
+    terminal: true
+    # A spectrum from whatever SDR is attached: the osmocom source's own FFT display, and the first proof that a device string opens
+
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/gr-satellites.yaml
+++ b/catalog/packages/gr-satellites.yaml
@@ -13,6 +13,15 @@ install:
       method: apt
       packages: [gr-satellites]
 
+# D-050: the unit ships several command-line tools and no desktop entry, so
+# `menus apply` could not pick one without guessing. This is the pick: the
+# entry an operator opens first. Terminal launchers hold their window.
+launchers:
+  - name: gr_satellites
+    exec: gr_satellites --list_satellites
+    terminal: true
+    # Which satellites it decodes: the supported list with each downlink. Every other invocation needs a satellite name and a recording or a live source, so this is the representative entry rather than a decoder session
+
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/hcxtools.yaml
+++ b/catalog/packages/hcxtools.yaml
@@ -11,6 +11,9 @@ install:
       method: apt
       packages: [hcxtools]
 
+# D-050: no menu entry, deliberately. A converter set: every tool takes a
+# capture file and writes a hash file; none is interactive or informational
+# without arguments.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/libfreefare-bin.yaml
+++ b/catalog/packages/libfreefare-bin.yaml
@@ -11,6 +11,9 @@ install:
       method: apt
       packages: [libfreefare-bin]
 
+# D-050: no menu entry, deliberately. Every tool is a per-card operation and
+# most of them write (format, write-ndef, create-ndef, configure-ats); the
+# "what does the reader see" question is nfc-list, libnfc-bin's launcher.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/stlink-tools.yaml
+++ b/catalog/packages/stlink-tools.yaml
@@ -11,6 +11,15 @@ install:
       method: apt
       packages: [stlink-tools]
 
+# D-050: the unit ships several command-line tools and no desktop entry, so
+# `menus apply` could not pick one without guessing. This is the pick: the
+# entry an operator opens first. Terminal launchers hold their window.
+launchers:
+  - name: st-info
+    exec: st-info --probe
+    terminal: true
+    # Is the probe there: identifies the ST-Link and the target behind it -- the first thing to run before blaming the board (known_problems below)
+
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/uronode.yaml
+++ b/catalog/packages/uronode.yaml
@@ -14,6 +14,9 @@ install:
       method: apt
       packages: [uronode]
 
+# D-050: no menu entry, deliberately. Everything is under /usr/sbin:
+# uronode is spawned by ax25d for each inbound connection, and axdigi,
+# calibrate, flexd and nodeusers are its administration; nothing to open.
 update:
   probe:
     method: apt_policy

--- a/catalog/packages/yagiuda.yaml
+++ b/catalog/packages/yagiuda.yaml
@@ -11,6 +11,15 @@ install:
       method: apt
       packages: [yagiuda]
 
+# D-050: the unit ships several command-line tools and no desktop entry, so
+# `menus apply` could not pick one without guessing. This is the pick: the
+# entry an operator opens first. Terminal launchers hold their window.
+launchers:
+  - name: input
+    exec: input
+    terminal: true
+    # Where a design starts: input is the unit's interactive program, asking for element positions and the frequency span and writing the file yagi, output and optimise then read
+
 update:
   probe:
     method: apt_policy

--- a/src/hammunition/launchers.py
+++ b/src/hammunition/launchers.py
@@ -128,6 +128,22 @@ def wrapper_body(
                 f"install method have diverged"
             )
         exec_line = exec_line.replace("{node}", str(node_wrapper))
+    if exec_line.split()[:1] == [launcher.name]:
+        # The wrapper is written to ~/.local/bin under the tool's own name,
+        # and Debian's .profile puts that directory first on PATH, so the
+        # command line below would resolve to this file again -- measured on
+        # the field laptop, where ubertooth-util forked itself until the
+        # process limit. Take this directory out of PATH first. Compared
+        # both as written and resolved, so a symlinked home matches either way.
+        # Shell builtins only: PATH is what is being edited.
+        lines += [
+            "case $0 in */*) here=${0%/*} ;; *) here=. ;; esac",
+            'real=$(cd -- "$here" && pwd -P)',
+            "rest=; IFS=:; for dir in $PATH; do",
+            '  [ "$dir" = "$here" ] || [ "$dir" = "$real" ] || rest="${rest:+$rest:}$dir"',
+            "done; unset IFS",
+            "PATH=$rest; export PATH",
+        ]
     lines.append(exec_line)
     if launcher.terminal:
         # A terminal launcher holds its window: the tool's output is the

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -283,3 +283,76 @@ def test_a_terminal_launcher_may_not_exec_away_the_shell_that_would_hold() -> No
 
     with pytest.raises((ValidationError, ManifestError), match="terminal"):
         manifest(launchers=[{"name": "l", "exec": "exec hackrf_info", "terminal": True}])
+
+
+# ---------------------------------------------------------------------------
+# A wrapper named like its tool must run the tool, not itself.
+# ---------------------------------------------------------------------------
+
+
+def _user_task_count() -> int:
+    """What RLIMIT_NPROC is compared against: every thread of every process
+    of this user, not the process count /proc's directory listing gives."""
+    uid = os.getuid()
+    count = 0
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        try:
+            if os.stat(f"/proc/{entry}").st_uid != uid:
+                continue
+            status = Path(f"/proc/{entry}/status").read_text()
+        except OSError:
+            continue
+        for line in status.splitlines():
+            if line.startswith("Threads:"):
+                count += int(line.split()[1])
+                break
+    return count
+
+
+def test_a_wrapper_named_like_its_tool_runs_the_tool_and_not_itself(tmp_path: Path) -> None:
+    """The wrapper lands in ``~/.local/bin`` under the tool's own name, and
+    Debian's ``.profile`` puts that directory first on PATH. Measured on the
+    field laptop: ``~/.local/bin/ubertooth-util`` ran ``ubertooth-util -v``,
+    which resolved to the wrapper again, forever. The wrapper must take its
+    own directory out of PATH before the command line."""
+    import resource
+
+    m = manifest(launchers=[{"name": "tool", "exec": "tool -v", "terminal": True}])
+    bin_dir = tmp_path / "bin"
+    real_dir = tmp_path / "real"
+    bin_dir.mkdir()
+    real_dir.mkdir()
+    (bin_dir / "tool").write_text(wrapper_body(m, m.launchers[0]))
+    (bin_dir / "tool").chmod(0o755)
+    (real_dir / "tool").write_text('#!/bin/sh\necho "real tool ran $*"\n')
+    (real_dir / "tool").chmod(0o755)
+
+    # The unfixed wrapper forks itself without bound. A process-count ceiling
+    # a little above what this user already runs makes that fail fast inside
+    # this subtree only; the process group is killed on timeout regardless.
+    ceiling = _user_task_count() + 40
+
+    def limit() -> None:
+        resource.setrlimit(resource.RLIMIT_NPROC, (ceiling, ceiling))
+
+    proc = subprocess.Popen(
+        ["/bin/sh", str(bin_dir / "tool")],
+        env={"PATH": f"{bin_dir}:{real_dir}"},
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+        preexec_fn=limit,
+    )
+    try:
+        out, _ = proc.communicate(timeout=20)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, 9)
+        proc.wait()
+        pytest.fail("the wrapper did not finish: it is calling itself")
+    assert "real tool ran -v" in out, out
+    assert "[exit 0]" in out, out
+    assert out.count("real tool ran") == 1, out

--- a/tests/test_verify_tree_launchers.py
+++ b/tests/test_verify_tree_launchers.py
@@ -334,8 +334,15 @@ def test_every_catalog_launcher_working_directory_is_under_the_shared_prefix() -
     assert launcher_units == {
         "ais-catcher",
         "artemis",
+        "ax25-apps",
+        "ax25-tools",
+        "bladerf",
         "gpa",
+        "gpsd",
         "gpsd-tools",
+        "gr-gsm",
+        "gr-osmosdr",
+        "gr-satellites",
         "hackrf",
         "hamclock-next",
         "hammunition-hill",
@@ -346,9 +353,11 @@ def test_every_catalog_launcher_working_directory_is_under_the_shared_prefix() -
         "openhamclock",
         "radiosonde-auto-rx",
         "rtl-sdr",
+        "stlink-tools",
         "supersdr",
         "ubertooth",
         "yaac",
+        "yagiuda",
     }, "a unit gained or lost launchers; update this pin"
     for name in launcher_units:
         for launcher in catalog[name].launchers:


### PR DESCRIPTION
## What this is

The second round of the D-050 menu summary's skip list, measured on the field laptop: 21 installed catalog units `menus apply` could not give a desktop entry (several executables, none named like the unit; or only `/usr/sbin`). Each is decided in its manifest, and a wrapper bug found on the way is fixed first.

## Commit 1 — `launchers.py`: a wrapper named like its tool took its own directory out of PATH, or it called itself

The launcher wrapper lands in `~/.local/bin` under the tool's own name and its command line names the tool bare. Debian's `.profile` puts `~/.local/bin` first on PATH, so the command resolved to the wrapper again. Measured on the laptop with today's `~/.local/bin/ubertooth-util`: `type ubertooth-util` is the wrapper, and running it under a process-count ceiling forked until `Cannot fork`. This affected all six launchers merged today (rtl_test, rigctl, hackrf_info, ubertooth-util, nfc-list, cgps); the bench page never claims a generated entry was opened by eye, which is how it went unmeasured.

Fix: when the exec line's first word is the launcher's own name, the wrapper removes its directory from PATH before the command (compared as written and as `pwd -P`; shell builtins only, since PATH is what is being edited). Every other wrapper is byte-identical. The test writes such a wrapper into a directory that precedes a fake tool on PATH and runs it under an `RLIMIT_NPROC` ceiling in its own process group: red on the unfixed engine, green with the fix, and the real tool runs exactly once.

## Commit 2 — catalog decisions, one per unit

Nine units get a `launchers:` block, all terminal launchers (the window holds after exit):

| unit | tool | why |
|---|---|---|
| ax25-apps | `axlisten -a` | raw AX.25 frames on every port, outgoing and incoming |
| ax25-tools | `mheard` | stations heard per port; the rest is per-port configuration typed at a shell |
| bladerf | `bladeRF-cli -i` | interactive session; `probe`/`info` inside it |
| gpsd | `gpsctl` | which receiver the daemon owns, or that none is connected; `cgps` stays gpsd-tools' launcher |
| gr-gsm | `grgsm_livemon` | the live monitor GUI; the terminal keeps the GNU Radio log |
| gr-osmosdr | `osmocom_fft` | a spectrum from whatever SDR is attached |
| gr-satellites | `gr_satellites --list_satellites` | the representative entry (every decode needs a satellite and an input); said in the manifest comment |
| stlink-tools | `st-info --probe` | the first thing its own known_problems says to run |
| yagiuda | `input` | the interactive design program its manual page starts with |

Ten units get a comment above `update:` recording that there is deliberately no entry and why:

| unit | reason |
|---|---|
| ampr-ripd, aprsdigi, aprx, axmail, cwdaemon, uronode | only `/usr/sbin` executables: daemons, or tools the node spawns per caller |
| flashrom | `/usr/sbin/flashrom` needs a programmer argument, a chip and usually root |
| hcxtools | converter set; nothing interactive or informational without arguments |
| ax25mail-utils | forwarding tools run against a configured BBS session |
| libfreefare-bin | per-card operations, most of them writes; `nfc-list` in libnfc-bin already answers what the reader sees |

pciutils and usbutils are untouched: both carry `hardware` beside `workstation`, which is why they surfaced despite Workstation being `menu: false`.

`tests/test_verify_tree_launchers.py` pins the nine new launcher units. The package reference was regenerated and is unchanged (it does not render launchers).

## Verification

- `make check`: exit 0, 1785 passed, 21 skipped.
- Dry run on the laptop (`install <unit> --dry-run --no-refresh`) for bladerf, gr-osmosdr and yagiuda: each plan is exactly the `[wrapper]` and `[desktop-entry]` steps.
- The fixed wrapper run by hand from a PATH where its directory comes first: the real tool ran once, then the hold.
- Not done here: a real `install` or `menus apply` on the laptop, and the by-eye check of the entries in the launcher. The six existing wrappers in `~/.local/bin` are the old body until they are regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
