### PR TITLE
menus: land #80 on main — icons from the vocabulary, and an install ends by re-applying the menu

### DIFF
--- a/catalog/categories.yaml
+++ b/catalog/categories.yaml
@@ -16,6 +16,9 @@
 # no manifest may use an undeclared tag, and no declared tag may go unused, so
 # the vocabulary cannot accumulate names nothing carries.
 #
+# `icon` is a freedesktop icon name (checked against Breeze and Adwaita on the
+# field laptop, 2026-09-12) for the submenu and for entries that carry none.
+#
 # `title` is how the tag reads on a desktop menu -- the acronyms nothing can
 # derive from the tag (`sdr` is SDR, not Sdr; a title-cased `hf-propagation`
 # read "Hf Propagation" on the Kali VM's Xfce tree, 2026-09-01).
@@ -33,50 +36,60 @@
 
 categories:
   - name: antenna
+    icon: applications-engineering
     title: Antenna
     summary: >-
       Antenna and transmission-line design, modelling, and measurement.
 
   - name: contest
+    icon: applications-utilities
     title: Contest
     summary: >-
       Contest operating -- scoring, duplicate checking, rate keeping,
       and keying under time pressure.
 
   - name: cw
+    icon: preferences-desktop-keyboard
     title: CW
     summary: >-
       Morse code -- keying, decoding, and learning to hear it.
 
   - name: digital-modes
+    icon: audio-x-generic
     title: Digital Modes
     summary: >-
       Keyboard-to-keyboard and weak-signal modes worked with a transceiver:
       PSK31, RTTY, FT8, JS8, SSTV and the rest.
 
   - name: dmr
+    icon: radio
     title: DMR
     summary: DMR — codeplugs, talkgroups, and the radios that use them.
 
   - name: electronics
+    icon: applications-engineering
     title: Electronics
     summary: Bench electronics and EDA — circuit design, simulation, test gear.
 
   - name: emcomm
+    icon: network-wireless
     title: EMCOMM
     summary: Emergency and public-service communications.
 
   - name: hardware
+    icon: applications-engineering
     title: Hardware
     summary: >-
       Device support rather than an application: drivers, firmware, udev
       permissions, and the tools for talking to a device at all.
 
   - name: hf-propagation
+    icon: map-globe
     title: HF Propagation
     summary: Propagation prediction, solar indices, beacons and grey line.
 
   - name: listening
+    icon: audio-input-microphone
     title: Listening
     summary: >-
       Receive-only monitoring and decoding. Needs no licence and often no
@@ -84,51 +97,61 @@ categories:
       but a dongle yet.
 
   - name: logging
+    icon: applications-utilities
     title: Logging
     summary: >-
       Contact logging, awards tracking, QSL and confirmation services.
 
   - name: mesh
+    icon: network-wireless
     title: Mesh
     summary: LoRa and mesh networking — Meshtastic, MeshCore, Reticulum.
 
   - name: nbems
+    icon: audio-x-generic
     title: NBEMS
     summary: >-
       The NBEMS stack specifically — fldigi with flmsg, flamp and flwrap for
       formal message handling without an internet connection.
 
   - name: packet
+    icon: network-wireless
     title: Packet
     summary: AX.25 and packet radio, including Winlink and BBS work.
 
   - name: programmer
+    icon: applications-development
     title: Programmer
     summary: Device programmers and flashers for microcontrollers and memories.
 
   - name: radio-programming
+    icon: radio
     title: Radio Programming
     summary: >-
       Writing memories and settings into a transceiver — codeplugs and channel
       lists, as distinct from controlling a radio while operating it.
 
   - name: rf-research
+    icon: applications-science
     title: RF Research
     summary: >-
       Research tooling whose lawful use is jurisdiction-dependent. Consent-gated
       (D-021).
 
   - name: rf-security
+    icon: applications-utilities
     title: RF Security
     summary: >-
       RF security and SIGINT tooling. Opt-in by profile, never installed by
       default.
 
   - name: rfid
+    icon: applications-engineering
     title: RFID
     summary: RFID and NFC — readers, transponders, and the cards themselves.
 
   - name: rig-control
+    icon: radio
     title: Rig Control
     summary: >-
       CAT control of a transceiver while operating: frequency, mode, PTT
@@ -136,37 +159,44 @@ categories:
       memories.
 
   - name: satellite
+    icon: map-globe
     title: Satellite
     summary: >-
       Amateur satellites and weather satellites — tracking, prediction,
       telemetry and image decoding.
 
   - name: sdr
+    icon: applications-science
     title: SDR
     summary: Software-defined radio — receivers, transceivers and the software.
 
   - name: station
+    icon: radio
     title: Station
     summary: >-
       Station infrastructure that is not itself a radio application: time,
       position, and the plumbing an operating position needs.
 
   - name: timing
+    icon: preferences-system
     title: Timing
     summary: Time and frequency — clocks, disciplining, and stable references.
 
   - name: tracking
+    icon: gps
     title: Tracking
     summary: >-
       Position reporting and target tracking: APRS, ADS-B, AIS, and the
       map that shows them.
 
   - name: training
+    icon: applications-education
     title: Training
     summary: >-
       Licence exam preparation and operating practice.
 
   - name: workstation
+    icon: utilities-terminal
     title: Workstation
     summary: >-
       The machine the station runs on rather than the radio: editors, serial
@@ -175,41 +205,49 @@ categories:
 groups:
   - order: 1
     name: station
+    icon: radio
     title: Station
     summary: The operating position — rig control, time and position, logs and contests.
     categories: [station, rig-control, timing, logging, contest]
   - order: 2
     name: digital-modes
+    icon: audio-x-generic
     title: Digital Modes
     summary: Keyboard modes, NBEMS and Morse.
     categories: [digital-modes, nbems, cw]
   - order: 3
     name: packet
+    icon: network-wireless
     title: Packet & EMCOMM
     summary: AX.25, APRS, Winlink, mesh and the emergency-communications stack.
     categories: [packet, emcomm, mesh]
   - order: 4
     name: sdr
+    icon: applications-science
     title: SDR & Listening
     summary: Software-defined radio, receivers, satellites, tracking and propagation.
     categories: [sdr, listening, satellite, tracking, hf-propagation]
   - order: 5
     name: rf-security
+    icon: applications-utilities
     title: RF Security
     summary: Spectrum analysis, wireless auditing, RFID and consent-gated research tooling.
     categories: [rf-security, rf-research, rfid]
   - order: 6
     name: hardware
+    icon: applications-engineering
     title: Hardware & Bench
     summary: Devices, radio programming, programmers, electronics and antennas.
     categories: [hardware, radio-programming, dmr, programmer, electronics, antenna]
   - order: 7
     name: learning
+    icon: applications-education
     title: Learning
     summary: Training and licence exam practice.
     categories: [training]
   - order: 8
     name: workstation
+    icon: utilities-terminal
     title: Workstation
     summary: The machine the station runs on.
     categories: [workstation]

--- a/src/hammunition/cli/main.py
+++ b/src/hammunition/cli/main.py
@@ -818,6 +818,10 @@ def cmd_install(args: argparse.Namespace) -> int:
     ):
         print(line)
 
+    print(
+        "\nAfterwards: the Hammunition menu is re-applied for this user "
+        "(per-user files, unprivileged, D-050)."
+    )
     if args.dry_run:
         print("\nDry run: nothing above was executed.")
         return EXIT_OK
@@ -918,6 +922,8 @@ def cmd_install(args: argparse.Namespace) -> int:
         return EXIT_FAILED
     if report.ok:
         print(f"\nDone. {len(report.completed)} command(s) completed and confirmed.")
+        for line in refresh_menus_after_install(catalog_root):
+            print(line)
         if plan.group_memberships:
             print(
                 "Group membership does not apply to a session that is already open — "
@@ -1131,6 +1137,74 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
     return EXIT_FAILED
 
 
+def refresh_menus_after_install(catalog_root: Path) -> list[str]:
+    """Re-apply the Hammunition menu for this user, quietly. D-050, round 3.
+
+    After the full install on the field laptop, 42 of 60 tagged entries sat
+    directly under *Hammunition*: placement happens at apply time, and the
+    last apply predated the install. So a real install ends here. Per-user
+    files only, unprivileged; a machine where no root menu can be decided
+    gets a line saying so, never a failed install.
+    """
+    from hammunition.menus import (
+        APPLICATIONS_DIR,
+        MenuPaths,
+        MenuPrefixError,
+        cli_entries,
+        cli_entry_steps,
+        decorate_entries,
+        load_vocabulary,
+        menu_steps,
+        place_installed_entries,
+        refresh_command,
+        resolve_menu_prefix,
+    )
+
+    home = Path.home()
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME") or home / ".config")
+    data_home = Path(os.environ.get("XDG_DATA_HOME") or home / ".local" / "share")
+    config_dirs = [
+        Path(d) for d in (os.environ.get("XDG_CONFIG_DIRS") or "/etc/xdg").split(":") if d
+    ]
+    try:
+        prefix = resolve_menu_prefix(None, os.environ.get("XDG_MENU_PREFIX"), config_dirs)
+    except MenuPrefixError as exc:
+        return [
+            f"Menu: not re-applied -- {exc}. Run `hammunition menus apply` in your desktop session."
+        ]
+    vocabulary = load_vocabulary(catalog_root / "categories.yaml")
+    manifests, _ = load_all(catalog_root)
+    hidden = vocabulary.hidden_categories
+    placement = place_installed_entries(
+        manifests.values(), applications_dir=APPLICATIONS_DIR, hidden=hidden
+    )
+    generated = cli_entries(manifests.values(), placement, hidden=hidden)
+    paths = MenuPaths(
+        menus_dir=config_home / "menus", directories_dir=data_home / "desktop-directories"
+    )
+    applications = data_home / "applications"
+    steps = menu_steps(
+        vocabulary.categories,
+        paths,
+        menu_prefix=prefix,
+        placement=placement,
+        groups=vocabulary.groups,
+    )
+    steps += cli_entry_steps(generated, applications, vocabulary.icons)
+    steps += decorate_entries(applications, vocabulary.icons)
+    for step in steps:
+        step.perform()
+    refresh = refresh_command(prefix)
+    if refresh is not None:
+        SubprocessRunner().run(refresh)
+    placed = sum(len(v) for v in placement.by_category.values())
+    return [
+        f"Menu: re-applied for this user -- {len(placement.claimed)} entries placed "
+        f"{placed} times, {len(generated.entries)} generated, {len(generated.skipped)} "
+        f"without one (`hammunition menus apply` lists them)"
+    ]
+
+
 def cmd_menus_apply(args: argparse.Namespace) -> int:
 
     from hammunition.menus import (
@@ -1139,6 +1213,7 @@ def cmd_menus_apply(args: argparse.Namespace) -> int:
         MenuPrefixError,
         cli_entries,
         cli_entry_steps,
+        decorate_entries,
         gnome_commands,
         load_vocabulary,
         menu_steps,
@@ -1177,7 +1252,10 @@ def cmd_menus_apply(args: argparse.Namespace) -> int:
         print(f"Refusing to write a menu that nothing would read: {exc}", file=sys.stderr)
         return EXIT_FAILED
     steps = menu_steps(categories, paths, menu_prefix=prefix, placement=placement, groups=groups)
-    steps.extend(cli_entry_steps(generated, paths.directories_dir.parent / "applications"))
+    steps.extend(
+        cli_entry_steps(generated, paths.directories_dir.parent / "applications", vocabulary.icons)
+    )
+    steps.extend(decorate_entries(paths.directories_dir.parent / "applications", vocabulary.icons))
 
     desktop = os.environ.get("XDG_CURRENT_DESKTOP", "")
     wants_gnome = "GNOME" in desktop.upper() or args.gnome

--- a/src/hammunition/menus.py
+++ b/src/hammunition/menus.py
@@ -36,9 +36,10 @@ mechanisms share and the launcher artifacts already have.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -61,6 +62,7 @@ __all__ = [
     "Vocabulary",
     "cli_entries",
     "cli_entry_steps",
+    "decorate_entries",
     "gnome_commands",
     "load_vocabulary",
     "menu_steps",
@@ -165,6 +167,9 @@ class Category:
     """How the tag reads on a menu — ``SDR``, not ``Sdr``. Falls back to a
     title-cased name, which is wrong for every acronym; the vocabulary carries
     the real one."""
+    icon: str = "folder"
+    """A freedesktop icon name for the submenu and for entries under it that
+    carry none. ``folder`` when the vocabulary says nothing."""
 
     @property
     def label(self) -> str:
@@ -183,6 +188,7 @@ class Group:
     title: str
     summary: str
     categories: tuple[str, ...]
+    icon: str = "folder"
     menu: bool = True
     """``menu: false`` hides the group and its categories from every desktop
     integration: no submenu, no folder, no generated entry, and the packaged
@@ -201,13 +207,23 @@ class Vocabulary:
     def hidden_categories(self) -> frozenset[str]:
         return frozenset(c for g in self.groups if not g.menu for c in g.categories)
 
+    @property
+    def icons(self) -> dict[str, str]:
+        """Category tag -> icon name, for entries that carry none."""
+        return {c.name: c.icon for c in self.categories}
+
 
 def load_vocabulary(path: Path) -> Vocabulary:
     """``catalog/categories.yaml`` as the menu needs it: the categories in
     file order, the groups sorted by their declared order."""
     data = yaml.safe_load(path.read_text())
     categories = [
-        Category(name=c["name"], summary=c["summary"], title=c.get("title", ""))
+        Category(
+            name=c["name"],
+            summary=c["summary"],
+            title=c.get("title", ""),
+            icon=c.get("icon", "folder"),
+        )
         for c in data["categories"]
     ]
     groups = sorted(
@@ -219,6 +235,7 @@ def load_vocabulary(path: Path) -> Vocabulary:
                 summary=g["summary"],
                 categories=tuple(g["categories"]),
                 menu=bool(g.get("menu", True)),
+                icon=g.get("icon", "folder"),
             )
             for g in data.get("groups", [])
         ),
@@ -533,12 +550,15 @@ def cli_entries(
     return CliEntries(entries=tuple(entries), skipped=tuple(skipped))
 
 
-def render_cli_entry(entry: CliEntry) -> str:
+def render_cli_entry(entry: CliEntry, icons: Mapping[str, str] | None = None) -> str:
     markers = ";".join(f"X-Hammunition-{c}" for c in entry.categories)
     keywords = ";".join((*entry.categories, entry.unit))
+    icon = next((icons[c] for c in entry.categories if icons and c in icons), None)
+    icon_line = f"Icon={icon}\n" if icon else ""
     return (
         "[Desktop Entry]\n"
         "Type=Application\n"
+        f"{icon_line}"
         f"Name={entry.unit}\n"
         f"Comment={entry.comment}\n"
         f"Exec={entry.exec}\n"
@@ -555,7 +575,9 @@ def _remove(path: Path) -> str:
     return f"removed {path}"
 
 
-def cli_entry_steps(result: CliEntries, applications_dir: Path) -> list[Action]:
+def cli_entry_steps(
+    result: CliEntries, applications_dir: Path, icons: Mapping[str, str] | None = None
+) -> list[Action]:
     """Write this run's entries; remove ours from earlier runs that this run
     did not produce (the unit was uninstalled, or now ships an entry).
     Only ``hammunition-cli-*.desktop`` is ours to prune — a launcher's
@@ -566,7 +588,9 @@ def cli_entry_steps(result: CliEntries, applications_dir: Path) -> list[Action]:
             kind="menu",
             description=f"Write a menu entry for {entry.unit} ({entry.exec})",
             detail=str(applications_dir / entry.desktop_id),
-            perform=partial(_write, applications_dir / entry.desktop_id, render_cli_entry(entry)),
+            perform=partial(
+                _write, applications_dir / entry.desktop_id, render_cli_entry(entry, icons)
+            ),
         )
         for entry in result.entries
     ]
@@ -580,6 +604,46 @@ def cli_entry_steps(result: CliEntries, applications_dir: Path) -> list[Action]:
                     perform=partial(_remove, stale),
                 )
             )
+    return steps
+
+
+_MARKER = re.compile(r"X-Hammunition-([a-z0-9-]+)")
+
+
+def _decorate(path: Path, icon: str) -> str:
+    text = path.read_text()
+    lines = text.split("\n")
+    at = next((i for i, line in enumerate(lines) if line.startswith("Type=")), 0)
+    lines.insert(at + 1, f"Icon={icon}")
+    path.write_text("\n".join(lines))
+    return f"added Icon={icon} to {path.name}"
+
+
+def decorate_entries(applications_dir: Path, icons: Mapping[str, str]) -> list[Action]:
+    """Give our bare entries an icon from their first marker's category.
+
+    Launchers are written at install time by code that has no vocabulary in
+    hand, so they carried no ``Icon=`` and rendered generic (field laptop,
+    2026-09-12). Only ``hammunition-*.desktop`` is ours to touch; the
+    distribution's entries are never edited (D-022). An entry that already
+    has an icon keeps it.
+    """
+    steps: list[Action] = []
+    for path in sorted(applications_dir.glob("hammunition-*.desktop")):
+        text = path.read_text()
+        if re.search(r"^Icon=", text, re.M):
+            continue
+        icon = next((icons[m] for m in _MARKER.findall(text) if m in icons), None)
+        if icon is None:
+            continue
+        steps.append(
+            Action(
+                kind="menu",
+                description=f"Give {path.name} the {icon} icon",
+                detail=str(path),
+                perform=partial(_decorate, path, icon),
+            )
+        )
     return steps
 
 
@@ -699,8 +763,8 @@ def render_menu(
 """
 
 
-def render_directory(name: str, comment: str) -> str:
-    return f"[Desktop Entry]\nType=Directory\nName={name}\nComment={comment}\nIcon=folder\n"
+def render_directory(name: str, comment: str, icon: str = "folder") -> str:
+    return f"[Desktop Entry]\nType=Directory\nName={name}\nComment={comment}\nIcon={icon}\n"
 
 
 def _write(path: Path, body: str) -> str:
@@ -773,7 +837,9 @@ def menu_steps(
                 kind="menu",
                 description=f"Name the {group.title} group",
                 detail=str(target),
-                perform=partial(_write, target, render_directory(group.title, group.summary)),
+                perform=partial(
+                    _write, target, render_directory(group.title, group.summary, group.icon)
+                ),
             )
         )
     for category in categories:
@@ -788,7 +854,7 @@ def menu_steps(
                 perform=partial(
                     _write,
                     target,
-                    render_directory(category.label, category.summary),
+                    render_directory(category.label, category.summary, category.icon),
                 ),
             )
         )

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -141,3 +141,17 @@ def test_groups_are_numbered_contiguously_titled_and_summarised(
         assert str(group["title"]).strip(), group
         assert str(group["summary"]).strip(), group
         assert len(group["categories"]) >= 1, group
+
+
+def test_every_category_and_group_names_an_icon(
+    declared: dict[str, str], groups: list[dict[str, Any]]
+) -> None:
+    """D-050, icons: generated entries and directory files carried no Icon=
+    and rendered generic on the field laptop's Plasma (2026-09-12). The
+    vocabulary carries a freedesktop icon name per category and per group;
+    the names were checked against the Breeze and Adwaita themes there."""
+    data = yaml.safe_load(VOCABULARY.read_text())
+    for c in data["categories"]:
+        assert str(c.get("icon", "")).strip(), f"{c['name']} has no icon"
+    for g in groups:
+        assert str(g.get("icon", "")).strip(), f"group {g['name']} has no icon"

--- a/tests/test_menus.py
+++ b/tests/test_menus.py
@@ -27,6 +27,8 @@ from hammunition.menus import (
     root_menu_prefixes,
 )
 
+REPO_CATALOG = Path(__file__).resolve().parent.parent / "catalog"
+
 CATS = [
     Category(name="packet", summary="AX.25, Winlink and friends"),
     Category(name="sdr", summary="Software-defined receivers", title="SDR"),
@@ -799,3 +801,105 @@ def test_parrot_extras_are_placed_even_when_the_shipped_entry_still_exists(tmp_p
         "parrot-gnuradio_filter_design.desktop",
     )
     assert found.replaced == () and found.missing == ()
+
+
+# ---------------------------------------------------------------------------
+# Icons, and an install that ends by re-applying the menu (D-050, round 3).
+# ---------------------------------------------------------------------------
+
+
+def test_the_vocabulary_loads_icons_for_categories_and_groups(tmp_path: Path) -> None:
+    from hammunition.menus import load_vocabulary
+
+    (tmp_path / "categories.yaml").write_text(
+        "categories:\n  - name: sdr\n    summary: R\n    icon: applications-science\n"
+        "groups:\n  - order: 1\n    name: sdr\n    title: SDR\n    summary: r\n"
+        "    icon: radio\n    categories: [sdr]\n"
+    )
+    v = load_vocabulary(tmp_path / "categories.yaml")
+    assert v.categories[0].icon == "applications-science"
+    assert v.groups[0].icon == "radio"
+
+
+def test_directory_entries_carry_the_vocabulary_icon(tmp_path: Path) -> None:
+    from hammunition.menus import Group, render_directory
+
+    assert "Icon=radio\n" in render_directory("Station", "d", icon="radio")
+    assert "Icon=folder\n" in render_directory("Station", "d")
+    cats = [Category(name="sdr", summary="R", title="SDR", icon="applications-science")]
+    groups = [Group(order=1, name="g", title="G", summary="s", categories=("sdr",), icon="radio")]
+    paths = MenuPaths(menus_dir=tmp_path / "menus", directories_dir=tmp_path / "dirs")
+    for step in menu_steps(cats, paths, menu_prefix="", groups=groups):
+        step.perform()
+    assert "Icon=radio" in (tmp_path / "dirs" / "hammunition-group-g.directory").read_text()
+    assert (
+        "Icon=applications-science" in (tmp_path / "dirs" / "hammunition-sdr.directory").read_text()
+    )
+
+
+def test_a_generated_entry_carries_its_first_categorys_icon() -> None:
+    from hammunition.menus import CliEntry, render_cli_entry
+
+    entry = CliEntry(
+        unit="tcpdump", exec="/usr/bin/tcpdump", comment="c", categories=("rf-security",)
+    )
+    body = render_cli_entry(entry, icons={"rf-security": "applications-utilities"})
+    assert "Icon=applications-utilities\n" in body
+    assert "Icon=" not in render_cli_entry(entry)
+
+
+def test_our_entries_without_an_icon_get_one_from_their_markers_and_others_are_left(
+    tmp_path: Path,
+) -> None:
+    """Launchers are written at install time, by code that has no vocabulary
+    in hand; `menus apply` has it and decorates what it finds bare."""
+    from hammunition.menus import decorate_entries
+
+    bare = tmp_path / "hammunition-flrig.desktop"
+    bare.write_text(
+        "[Desktop Entry]\nType=Application\nName=x\nCategories=HamRadio;X-Hammunition-rig-control;\n"
+    )
+    has = tmp_path / "hammunition-mshv.desktop"
+    has.write_text(
+        "[Desktop Entry]\nType=Application\nName=y\nIcon=custom\nCategories=X-Hammunition-sdr;\n"
+    )
+    theirs = tmp_path / "flrig.desktop"
+    theirs.write_text("[Desktop Entry]\nType=Application\nName=z\nCategories=HamRadio;\n")
+    steps = decorate_entries(tmp_path, {"rig-control": "radio", "sdr": "applications-science"})
+    for step in steps:
+        step.perform()
+    assert "Icon=radio\n" in bare.read_text()
+    assert "Icon=custom" in has.read_text() and "Icon=applications-science" not in has.read_text()
+    assert "Icon=" not in theirs.read_text(), "the distribution's own entries are never edited"
+    assert len(steps) == 1
+
+
+def test_the_install_tail_re_applies_the_menu_quietly(tmp_path: Path, monkeypatch: Any) -> None:
+    """After the full install on the field laptop, 42 of 60 tagged entries sat
+    directly under Hammunition because the last apply predated the install.
+    A real install now ends by re-applying the menu, per-user, unprivileged."""
+    from hammunition.cli.main import refresh_menus_after_install
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setenv("XDG_MENU_PREFIX", "xfce-")
+    lines = refresh_menus_after_install(REPO_CATALOG)
+    assert any("Menu" in line for line in lines)
+    assert (home / ".config" / "menus" / "xfce-applications-merged" / "hammunition.menu").exists()
+
+
+def test_the_install_tail_reports_rather_than_fails_when_no_menu_can_be_decided(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    from hammunition.cli.main import refresh_menus_after_install
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_MENU_PREFIX", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_DIRS", str(tmp_path / "nowhere"))
+    lines = refresh_menus_after_install(REPO_CATALOG)
+    assert any("not re-applied" in line for line in lines)


### PR DESCRIPTION
#80 was stacked on `parrot-multi` and merged into that branch after `parrot-multi` had already merged into main (#77), so its two commits never reached main. This PR carries them: `catalog/categories.yaml` icons per category and group, `Category.icon`/`Group.icon`, `decorate_entries()`, `refresh_menus_after_install()` and the plan-time disclosure. Same tests, same measurement as #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)