### PR TITLE
Per-unit install_recommends: morse installs without evicting pipewire-alsa (closes #61)

### DIFF
--- a/catalog/packages/morse-classic.yaml
+++ b/catalog/packages/morse-classic.yaml
@@ -26,6 +26,14 @@ install:
   - install:
       method: apt
       packages: [morse]
+      # `morse` needs libpulse0, which is a Depends and which pipewire-pulse
+      # satisfies; pulseaudio itself is only a Recommends, and installing it
+      # is what evicts pipewire-alsa (measured: `apt-get install -s morse` on
+      # Parrot 7.3 + KDE planned `Remv pipewire-alsa [1.4.9-1~bpo13+2]`,
+      # 2026-09-12, #61). So this unit alone is installed with
+      # --no-install-recommends, in its own apt command, disclosed in the plan
+      # (D-052). Nothing else in any transaction changes.
+      install_recommends: false
 
 update:
   probe:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3744,3 +3744,70 @@ moved rebuilds, and that is the point: *at its pin*, not *at some pin*.
 `docs/reference/bench-verification-5430.md` once the laptop's second
 resume ends with a verified transaction): a dry run of the profiles that
 carry the 21 builds should plan launcher steps only.
+
+---
+
+## D-052 — A unit whose Recommends conflict with the target's desktop may opt itself out; the global default does not move, and the opt-out is a second apt command, simulated like the first
+
+**Date:** 2026-09-12. **Status:** accepted. **Depends on:** D-022 (never
+remove what the operator did not ask to remove), D-016 (resolution completes
+before anything runs), D-038 (a measured `--target-release` governs the apt
+step). **Closes:** issue #61, option A.
+
+**What was measured.** On the field laptop — Parrot Security 7.3, KDE,
+`pipewire-alsa 1.4.9-1~bpo13+2` installed — `hammunition install morse
+--dry-run --no-refresh` refused the whole profile, correctly, because:
+
+```
+$ apt-get install -s morse | grep -E '^(Inst|Remv)'
+Remv pipewire-alsa [1.4.9-1~bpo13+2]
+Inst morse (2.6-2 Parrot 7 Echo Parakeet:parrot [amd64])
+Inst libasound2-plugins (...)
+Inst pulseaudio (17.0+dfsg1-2+b1 ...)
+
+$ apt-cache depends morse | grep Recommends
+  Recommends: pulseaudio
+$ apt-cache show pipewire-alsa | grep Conflicts
+Conflicts: pulseaudio
+```
+
+`morse` *Depends* `libpulse0`, which `pipewire-pulse` satisfies; PulseAudio
+itself is only a Recommends. So the software does not need PulseAudio —
+Debian's metadata prefers it, and apt's default of installing Recommends turns
+that preference into the removal of the desktop's audio routing.
+
+**Rule.** An apt install block may carry `install_recommends: false`. It is a
+per-unit opt-out and nothing else:
+
+1. **The global default is untouched.** Recommends are still installed for
+   every other unit, on every target, exactly as the distribution does. The
+   apt backend's module docstring remains the authority on why.
+2. **The opted-out packages are a second set**, and two sets are two
+   `apt-get install` commands: the default one first, then one carrying
+   `--no-install-recommends` for the units that asked. A package named by an
+   opted-out unit *and* by a unit that did not opt out stays in the default
+   set — apt's defaults are what a manifest deviates from, never the reverse.
+3. **Both sets are simulated the way they will be installed**, the second
+   with `--no-install-recommends` on the `--simulate`. The two `AptSimulation`
+   results are merged — refused if either was, `Remv` lines from both — so the
+   D-022 removal check reads exactly what apt will do and not a simulation of
+   a different transaction. A `--target-release` measured for either set under
+   D-038 governs the whole apt step, so the other set is simulated again with
+   it; two different releases is a refusal, because one apt step cannot run
+   with both and nothing is guessed.
+4. **`--no-remove` stays on both commands.** The flag buys a unit its own apt
+   invocation, never an exemption from D-022: if apt still plans a removal
+   with Recommends suppressed, the plan refuses by name as before.
+5. **It is disclosed.** The plan prints the second set under *apt packages
+   installed without Recommends*, naming the units that asked and why, and
+   both commands appear under *Commands* before the confirmation.
+
+**Carried in the catalog by:** `morse-classic`, the case that produced the
+rule. Its `conflicts_with_repo_package: [pipewire-alsa]` declaration stays:
+the flag is what avoids the removal, the declaration is what names this unit
+as the reason if a future apt plans one anyway. Whether it returns to the
+`morse` profile is the maintainer's call and is not decided here.
+
+**Not decided here.** Nothing global, and no second use: a manifest that wants
+this flag needs the same shape of measurement — the Recommends named, the
+conflict named, the `apt-get install -s` output that shows the removal.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -105,6 +105,21 @@ licence and where it is stated, and the install directory, under the heading
 *Offline data that will be downloaded and installed*. `uninstall` removes
 the directory whole; it is namespaced, so it can only be ours.
 
+**Recommends, per unit (D-052).** Recommends are not suppressed globally —
+that would deviate from what every target distribution does, and several ham
+applications get their runtime data that way. A single manifest may opt its
+own packages out with `install_recommends: false`, for the measured case
+where a package's Recommends conflict with the target's desktop stack:
+Debian's `morse` Recommends `pulseaudio`, which `Conflicts: pipewire-alsa`,
+so on a PipeWire desktop apt would satisfy the transaction by removing the
+machine's audio routing and the plan refuses it (**D-022**, issue #61). Such
+a unit's packages become a second apt set, simulated with
+`--no-install-recommends` and installed by a second `apt-get install`
+carrying it. The plan prints the set under *apt packages installed without
+Recommends*, naming the units that asked, and both apt commands appear under
+*Commands*. `--no-remove` is on both: the flag buys a unit its own apt
+invocation, never an exemption from **D-022**.
+
 **Suggestion groups.** A profile may suggest one-of-several optional
 companions (the packet profile's mail client is the first): the run
 *detects* first — any of the group's known commands on PATH means the
@@ -368,7 +383,14 @@ Resolution is a distinct phase that finishes before anything is executed
    same simulate is read for what apt would **remove** (`Remv` lines): a
    package that `Breaks:` an installed one is "resolved" by apt removing
    the installed one, and the plan refuses that by name rather than let
-   the apt step do it unseen (**D-022**, issue #42).
+   the apt step do it unseen (**D-022**, issue #42). A unit whose manifest
+   sets `install_recommends: false` makes this two questions rather than
+   one: its packages are a second set, asked with
+   `--no-install-recommends` and installed by a second `apt-get install`
+   carrying the same flag, so the `Remv` lines the plan refuses on are the
+   ones the command that runs would produce (**D-052**). Both commands
+   carry `--no-remove`, both appear under *Commands*, and a measured
+   `--target-release` governs both.
 7. **Defer what the target does not offer** — but only for a member that
    reached the plan through a *profile*, and only for one of three reasons
    that are facts about the target: no install block matches this

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -74,6 +74,7 @@ argument — js8call is apt on Linux Mint 22.3 and a cmake build elsewhere.
 |---|---|---|---|
 | `method` | `Literal[apt]` | no (default `apt`) |  |
 | `packages` | `list[str]` | **yes** |  |
+| `install_recommends` | `bool` | no (default `True`) | Whether apt installs this unit's Recommends. The global default stays what every target distribution does -- Recommends are not suppressed catalog-wide -- and this is a per-unit opt-out for a package whose Recommends conflict with the target's desktop stack. Debian's `morse` Recommends pulseaudio, which Conflicts pipewire-alsa, so on a PipeWire desktop apt satisfies the transaction by removing the machine's audio routing and the plan refuses it (D-022, issue #61, measured on Parrot 7.3 + KDE 2026-09-12). Set false and this unit's packages are installed by a second `apt-get install --no-install-recommends`, simulated separately and disclosed in the plan (D-052); everything else in the transaction keeps apt's defaults. |
 
 ### `SourceInstall`
 

--- a/src/hammunition/backends/apt.py
+++ b/src/hammunition/backends/apt.py
@@ -41,6 +41,18 @@ ham applications get their runtime data and codecs that way. D-019 is about not
 treating Debian Blend *task metapackages* — which are almost entirely
 Recommends — as an install default; that is a catalog membership question and
 is settled in the catalog, not by a global apt flag applied to everything.
+
+That global default is untouched by the per-unit opt-out (D-052, issue #61). A
+manifest whose Recommends conflict with the target's desktop stack — Debian's
+``morse`` Recommends ``pulseaudio``, which ``Conflicts: pipewire-alsa``, so on
+a PipeWire desktop the default transaction removes the machine's audio routing
+and the plan refuses it under D-022 — sets ``install_recommends: false`` on its
+apt block. Its packages then form a **second** set: a second
+:meth:`AptBackend.simulate` with ``no_recommends=True``, whose ``Remv`` lines
+are read exactly like the first set's, and a second
+:meth:`AptBackend.install_commands` carrying ``--no-install-recommends``. Both
+keep ``--no-remove``; the flag buys a unit its own apt invocation, never an
+exemption from D-022.
 """
 
 from __future__ import annotations
@@ -368,7 +380,13 @@ class AptBackend:
         states = self.probe(packages)
         return sorted(p for p in packages if p not in states or not states[p].known)
 
-    def simulate(self, packages: Sequence[str], *, release: str | None = None) -> AptSimulation:
+    def simulate(
+        self,
+        packages: Sequence[str],
+        *,
+        release: str | None = None,
+        no_recommends: bool = False,
+    ) -> AptSimulation:
         """Run apt's resolver over the whole transaction without touching
         anything.
 
@@ -383,10 +401,17 @@ class AptBackend:
 
         A failed simulation is a result, not an exception: the plan reads
         apt's account and decides what it means.
+
+        *no_recommends* asks the question the way the second apt set's install
+        command will ask it (D-052). A simulation run without the flag is a
+        simulation of a different transaction, and its ``Remv`` lines would be
+        the wrong ones to refuse on.
         """
         if not set(packages):
             return AptSimulation(ok=True, release=release)
-        result = self.runner.run(self.simulate_command(packages, release=release))
+        result = self.runner.run(
+            self.simulate_command(packages, release=release, no_recommends=no_recommends)
+        )
         if not result.ok:
             # apt puts the E: lines and the solver's explanation on stderr;
             # stdout is "Reading package lists..." and worth nothing to a
@@ -407,6 +432,7 @@ class AptBackend:
         release: str | None = None,
         description: str = "",
         no_remove: bool = False,
+        no_recommends: bool = False,
     ) -> Command:
         """The ``--simulate`` invocation itself, for :meth:`simulate` and for a
         plan that wants it as a step. A local ``.deb`` may be among *packages*
@@ -416,12 +442,25 @@ class AptBackend:
 
         :meth:`simulate` asks *without* ``--no-remove`` so that the ``Remv``
         lines exist to be read and named; a step that stands in for the
-        install command asks *with* it, the way the install command will."""
+        install command asks *with* it, the way the install command will.
+        *no_recommends* is the same principle for the second apt set (D-052):
+        the question matches the command."""
         ordered = sorted(set(packages))
         target = ("--target-release", release) if release is not None else ()
         flags = ("--no-remove",) if no_remove else ()
+        recommends = ("--no-install-recommends",) if no_recommends else ()
         return Command(
-            argv=("apt-get", "install", "--simulate", "--yes", *flags, *target, "--", *ordered),
+            argv=(
+                "apt-get",
+                "install",
+                "--simulate",
+                "--yes",
+                *flags,
+                *recommends,
+                *target,
+                "--",
+                *ordered,
+            ),
             description=description or f"Ask apt how it would install {len(ordered)} package(s)",
             requires_root=False,
             env=dict(NONINTERACTIVE),
@@ -528,7 +567,7 @@ class AptBackend:
         )
 
     def install_commands(
-        self, packages: Iterable[str], *, release: str | None = None
+        self, packages: Iterable[str], *, release: str | None = None, recommends: bool = True
     ) -> list[Command]:
         """One apt-get invocation for the whole set.
 
@@ -546,16 +585,32 @@ class AptBackend:
         if the real solve disagrees with the simulation, apt exits 100 with
         ``Packages need to be removed but remove is disabled`` (Kali,
         2026-09-07) rather than removing an installed package unseen.
+
+        *recommends* is false only for the second apt set, whose units asked
+        for ``--no-install-recommends`` in their manifests (D-052). It changes
+        this invocation and no other, and ``--no-remove`` stays on: a unit may
+        buy its own apt command, never an exemption from D-022.
         """
         ordered = sorted(set(packages))
         if not ordered:
             return []
         target = ("--target-release", release) if release is not None else ()
+        suppress = ("--no-install-recommends",) if not recommends else ()
         where = f" from {release}" if release is not None else ""
+        without = " without Recommends" if not recommends else ""
         return [
             Command(
-                argv=("apt-get", "install", "--yes", "--no-remove", *target, "--", *ordered),
-                description=f"Install {len(ordered)} package(s) with apt{where}",
+                argv=(
+                    "apt-get",
+                    "install",
+                    "--yes",
+                    "--no-remove",
+                    *suppress,
+                    *target,
+                    "--",
+                    *ordered,
+                ),
+                description=f"Install {len(ordered)} package(s) with apt{where}{without}",
                 requires_root=True,
                 env=dict(NONINTERACTIVE),
             )

--- a/src/hammunition/cli/main.py
+++ b/src/hammunition/cli/main.py
@@ -261,6 +261,27 @@ def render_plan(
             lines.append(f"      {apt_package}")
         lines.append("")
 
+    if plan.apt_to_install_no_recommends:
+        # A second apt command is a second thing happening to the machine, and
+        # it deviates from what the distribution does by default. Name the
+        # units that asked, so the deviation is attributable rather than a flag
+        # that appeared in an argv. D-052.
+        units = ", ".join(plan.apt_no_recommends_units)
+        lines.append("apt packages installed without Recommends (D-052):")
+        lines.extend(
+            _wrap(
+                f"{units} asked for --no-install-recommends in the manifest, because the "
+                f"Recommends of these packages conflict with software this target installs; "
+                f"a second apt-get install carries the flag for them alone. Everything else "
+                f"in this transaction keeps apt's defaults, and both commands run with "
+                f"--no-remove:",
+                indent="  ",
+            )
+        )
+        for apt_package in plan.apt_to_install_no_recommends:
+            lines.append(f"      {apt_package}")
+        lines.append("")
+
     if plan.apt_repos:
         # Before group membership and the consent gates, because it is the
         # largest thing the transaction does to the machine: a repository

--- a/src/hammunition/execute.py
+++ b/src/hammunition/execute.py
@@ -498,7 +498,7 @@ def commands_for(
     # to install stays a no-op, and a source-only plan on a station with no
     # uplink never starts with a network command. A just-added repository
     # always needs it, whatever the flag says: apt has no index for it yet.
-    needs_lists = bool(plan.apt_to_install) or bool(debs)
+    needs_lists = bool(plan.apt_packages_all) or bool(debs)
     if (refresh and needs_lists) or plan.apt_repos:
         commands.append(apt.refresh_command())
     # The same question again for a just-added repository: the plan-time
@@ -532,7 +532,7 @@ def commands_for(
             )
         )
 
-    if plan.debconf_selections and plan.apt_to_install:
+    if plan.debconf_selections and plan.apt_packages_all:
         # Before the apt install, never after: a package's postinst reads its
         # preseeded answers as it configures, so wireshark-common creates the
         # wireshark group and grants dumpcap its capabilities in one pass. Fed
@@ -546,8 +546,20 @@ def commands_for(
             )
         )
     commands.extend(apt.install_commands(plan.apt_to_install, release=plan.apt_release))
+    # The second apt command, for the units whose manifests asked for
+    # `--no-install-recommends` (D-052). After the default one, because it is
+    # the deviation: the ordinary transaction settles first, and the operator
+    # reading the plan sees the narrower command as the exception it is. Both
+    # carry --no-remove and both were simulated the way they will run.
+    commands.extend(
+        apt.install_commands(
+            plan.apt_to_install_no_recommends,
+            release=plan.apt_release,
+            recommends=False,
+        )
+    )
 
-    if plan.reconfigure_after and plan.apt_to_install:
+    if plan.reconfigure_after and plan.apt_packages_all:
         # After the whole apt transaction is settled, so a postinst action that
         # needs another just-installed package (wireshark-common's setcap needs
         # libcap2-bin) re-runs with everything present. Non-interactive: the
@@ -767,7 +779,7 @@ def verify_effects(
             }
         )
     )
-    wanted = tuple(sorted({*plan.apt_to_install, *deb_packages}))
+    wanted = tuple(sorted({*plan.apt_packages_all, *deb_packages}))
     if wanted and prober is not None:
         states = prober.probe(wanted)
         for name in wanted:
@@ -910,7 +922,7 @@ def execute(
             "timestamp": datetime.now(UTC).isoformat(),
             "target": plan.target.to_log_entry(),
             "packages": [p.name for p in plan.packages],
-            "apt_packages": list(plan.apt_to_install),
+            "apt_packages": list(plan.apt_packages_all),
             "deferred": [d.to_log_entry() for d in plan.deferrals],
         }
     )

--- a/src/hammunition/manifest/schema.py
+++ b/src/hammunition/manifest/schema.py
@@ -191,6 +191,23 @@ def _check_tree_marker(installs_tree: bool, marker: str | None, how: str) -> Non
 class AptInstall(Strict):
     method: Literal["apt"] = "apt"
     packages: list[str] = Field(min_length=1)
+    install_recommends: bool = Field(
+        default=True,
+        description=(
+            "Whether apt installs this unit's Recommends. The global default "
+            "stays what every target distribution does -- Recommends are not "
+            "suppressed catalog-wide -- and this is a per-unit opt-out for a "
+            "package whose Recommends conflict with the target's desktop "
+            "stack. Debian's `morse` Recommends pulseaudio, which Conflicts "
+            "pipewire-alsa, so on a PipeWire desktop apt satisfies the "
+            "transaction by removing the machine's audio routing and the plan "
+            "refuses it (D-022, issue #61, measured on Parrot 7.3 + KDE "
+            "2026-09-12). Set false and this unit's packages are installed by "
+            "a second `apt-get install --no-install-recommends`, simulated "
+            "separately and disclosed in the plan (D-052); everything else in "
+            "the transaction keeps apt's defaults."
+        ),
+    )
 
     @model_validator(mode="after")
     def _check(self) -> AptInstall:

--- a/src/hammunition/plan.py
+++ b/src/hammunition/plan.py
@@ -236,6 +236,53 @@ class RepoAddition:
     """The apt packages this repository is expected to supply."""
 
 
+def _opts_out_of_recommends(block: InstallBlock) -> bool:
+    """Whether this block asked for ``--no-install-recommends``. D-052.
+
+    True only of an apt block that said so in the manifest. A source or binary
+    unit's ``build_depends`` are ordinary apt packages installed the ordinary
+    way; nothing but an apt block can opt its own packages out."""
+    install = block.install
+    return isinstance(install, AptInstall) and not install.install_recommends
+
+
+def _split_apt_sets(
+    packages: Sequence[PlannedPackage],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """The outstanding apt work, split into the two commands that will do it.
+
+    One set per apt invocation, because that is what the plan simulates and
+    what it prints. The opted-out set is narrowed by the default one: a
+    package two units want, one of them normally, is installed normally."""
+    default: set[str] = set()
+    opted_out: set[str] = set()
+    for planned in packages:
+        target = opted_out if _opts_out_of_recommends(planned.block) else default
+        target.update(planned.outstanding)
+    return tuple(sorted(default)), tuple(sorted(opted_out - default))
+
+
+def _merge_simulations(first: AptSimulation, second: AptSimulation) -> AptSimulation:
+    """One reading of the whole apt step, from the per-set simulations.
+
+    The removal check (D-022) and the vendor-`.deb` collision check both read
+    a single simulation, and both must see everything the apt step does, so
+    the two sets' answers are merged: refused if either was, every ``Remv``
+    line from both, and the installs unioned per package so
+    :meth:`AptSimulation.from_archive` still measures the target release the
+    same way."""
+    installs = dict(first.installs)
+    for name, archives in second.installs.items():
+        installs[name] = installs.get(name, frozenset()) | archives
+    return AptSimulation(
+        ok=first.ok and second.ok,
+        installs=installs,
+        removes={**first.removes, **second.removes},
+        error="\n".join(e for e in (first.error, second.error) if e),
+        release=first.release if first.release is not None else second.release,
+    )
+
+
 @dataclass(frozen=True)
 class InstallPlan:
     """Everything that will happen, before any of it does."""
@@ -274,11 +321,40 @@ class InstallPlan:
 
     @property
     def apt_to_install(self) -> tuple[str, ...]:
-        """The union of outstanding apt packages, sorted and de-duplicated."""
-        seen: set[str] = set()
-        for planned in self.packages:
-            seen.update(planned.outstanding)
-        return tuple(sorted(seen))
+        """Outstanding apt packages for the **default** apt command, sorted and
+        de-duplicated: everything apt installs the way the distribution does,
+        Recommends included."""
+        return _split_apt_sets(self.packages)[0]
+
+    @property
+    def apt_to_install_no_recommends(self) -> tuple[str, ...]:
+        """Outstanding apt packages for the second apt command, the one that
+        carries ``--no-install-recommends``. D-052.
+
+        A package named by an opted-out unit *and* by a unit that did not opt
+        out stays in the default set: apt's defaults are what the catalog
+        deviates from, never the other way round, and the narrower command is
+        for packages nothing else in the transaction asked for normally."""
+        return _split_apt_sets(self.packages)[1]
+
+    @property
+    def apt_no_recommends_units(self) -> tuple[str, ...]:
+        """The units that asked for the second command, for the disclosure."""
+        return tuple(
+            sorted(
+                planned.name
+                for planned in self.packages
+                if _opts_out_of_recommends(planned.block) and planned.outstanding
+            )
+        )
+
+    @property
+    def apt_packages_all(self) -> tuple[str, ...]:
+        """Both apt sets together -- what this transaction installs with apt,
+        whichever command does it. What needs lists fetched, what the log
+        records, and what the effect check asks apt about afterwards."""
+        default, no_recommends = _split_apt_sets(self.packages)
+        return tuple(sorted({*default, *no_recommends}))
 
     @property
     def debconf_selections(self) -> tuple[str, ...]:
@@ -309,7 +385,7 @@ class InstallPlan:
     @property
     def is_empty(self) -> bool:
         """Nothing to install and nothing to change — a legitimate outcome."""
-        return not self.apt_to_install and not self.group_memberships and not self.apt_repos
+        return not self.apt_packages_all and not self.group_memberships and not self.apt_repos
 
 
 # ---------------------------------------------------------------------------
@@ -699,7 +775,11 @@ def _check_node_floor(
 
 
 def _resolve_from_installed_release(
-    apt: AptBackend, packages: Sequence[str], failed: AptSimulation
+    apt: AptBackend,
+    packages: Sequence[str],
+    failed: AptSimulation,
+    *,
+    no_recommends: bool = False,
 ) -> tuple[AptSimulation, str, tuple[str, ...]] | Blocker:
     """The D-038 retry: when apt refuses because it would have to downgrade
     something already installed, ask again from the release that installed it.
@@ -737,7 +817,7 @@ def _resolve_from_installed_release(
     if len(releases) != 1:
         return refusal
     release = releases[0]
-    retried = apt.simulate(packages, release=release)
+    retried = apt.simulate(packages, release=release, no_recommends=no_recommends)
     if not retried.ok:
         return refusal
     return retried, release, retried.from_archive(release)
@@ -1287,21 +1367,101 @@ def resolve(
     # came after -- and one `--simulate` of the outstanding set answers both.
     # It is asked only when everything else has resolved: a simulation of a
     # set with a missing candidate fails for the reason already listed.
+    #
+    # A unit whose Recommends conflict with the target's desktop stack sets
+    # `install_recommends: false` and its packages form a second set, asked
+    # and installed with `--no-install-recommends` (D-052, issue #61). Two
+    # sets are two apt commands, so they are two simulations: the plan may
+    # only print, and refuse on, what will actually be run.
     from_repos = {p for addition in repo_additions for p in addition.packages}
-    outstanding_apt = [
-        p for p in all_apt if not (p in states and states[p].is_installed) and p not in from_repos
-    ]
+    opted_out_names = {
+        p for _, block, packages, _ in resolved if _opts_out_of_recommends(block) for p in packages
+    }
+    default_names = {
+        p
+        for _, block, packages, _ in resolved
+        if not _opts_out_of_recommends(block)
+        for p in packages
+    }
+    opted_out_names -= default_names
+
+    def _outstanding(names: set[str]) -> list[str]:
+        return [
+            p
+            for p in all_apt
+            if p in names and not (p in states and states[p].is_installed) and p not in from_repos
+        ]
+
+    apt_sets = ((_outstanding(default_names), False), (_outstanding(opted_out_names), True))
+    outstanding_apt = [p for set_packages, _ in apt_sets for p in set_packages]
     apt_release: str | None = None
     apt_from_release: tuple[str, ...] = ()
     simulation = AptSimulation(ok=True)
     if outstanding_apt and states and not blockers:
-        simulation = apt.simulate(outstanding_apt)
-        if not simulation.ok:
-            retried = _resolve_from_installed_release(apt, outstanding_apt, simulation)
-            if isinstance(retried, Blocker):
-                blockers.append(retried)
-            else:
-                simulation, apt_release, apt_from_release = retried
+        results: list[AptSimulation] = []
+        for set_packages, no_recommends in apt_sets:
+            if not set_packages:
+                results.append(AptSimulation(ok=True))
+                continue
+            result = apt.simulate(set_packages, no_recommends=no_recommends)
+            if not result.ok:
+                retried = _resolve_from_installed_release(
+                    apt, set_packages, result, no_recommends=no_recommends
+                )
+                if isinstance(retried, Blocker):
+                    blockers.append(retried)
+                else:
+                    result, _, _ = retried
+            results.append(result)
+        # `--target-release` is apt's, not one command's: a release measured
+        # for either set governs the whole apt step, so the other set is asked
+        # again with it rather than the plan disclosing a simulation of
+        # something the machine will not be asked to do. Two releases is the
+        # D-038 refusal for the same reason none is: nothing is guessed.
+        releases = sorted({r.release for r in results if r.release is not None})
+        if not blockers and len(releases) > 1:
+            blockers.append(
+                Blocker(
+                    subject="apt",
+                    reason=(
+                        f"the two apt sets in this transaction resolve from different "
+                        f"releases ({', '.join(releases)}), and one apt step cannot run "
+                        f"with both"
+                    ),
+                    remedy=(
+                        "install them in separate runs, or leave out the unit whose "
+                        "packages need the other release -- the plan will not pick one "
+                        "release over the other for you (D-038)"
+                    ),
+                )
+            )
+        elif not blockers and releases:
+            apt_release = releases[0]
+            for index, (set_packages, no_recommends) in enumerate(apt_sets):
+                if not set_packages or results[index].release is not None:
+                    continue
+                again = apt.simulate(set_packages, release=apt_release, no_recommends=no_recommends)
+                results[index] = again
+                if not again.ok:
+                    blockers.append(
+                        Blocker(
+                            subject="apt",
+                            reason=(
+                                f"cannot resolve this transaction as one apt-get install: "
+                                f"the rest of it needs --target-release {apt_release}, and "
+                                f"these packages do not resolve from there:\n"
+                                f"{_indent(again.error)}"
+                            ),
+                            remedy=(
+                                "leave out the unit that needs the other release, or "
+                                "install the two in separate runs -- the plan will not "
+                                "start a transaction apt has already refused (D-016)"
+                            ),
+                        )
+                    )
+        simulation = _merge_simulations(results[0], results[1])
+        if apt_release is not None:
+            apt_from_release = simulation.from_archive(apt_release)
 
     # -- what the apt step would REMOVE (D-022) ---------------------------
     # apt "resolves" a `Breaks:` against an installed package by removing

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -224,6 +224,42 @@ def test_recommends_are_not_suppressed() -> None:
     assert "--no-install-recommends" not in command.argv
 
 
+def test_a_unit_may_opt_out_of_recommends_for_its_own_command() -> None:
+    """D-052: the opt-out is per unit and per command, never global. Debian's
+    `morse` Recommends pulseaudio, which Conflicts pipewire-alsa, so on a
+    PipeWire desktop the default command removes the machine's audio routing
+    (#61). `--no-remove` stays on, because D-022 does not bend for it."""
+    (command,) = AptBackend(RecordingRunner()).install_commands(["morse"], recommends=False)
+    assert command.argv == (
+        "apt-get",
+        "install",
+        "--yes",
+        "--no-remove",
+        "--no-install-recommends",
+        "--",
+        "morse",
+    )
+    assert "without Recommends" in command.description
+
+
+def test_the_opted_out_simulate_asks_the_question_the_install_will_ask() -> None:
+    """A simulation that does not carry the flag is a simulation of a different
+    transaction, and the `Remv` lines read from it would be the wrong ones."""
+    command = AptBackend(RecordingRunner()).simulate_command(
+        ["morse"], no_recommends=True, no_remove=True
+    )
+    assert command.argv == (
+        "apt-get",
+        "install",
+        "--simulate",
+        "--yes",
+        "--no-remove",
+        "--no-install-recommends",
+        "--",
+        "morse",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Privilege, which the type carries rather than the call site
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -832,7 +832,7 @@ def _mock_apt(monkeypatch: pytest.MonkeyPatch, *, populated: bool) -> None:
     monkeypatch.setattr(
         AptBackend,
         "simulate",
-        lambda self, pkgs, *, release=None: AptSimulation(
+        lambda self, pkgs, *, release=None, no_recommends=False: AptSimulation(
             ok=True, installs={p: frozenset({"stable"}) for p in pkgs}, release=release
         ),
     )
@@ -1309,3 +1309,56 @@ def test_plan_state_says_already_installed_for_a_deb_this_engine_installed() -> 
     text = "\n".join(render_plan(plan, (), euid=1000))
     assert "already installed" in text
     assert "will fetch+install" not in text
+
+
+# ---------------------------------------------------------------------------
+# The second apt command is disclosed, and says whose it is (D-052, #61)
+# ---------------------------------------------------------------------------
+
+
+def test_the_plan_names_the_units_that_asked_for_no_recommends() -> None:
+    """Two apt commands are two things happening to the machine, and the
+    second deviates from what the distribution does by default. An operator
+    reading the plan sees which unit asked and why, before confirming."""
+    manifest = PackageManifest.model_validate(
+        {
+            "name": "morse-classic",
+            "version": "2.6",
+            "summary": "A Morse sounder",
+            "categories": ["cw"],
+            "install": [
+                {"install": {"method": "apt", "packages": ["morse"], "install_recommends": False}}
+            ],
+            "update": {"probe": {"method": "apt_policy"}},
+            "documentation": {
+                "what_it_does": "Sounds text as Morse for the purposes of testing.",
+                "why_you_want_it": "Because the test suite requires a valid manifest.",
+                "upstream_url": "https://example.invalid/",
+            },
+        }
+    )
+    plan = _plan(
+        packages=(
+            PlannedPackage(
+                manifest=_manifest(),
+                block=_manifest().install[0],
+                apt_packages=("example",),
+            ),
+            PlannedPackage(
+                manifest=manifest,
+                block=manifest.install[0],
+                apt_packages=("morse",),
+            ),
+        )
+    )
+    apt = AptBackend(RecordingRunner())
+    commands = commands_for(plan, apt, current_groups=frozenset())
+    text = "\n".join(render_plan(plan, commands, euid=0))
+    assert "without Recommends" in text
+    assert "morse-classic" in text
+    installs = [
+        c for c in commands if isinstance(c, Command) and c.argv[:2] == ("apt-get", "install")
+    ]
+    assert len(installs) == 2
+    for command in installs:
+        assert command.display(euid=0) in text

--- a/tests/test_displacement.py
+++ b/tests/test_displacement.py
@@ -230,7 +230,9 @@ def _plan_with_in_transaction_conflict(tmp_path: Path, pulled_in: set[str]) -> A
     apt = _apt(tmp_path, known)
 
     class SimulatingApt(type(apt)):  # type: ignore[misc]
-        def simulate(self, packages: Any, *, release: str | None = None) -> Any:
+        def simulate(
+            self, packages: Any, *, release: str | None = None, no_recommends: bool = False
+        ) -> Any:
             from hammunition.backends.apt import AptSimulation
 
             assert "puller" in packages
@@ -406,7 +408,9 @@ def _plan_with_removal(tmp_path: Path, removes: dict[str, str], *, declared: boo
     apt = _apt(tmp_path, {"displacer": None, "distro-owned": "1.0-1"})
 
     class SimulatingApt(type(apt)):  # type: ignore[misc]
-        def simulate(self, packages: Any, *, release: str | None = None) -> Any:
+        def simulate(
+            self, packages: Any, *, release: str | None = None, no_recommends: bool = False
+        ) -> Any:
             from hammunition.backends.apt import AptSimulation
 
             return AptSimulation(

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -845,3 +845,108 @@ def test_a_vendor_deb_with_no_log_to_consult_is_planned_again(tmp_path: Path) ->
     plan = _resolve(tmp_path, ["hill"], catalog={"hill": _deb_manifest()}, known={"hill": "1.0.0"})
     [planned] = plan.packages
     assert planned.deb_installed is False
+
+
+# ---------------------------------------------------------------------------
+# Recommends, per unit: two apt sets, both simulated (D-052, issue #61)
+# ---------------------------------------------------------------------------
+
+
+def _no_recommends_manifest() -> PackageManifest:
+    """morse-classic's shape: Debian's `morse`, whose Recommends (pulseaudio)
+    Conflicts the desktop's pipewire-alsa."""
+    return _manifest(
+        name="morse-classic",
+        install=[
+            {
+                "install": {
+                    "method": "apt",
+                    "packages": ["morse"],
+                    "install_recommends": False,
+                }
+            }
+        ],
+        conflicts_with_repo_package=["pipewire-alsa"],
+    )
+
+
+def _mixed_catalog() -> dict[str, PackageManifest]:
+    return {"example": _manifest(), "morse-classic": _no_recommends_manifest()}
+
+
+def _simulates(apt: Any) -> list[str]:
+    import shlex
+
+    return [shlex.join(c.argv) for c in apt.runner.commands if "--simulate" in c.argv]
+
+
+def test_an_opted_out_unit_leaves_the_default_apt_set(tmp_path: Path) -> None:
+    plan = _resolve(
+        tmp_path,
+        ["morse-classic"],
+        catalog={"morse-classic": _no_recommends_manifest()},
+        known={"morse": None},
+    )
+    assert plan.apt_to_install == ()
+    assert plan.apt_to_install_no_recommends == ("morse",)
+    assert plan.apt_no_recommends_units == ("morse-classic",)
+    assert plan.apt_packages_all == ("morse",)
+    assert not plan.is_empty
+
+
+def test_each_set_is_simulated_the_way_it_will_be_installed(tmp_path: Path) -> None:
+    """D-016 and D-022 both rest on the simulation being of the transaction
+    that will actually run: one `--simulate` per set, the second carrying the
+    flag the second install carries."""
+    apt = _apt(tmp_path, {"example": None, "morse": None})
+    plan = _resolve(tmp_path, ["example", "morse-classic"], apt=apt, catalog=_mixed_catalog())
+    assert plan.apt_to_install == ("example",)
+    assert plan.apt_to_install_no_recommends == ("morse",)
+    assert _simulates(apt) == [
+        "apt-get install --simulate --yes -- example",
+        "apt-get install --simulate --yes --no-install-recommends -- morse",
+    ]
+
+
+def test_the_two_sets_become_two_apt_commands_in_order(tmp_path: Path) -> None:
+    from hammunition.backends.base import Command
+    from hammunition.execute import commands_for
+
+    apt = _apt(tmp_path, {"example": None, "morse": None})
+    plan = _resolve(tmp_path, ["example", "morse-classic"], apt=apt, catalog=_mixed_catalog())
+    steps = commands_for(plan, apt=apt, refresh=False)
+    installs = [s for s in steps if isinstance(s, Command) and s.argv[:2] == ("apt-get", "install")]
+    assert [s.argv for s in installs] == [
+        ("apt-get", "install", "--yes", "--no-remove", "--", "example"),
+        ("apt-get", "install", "--yes", "--no-remove", "--no-install-recommends", "--", "morse"),
+    ]
+
+
+def test_a_removal_in_the_opted_out_simulate_still_refuses(tmp_path: Path) -> None:
+    """The flag is not an escape from D-022. If apt still plans a removal with
+    Recommends suppressed, the plan refuses it and names the unit whose
+    conflicts_with_repo_package declared it."""
+    from hammunition.backends.base import CommandResult
+
+    apt = _apt(tmp_path, {"morse": None})
+    apt.runner = RecordingRunner(
+        {
+            "apt-get install --simulate --yes --no-install-recommends -- morse": CommandResult(
+                argv=(),
+                returncode=0,
+                stdout="Remv pipewire-alsa [1.4.9-1~bpo13+2]\nInst morse (2.6-2 x:parrot [amd64])\n",
+                stderr="",
+            )
+        }
+    )
+    with pytest.raises(PlanError) as excinfo:
+        _resolve(
+            tmp_path,
+            ["morse-classic"],
+            apt=apt,
+            catalog={"morse-classic": _no_recommends_manifest()},
+        )
+    text = str(excinfo.value)
+    assert "morse-classic" in text
+    assert "pipewire-alsa (1.4.9-1~bpo13+2)" in text
+    assert "--no-remove" in text

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -831,3 +831,23 @@ def test_a_probe_url_belongs_to_a_label_file_probe_only() -> None:
     data = _minimal(update={"probe": {"method": "none", "url": "https://example.invalid/x.txt"}})
     with pytest.raises((ManifestError, ValidationError), match="only a label_file probe"):
         PackageManifest.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Recommends, per unit (D-052, issue #61)
+# ---------------------------------------------------------------------------
+
+
+def test_an_apt_unit_installs_recommends_by_default() -> None:
+    """The global default is what every target distribution does, and this
+    field does not touch it."""
+    block = AptInstall.model_validate({"method": "apt", "packages": ["morse"]})
+    assert block.install_recommends is True
+
+
+def test_an_apt_unit_may_opt_out_of_recommends() -> None:
+    """Debian's `morse` Recommends pulseaudio, which Conflicts pipewire-alsa."""
+    block = AptInstall.model_validate(
+        {"method": "apt", "packages": ["morse"], "install_recommends": False}
+    )
+    assert block.install_recommends is False

--- a/tests/test_target_release.py
+++ b/tests/test_target_release.py
@@ -74,11 +74,17 @@ def _failed(stderr: str) -> CommandResult:
     return CommandResult(argv=(), returncode=100, stdout="Reading package lists...", stderr=stderr)
 
 
-def _parrot_apt(tmp_path: Path, *, retry_succeeds: bool = True, culprit_known: bool = True) -> Any:
+def _parrot_apt(
+    tmp_path: Path,
+    *,
+    retry_succeeds: bool = True,
+    culprit_known: bool = True,
+    also_known: dict[str, str | None] | None = None,
+) -> Any:
     """An apt whose default resolution refuses the way Parrot's did."""
     from test_plan import _apt
 
-    apt = _apt(tmp_path, {"curl-unit": None, "libcurl4-openssl-dev": None})
+    apt = _apt(tmp_path, {"curl-unit": None, "libcurl4-openssl-dev": None, **(also_known or {})})
     packages = "curl-unit libcurl4-openssl-dev"
     responses = {
         f"apt-get install --simulate --yes -- {packages}": _failed(PARROT_REFUSAL),
@@ -261,3 +267,52 @@ def test_the_install_failure_says_stale_lists_installed_nothing_and_names_the_fi
     assert stale_lists_diagnosis(remove, PARROT_STALE_LISTS) is None
     unpack = Action(kind="unpack", description="unpack", detail="", perform=lambda: "")
     assert stale_lists_diagnosis(unpack, PARROT_STALE_LISTS) is None
+
+
+# ---------------------------------------------------------------------------
+# D-038 meets D-052: a measured release governs both apt sets
+# ---------------------------------------------------------------------------
+
+
+def test_a_measured_release_is_carried_by_both_apt_sets(tmp_path: Path) -> None:
+    """The retry measures the release for the set that failed, and the other
+    set's install command runs with it too -- so that set is simulated again
+    with it, rather than the plan disclosing a simulation of something else."""
+    from hammunition.backends.base import Command
+    from hammunition.execute import commands_for
+    from test_plan import _manifest, _resolve
+
+    apt = _parrot_apt(tmp_path, also_known={"morse": None})
+    catalog = {
+        "curl-unit": _manifest(
+            name="curl-unit",
+            install=[
+                {
+                    "install": {
+                        "method": "apt",
+                        "packages": ["libcurl4-openssl-dev", "curl-unit"],
+                    }
+                }
+            ],
+        ),
+        "morse-classic": _manifest(
+            name="morse-classic",
+            install=[
+                {"install": {"method": "apt", "packages": ["morse"], "install_recommends": False}}
+            ],
+        ),
+    }
+    plan = _resolve(tmp_path, ["curl-unit", "morse-classic"], apt=apt, catalog=catalog)
+    assert plan.apt_release == "parrot-backports"
+    argvs = _argvs(apt)
+    assert (
+        "apt-get install --simulate --yes --no-install-recommends "
+        "--target-release parrot-backports -- morse"
+    ) in argvs
+
+    steps = commands_for(plan, apt=apt, refresh=False)
+    installs = [s for s in steps if isinstance(s, Command) and s.argv[:2] == ("apt-get", "install")]
+    assert len(installs) == 2
+    for command in installs:
+        assert "--target-release" in command.argv
+    assert "--no-install-recommends" in installs[1].argv


### PR DESCRIPTION
Closes #61 (option A, the engine half; the catalog half was #65).

## The gap

Debian's `morse` *Recommends* `pulseaudio`; `pulseaudio` `Conflicts:
pipewire-alsa`. apt installs Recommends by default, so on a PipeWire desktop
the only way apt can satisfy `morse` is by removing the desktop's ALSA
routing — and the plan refuses that, correctly, under D-022. `morse` *Depends*
`libpulse0`, which `pipewire-pulse` satisfies, so the software does not need
PulseAudio. Debian's metadata merely prefers it.

## What this adds

`AptInstall.install_recommends`, default `true`. **The global default does not
move**: Recommends stay on for every other unit on every target, and the apt
backend's module docstring still says why. One manifest may opt its own
packages out, and that opt-out is:

- **A second apt set.** Two sets are two `apt-get install` commands: the
  default one, then one carrying `--no-install-recommends` for the units that
  asked. A package named by an opted-out unit *and* by a unit that did not opt
  out stays in the default set.
- **Simulated the way it will be installed.** `plan.resolve` runs a second
  `apt-get install --simulate --no-install-recommends` and merges the two
  `AptSimulation` results — refused if either was, `Remv` lines from both — so
  the D-022 removal check reads exactly what apt will do. A `--target-release`
  measured by the D-038 retry for either set governs the whole apt step, so
  the other set is simulated again with it; two different releases is a
  refusal, because nothing is guessed.
- **Still `--no-remove`, on both commands.** The flag buys a unit its own apt
  invocation, never an exemption from D-022: a removal that survives the flag
  still refuses by name.
- **Disclosed.** The plan prints the set under *apt packages installed without
  Recommends*, naming the units that asked, and both commands appear under
  *Commands* before the confirmation.

Recorded as **D-052** in `docs/DECISIONS.md`; `docs/reference/cli.md` gains a
"Recommends, per unit" paragraph and an amendment to step 6 of *How a run is
ordered*; `docs/reference/schema.md` is regenerated.

## Catalog

`catalog/packages/morse-classic.yaml` sets `install_recommends: false` with
the measurement in a comment. Its `conflicts_with_repo_package:
[pipewire-alsa]` declaration **stays** — the flag is what avoids the removal,
the declaration is what names this unit as the reason if apt ever plans one
anyway.

**Its profile membership is unchanged: it is still not in the `morse`
profile.** Putting it back is the maintainer's call and is deliberately not
made here.

## Measured on the field target

Parrot Security 7.3, KDE, `pipewire-alsa 1.4.9-1~bpo13+2` installed,
2026-09-12, unprivileged dry runs from this branch's venv. No install was run.

`hammunition install morse-classic --dry-run --no-refresh` — exit 0, where
before it refused with `apt would remove installed package(s) ...
pipewire-alsa`:

```
apt packages installed without Recommends (D-052):
  morse-classic asked for --no-install-recommends in the manifest, because the
  Recommends of these packages conflict with software this target installs; a second
  apt-get install carries the flag for them alone. Everything else in this transaction
  keeps apt's defaults, and both commands run with --no-remove:
      morse

Commands (1):
  # Install 1 package(s) with apt without Recommends
  $ sudo env DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-remove --no-install-recommends -- morse
```

`hammunition install morse --dry-run --no-refresh` — exit 0, 16 units, three
of them source/git builds; every apt member of the profile is already
installed on this machine, so the apt step is empty and the commands are the
builds:

```
Commands (18):
  # Download and verify the flwkey source archive
  $ [fetch] https://w1hkj.org/files/flwkey/flwkey-1.2.4.tar.gz -> ~/.cache/hammunition/artifacts/e36e8678...-flwkey-1.2.4.tar.gz (sha256 verified)
  # Download and verify the ibp source archive
  $ [fetch] http://www.pa3fwm.nl/software/ibp/ibp-0.21.tgz -> ~/.cache/hammunition/artifacts/b3b118ca...-ibp-0.21.tgz (sha256 verified)
  # Clear any previous cwwav checkout
  $ [prepare] ~/.cache/hammunition/build/cwwav-0.4.1/src (removed if present, then recreated)
  # Start an empty repository for cwwav
  $ git init --quiet ~/.cache/hammunition/build/cwwav-0.4.1/src
  # Point it at https://github.com/oyvholm/cwwav
  $ git -C ~/.cache/hammunition/build/cwwav-0.4.1/src remote add origin https://github.com/oyvholm/cwwav
  # Fetch cwwav at 0.4.1
  $ git -C ~/.cache/hammunition/build/cwwav-0.4.1/src fetch --depth 1 origin 0.4.1
  # Check out 0.4.1
  $ git -C ~/.cache/hammunition/build/cwwav-0.4.1/src checkout --quiet FETCH_HEAD
  # Recreate the 0.4.1 tag for describe-based versioning
  $ git -C ~/.cache/hammunition/build/cwwav-0.4.1/src tag -f 0.4.1 FETCH_HEAD
  # Confirm cwwav is at the pinned revision
  $ [verify-pin] git rev-parse HEAD in ~/.cache/hammunition/build/cwwav-0.4.1/src must be 0.4.1
  # Compile cwwav (8 parallel jobs; sized to CPUs and memory)
  $ cd ~/.cache/hammunition/build/cwwav-0.4.1/src && CFLAGS=... make -j 8
  # Install cwwav's cwwav as cwwav
  $ sudo install -D -m 0755 ~/.cache/hammunition/build/cwwav-0.4.1/src/cwwav /usr/local/bin/cwwav
  # Unpack the flwkey source
  $ [extract] ~/.cache/hammunition/artifacts/e36e8678...-flwkey-1.2.4.tar.gz -> ~/.cache/hammunition/build/flwkey-e36e8678/src
  # Configure flwkey
  $ cd ~/.cache/hammunition/build/flwkey-e36e8678/src && ./configure --prefix=/usr/local
  # Compile flwkey (8 parallel jobs; sized to CPUs and memory)
  $ cd ~/.cache/hammunition/build/flwkey-e36e8678/src && make -j 8
  # Install flwkey into /usr/local
  $ cd ~/.cache/hammunition/build/flwkey-e36e8678/src && sudo make install
  # Unpack the ibp source
  $ [extract] ~/.cache/hammunition/artifacts/b3b118ca...-ibp-0.21.tgz -> ~/.cache/hammunition/build/ibp-b3b118ca/src
  # Compile ibp (8 parallel jobs; sized to CPUs and memory)
  $ cd ~/.cache/hammunition/build/ibp-b3b118ca/src && make -j 8
  # Install ibp's ibp as ibp
  $ sudo install -D -m 0755 ~/.cache/hammunition/build/ibp-b3b118ca/src/ibp /usr/local/bin/ibp
```

(Home paths abbreviated to `~`; the real output prints them in full. The two
apt commands side by side could not be shown on this machine — every other
apt unit in reach is already installed — so that case is covered by
`test_the_two_sets_become_two_apt_commands_in_order` instead.)

## Tests

Written first, watched fail. The schema field and its default; both argv
forms; the split into two sets; the two simulations in order with the flag on
the second; the two install commands in order; a removal reported by the
opted-out simulate still refusing with the unit named; and a D-038 release
reaching both sets. The `simulate` stubs in `tests/test_cli.py` and
`tests/test_displacement.py` take the new keyword.

`make check`: **1814 passed, 21 skipped**, mypy --strict and ruff clean, doc
links checked (1965 references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
