### PR TITLE
Per-block `binaries`, and rayhunter on aarch64 and armv7l

### DIFF
--- a/catalog/packages/rayhunter.yaml
+++ b/catalog/packages/rayhunter.yaml
@@ -15,15 +15,19 @@ categories: [rf-security, hardware]
 # `rayhunter-check` per host platform. Only those two are installed; the
 # daemon runs on the hotspot, not here.
 #
-# x86_64 only for now: the zip's rayhunter-check lives under a per-platform
-# directory (rayhunter-check-linux-x64/, -aarch64/, -armv7/) and `binaries`
-# is one list for the whole manifest, so an aarch64 block would install the
-# wrong one. Per-block binaries is the engine gap; recorded on #69.
+# One block per architecture, each naming its own `binaries`: the zip's
+# rayhunter-check lives under a per-platform directory
+# (rayhunter-check-linux-x64/, -aarch64/, -armv7/) while `installer` sits at
+# the top level, so the produced path differs per arch and a single
+# manifest-level list could not describe all three. The maintainer's
+# ClockworkPi uConsole is aarch64 (docs/reference/hardware-gaps.md).
 #
-# The digest is upstream's own, published as rayhunter-v0.12.0-linux-x64.zip.sha256
-# beside the asset and verified against the download (D-014 amendment,
-# 2026-08-26; re-verified 2026-09-12). First unit in the catalog with an
-# inherited rather than self-pinned hash.
+# Each digest is upstream's own, published as
+# rayhunter-v0.12.0-linux-<platform>.zip.sha256 beside the asset and verified
+# against the download (D-014 amendment, 2026-08-26 for x64; aarch64 and
+# armv7 fetched and hashed 2026-09-12, and all three .sha256 files re-read
+# the same day). First unit in the catalog with an inherited rather than
+# self-pinned hash.
 install:
   - when:
       arch: [x86_64]
@@ -33,13 +37,38 @@ install:
         url: https://github.com/EFForg/rayhunter/releases/download/v0.12.0/rayhunter-v0.12.0-linux-x64.zip
         sha256: 2472e86bcdc9fb6023996c06555365daee849a9fbbaa59900083ae3544bc54ee
       format: zip
-
-binaries:
-  # `installer` is too generic a name to own on PATH.
-  - produced: installer
-    install_as: rayhunter-installer
-  - produced: rayhunter-check-linux-x64/rayhunter-check
-    install_as: rayhunter-check
+    binaries:
+      # `installer` is too generic a name to own on PATH.
+      - produced: installer
+        install_as: rayhunter-installer
+      - produced: rayhunter-check-linux-x64/rayhunter-check
+        install_as: rayhunter-check
+  - when:
+      arch: [aarch64]
+    install:
+      method: binary
+      artifact:
+        url: https://github.com/EFForg/rayhunter/releases/download/v0.12.0/rayhunter-v0.12.0-linux-aarch64.zip
+        sha256: 3759e44ef94259009d13967efc6931a076f1dad13aa173b8a83d09468989e9db
+      format: zip
+    binaries:
+      - produced: installer
+        install_as: rayhunter-installer
+      - produced: rayhunter-check-linux-aarch64/rayhunter-check
+        install_as: rayhunter-check
+  - when:
+      arch: [armv7l]
+    install:
+      method: binary
+      artifact:
+        url: https://github.com/EFForg/rayhunter/releases/download/v0.12.0/rayhunter-v0.12.0-linux-armv7.zip
+        sha256: 77cd66f99bd32bcd83300e799ebb8611871e7c01dbb957c0b408cf43b76033ee
+      format: zip
+    binaries:
+      - produced: installer
+        install_as: rayhunter-installer
+      - produced: rayhunter-check-linux-armv7/rayhunter-check
+        install_as: rayhunter-check
 
 update:
   probe:

--- a/docs/packages/rayhunter.md
+++ b/docs/packages/rayhunter.md
@@ -23,11 +23,17 @@ A supported hotspot, its admin password, and a USB cable; the installer speaks U
 ## How it installs
 
 - prebuilt zip from https://github.com/EFForg/rayhunter/releases/download/v0.12.0/rayhunter-v0.12.0-linux-x64.zip — *arch x86_64*
-
-Binaries this produces:
-
-- `installer` → `rayhunter-installer`
-- `rayhunter-check-linux-x64/rayhunter-check`
+  - binaries, this block only:
+    - `installer` → `rayhunter-installer`
+    - `rayhunter-check-linux-x64/rayhunter-check`
+- prebuilt zip from https://github.com/EFForg/rayhunter/releases/download/v0.12.0/rayhunter-v0.12.0-linux-aarch64.zip — *arch aarch64*
+  - binaries, this block only:
+    - `installer` → `rayhunter-installer`
+    - `rayhunter-check-linux-aarch64/rayhunter-check`
+- prebuilt zip from https://github.com/EFForg/rayhunter/releases/download/v0.12.0/rayhunter-v0.12.0-linux-armv7.zip — *arch armv7l*
+  - binaries, this block only:
+    - `installer` → `rayhunter-installer`
+    - `rayhunter-check-linux-armv7/rayhunter-check`
 
 ## Known problems
 

--- a/docs/reference/capability-matrix.md
+++ b/docs/reference/capability-matrix.md
@@ -41,7 +41,7 @@ build HAS been run in a container say so in their own install notes.
 | kali-rolling *(unswept)* | 0 | 0 | 48 | 0 | 201 |
 | parrot *(unswept)* | 0 | 0 | 51 | 2 | 196 |
 | linuxmint-22.3 *(unswept)* | 0 | 0 | 51 | 2 | 196 |
-| debian-13-arm64 *(unswept)* | 0 | 0 | 49 | 6 | 194 |
+| debian-13-arm64 *(unswept)* | 0 | 0 | 50 | 5 | 194 |
 
 **249 manifests** against **7 targets**.
 
@@ -229,7 +229,7 @@ build HAS been run in a container say so in their own install notes.
 | `quisk` | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? |
 | `radioclk` | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? |
 | `radiosonde-auto-rx` | venv | venv | venv | venv | venv | venv | venv |
-| `rayhunter` | binary | binary | binary | binary | binary | binary | — |
+| `rayhunter` | binary | binary | binary | binary | binary | binary | binary |
 | `readsb` | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? |
 | `remotetrx` | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? |
 | `rtl-433` | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? | apt ? |

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -66,6 +66,7 @@ argument — js8call is apt on Linux Mint 22.3 and a cmake build elsewhere.
 | `when` | `Selector` | no |  |
 | `install` | `AptInstall \| SourceInstall \| GitInstall \| BinaryInstall \| VenvInstall \| NodeInstall \| PipxInstall \| DataInstall` | **yes** |  |
 | `build_depends` | `list[str]` | no | apt packages needed to BUILD only. Never reported as installed. |
+| `binaries` | `list[Binary] \| None` | no | This block's own build outputs, replacing the manifest's `binaries` wherever this block is the one that resolves. A prebuilt archive selected by `arch` can carry a different path per architecture -- rayhunter's zip has `installer` at the top level and one `rayhunter-check` under a per-platform directory -- and one manifest-level list cannot describe both. Omit the key to use the manifest's list; an empty list is refused, because it reads as an override to nothing. |
 | `note` | `str \| None` | no |  |
 
 ### `AptInstall`

--- a/scripts/gen_package_reference.py
+++ b/scripts/gen_package_reference.py
@@ -41,6 +41,7 @@ from hammunition.backends.source import DEFAULT_PREFIX, tree_destination  # noqa
 from hammunition.manifest.load import load_catalog  # noqa: E402
 from hammunition.manifest.schema import (  # noqa: E402
     AptInstall,
+    Binary,
     BinaryInstall,
     DataInstall,
     GitInstall,
@@ -89,6 +90,13 @@ def method_of(block: InstallBlock) -> str:
     # failing to compile when one is added.
     assert isinstance(install, PipxInstall)
     return f"pipx: `{install.spec}`"
+
+
+def _binary_line(b: Binary) -> str:
+    """One `produced -> install_as` row, the arrow dropped when they agree."""
+    if b.produced.split("/")[-1] == b.install_as:
+        return f"`{b.produced}`"
+    return f"`{b.produced}` → `{b.install_as}`"
 
 
 def selector_of(block: InstallBlock) -> str:
@@ -180,6 +188,14 @@ def page(m: PackageManifest) -> str:
                 "  - the project's build system has no install rule; the binaries "
                 "listed below are copied into the prefix instead"
             )
+        if block.binaries is not None:
+            # A block with its own `binaries` overrides the manifest's list for
+            # the targets it matches, so the page has to say so here rather
+            # than once at the bottom: rayhunter's zip carries a different
+            # `rayhunter-check` path per architecture (issue #69).
+            out.append("  - binaries, this block only:")
+            for b in block.binaries:
+                out.append(f"    - {_binary_line(b)}")
         if block.note:
             out.append("  - " + " ".join(block.note.split()))
     out.append("")
@@ -187,8 +203,7 @@ def page(m: PackageManifest) -> str:
     if m.binaries:
         out.append("Binaries this produces:\n")
         for b in m.binaries:
-            same = " " if b.produced.split("/")[-1] == b.install_as else " installed as "
-            out.append(f"- `{b.produced}`" + ("" if same == " " else f" → `{b.install_as}`"))
+            out.append(f"- {_binary_line(b)}")
         out.append("")
 
     if m.conflicts_with_repo_package:

--- a/src/hammunition/backends/binary.py
+++ b/src/hammunition/backends/binary.py
@@ -43,7 +43,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from hammunition.fetch import Fetcher
-from hammunition.manifest.schema import BinaryInstall, PackageManifest
+from hammunition.manifest.schema import (
+    BinaryInstall,
+    InstallBlock,
+    PackageManifest,
+    effective_binaries,
+)
 
 from .base import Action, BackendError, Command, CommandRunner
 from .source import (
@@ -91,7 +96,23 @@ class BinaryBackend:
         """
         return SourceLayout(self.build_root / f"{manifest.name}-{block.artifact.sha256[:12]}")
 
-    def steps(self, manifest: PackageManifest, block: BinaryInstall) -> list[Action | Command]:
+    def steps(
+        self, manifest: PackageManifest, install_block: InstallBlock
+    ) -> list[Action | Command]:
+        """The steps for one resolved block.
+
+        Takes the whole :class:`InstallBlock`, not just its method, because the
+        block may carry its own `binaries` overriding the manifest's: rayhunter
+        unpacks a different per-platform path on each architecture (issue #69).
+        """
+        block = install_block.install
+        if not isinstance(block, BinaryInstall):
+            raise BackendError(
+                f"{manifest.name} resolved to a {block.method} block and this backend "
+                f"installs prebuilt artifacts. Installing it anyway would install "
+                f"something the plan never named."
+            )
+        binaries = effective_binaries(manifest, install_block)
         if block.format not in IMPLEMENTED_BINARY_FORMATS:
             raise BackendError(
                 f"{manifest.name} is a {block.format!r} artifact and this backend does "
@@ -135,7 +156,7 @@ class BinaryBackend:
 
         if block.format in _ARCHIVE_FORMATS:
             layout = self.layout(manifest, block)
-            if not manifest.binaries and not block.install_tree:
+            if not binaries and not block.install_tree:
                 raise BackendError(
                     f"{manifest.name} is a prebuilt archive and names no `binaries` "
                     f"and no `install_tree`. Unpacking it would leave a directory in "
@@ -163,7 +184,7 @@ class BinaryBackend:
                     name=manifest.name,
                     produced_in=layout.src,
                     prefix=self.prefix,
-                    binaries=manifest.binaries,
+                    binaries=binaries,
                 )
             )
             if block.install_tree:
@@ -178,13 +199,13 @@ class BinaryBackend:
             return steps
 
         # `executable`: one file, installed under the name the manifest gives it.
-        if len(manifest.binaries) != 1:
+        if len(binaries) != 1:
             raise BackendError(
                 f"{manifest.name} is a single prebuilt executable, so it must declare "
                 f"exactly one `binaries` entry saying what to call it; it declares "
-                f"{len(manifest.binaries)}."
+                f"{len(binaries)}."
             )
-        target = self.prefix / "bin" / manifest.binaries[0].install_as
+        target = self.prefix / "bin" / binaries[0].install_as
         steps.append(
             Action(
                 kind="install-binary",

--- a/src/hammunition/backends/git.py
+++ b/src/hammunition/backends/git.py
@@ -32,7 +32,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from hammunition.manifest.schema import COMMIT_SHA, GitInstall, PackageManifest
+from hammunition.manifest.schema import (
+    COMMIT_SHA,
+    GitInstall,
+    InstallBlock,
+    PackageManifest,
+    effective_binaries,
+)
 
 from .base import Action, BackendError, Command, CommandRunner
 from .source import SourceLayout, build_commands, prepare_tree, tree_install_commands
@@ -65,7 +71,22 @@ class GitBackend:
         """
         return SourceLayout(self.build_root / f"{manifest.name}-{block.ref[:12]}")
 
-    def steps(self, manifest: PackageManifest, block: GitInstall) -> list[Action | Command]:
+    def steps(
+        self, manifest: PackageManifest, install_block: InstallBlock
+    ) -> list[Action | Command]:
+        """The steps for one resolved block.
+
+        Takes the whole :class:`InstallBlock` rather than its method alone: a
+        block may declare its own `binaries`, and the list this backend copies
+        must be the one the effect check reads back (issue #69).
+        """
+        block = install_block.install
+        if not isinstance(block, GitInstall):
+            raise BackendError(
+                f"{manifest.name} resolved to a {block.method} block and this backend "
+                f"builds from a git checkout. Building it anyway would install "
+                f"something the plan never named."
+            )
         layout = self.layout(manifest, block)
         src = layout.src
         steps: list[Action | Command] = [
@@ -126,7 +147,7 @@ class GitBackend:
                 project_file=block.project_file,
                 build_args=block.build_args,
                 provides_install_target=block.provides_install_target,
-                binaries=manifest.binaries,
+                binaries=effective_binaries(manifest, install_block),
                 autoreconf=block.autoreconf,
             )
         )

--- a/src/hammunition/backends/source.py
+++ b/src/hammunition/backends/source.py
@@ -57,7 +57,14 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from hammunition.fetch import Fetcher
-from hammunition.manifest.schema import Binary, PackageManifest, Patch, SourceInstall
+from hammunition.manifest.schema import (
+    Binary,
+    InstallBlock,
+    PackageManifest,
+    Patch,
+    SourceInstall,
+    effective_binaries,
+)
 
 from .base import Action, BackendError, Command
 
@@ -307,13 +314,26 @@ class SourceBackend:
         print every path before anything is fetched."""
         return SourceLayout(self.build_root / f"{manifest.name}-{block.source.sha256[:8]}")
 
-    def steps(self, manifest: PackageManifest, block: SourceInstall) -> list[Action | Command]:
+    def steps(
+        self, manifest: PackageManifest, install_block: InstallBlock
+    ) -> list[Action | Command]:
         """Fetch, verify, unpack, configure, build, install — in that order.
 
         Only the final install needs root. CLAUDE.md drops to the operator
         wherever possible, and a build that ran wholly as root would leave a
         tree of root-owned objects in the operator's cache for no benefit.
+
+        Takes the whole :class:`InstallBlock` rather than its method alone: a
+        block may declare its own `binaries`, and the list this backend copies
+        must be the one the effect check reads back (issue #69).
         """
+        block = install_block.install
+        if not isinstance(block, SourceInstall):
+            raise BackendError(
+                f"{manifest.name} resolved to a {block.method} block and this backend "
+                f"builds from a source archive. Building it anyway would install "
+                f"something the plan never named."
+            )
         if block.build_system not in IMPLEMENTED_BUILD_SYSTEMS:
             raise BackendError(
                 f"{manifest.name} declares build_system {block.build_system!r}, which "
@@ -340,7 +360,7 @@ class SourceBackend:
             ),
         ]
         steps.extend(patch_steps(manifest.name, block.patches, layout))
-        steps.extend(self._build_commands(manifest, block, layout))
+        steps.extend(self._build_commands(manifest, install_block, block, layout))
         return steps
 
     def _fetch(self, manifest: PackageManifest, block: SourceInstall) -> str:
@@ -351,6 +371,7 @@ class SourceBackend:
     def _build_commands(
         self,
         manifest: PackageManifest,
+        install_block: InstallBlock,
         block: SourceInstall,
         layout: SourceLayout,
     ) -> list[Command]:
@@ -365,7 +386,7 @@ class SourceBackend:
             project_file=block.project_file,
             build_args=block.build_args,
             provides_install_target=block.provides_install_target,
-            binaries=manifest.binaries,
+            binaries=effective_binaries(manifest, install_block),
             autoreconf=block.autoreconf,
         )
         if block.install_tree:

--- a/src/hammunition/execute.py
+++ b/src/hammunition/execute.py
@@ -56,6 +56,7 @@ from hammunition.manifest.schema import (
     NodeInstall,
     SourceInstall,
     VenvInstall,
+    effective_binaries,
 )
 from hammunition.plan import InstallPlan
 from hammunition.state import RemovalPlan, TransactionLog
@@ -310,7 +311,7 @@ def already_built(
         else:
             continue
         present: list[bool] = []
-        for declared in planned.manifest.binaries:
+        for declared in effective_binaries(planned.manifest, planned.block):
             path = prefix / "bin" / declared.install_as
             present.append(path.is_file() and os.access(path, os.X_OK))
         marker = _tree_marker(planned.block)
@@ -399,14 +400,14 @@ def commands_for(
                     f"{planned.name} is a source build and no source backend was supplied. "
                     f"Skipping it would report a successful run that installed nothing."
                 )
-            builds.extend(source.steps(planned.manifest, block))
+            builds.extend(source.steps(planned.manifest, planned.block))
         elif isinstance(block, GitInstall):
             if git is None:
                 raise BackendError(
                     f"{planned.name} builds from git and no git backend was supplied. "
                     f"Skipping it would report a successful run that installed nothing."
                 )
-            builds.extend(git.steps(planned.manifest, block))
+            builds.extend(git.steps(planned.manifest, planned.block))
         elif isinstance(block, BinaryInstall):
             if planned.deb_installed:
                 # The plan attributed this .deb to us and dpkg still holds it
@@ -419,7 +420,7 @@ def commands_for(
                     f"was supplied. Skipping it would report a successful run that "
                     f"installed nothing."
                 )
-            builds.extend(binary.steps(planned.manifest, block))
+            builds.extend(binary.steps(planned.manifest, planned.block))
         elif isinstance(block, VenvInstall):
             if venv is None:
                 raise BackendError(
@@ -731,7 +732,7 @@ def verify_effects(
         for planned in plan.packages:
             if not _declares_installed_binaries(planned.block):
                 continue
-            for binary in planned.manifest.binaries:
+            for binary in effective_binaries(planned.manifest, planned.block):
                 path = prefix / "bin" / binary.install_as
                 present = path.is_file() and os.access(path, os.X_OK)
                 checks.append(

--- a/src/hammunition/manifest/schema.py
+++ b/src/hammunition/manifest/schema.py
@@ -30,6 +30,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = [
+    "Binary",
     "ConsentGate",
     "InstallBlock",
     "ManifestError",
@@ -40,6 +41,7 @@ __all__ = [
     "RiskCategory",
     "Selector",
     "Status",
+    "effective_binaries",
 ]
 
 SHA256 = re.compile(r"^[0-9a-f]{64}$")
@@ -763,26 +765,9 @@ InstallMethod = Annotated[
 ]
 
 
-class InstallBlock(Strict):
-    """One (selector -> method) pair. The method itself varies, not just its
-    argument — js8call is apt on Linux Mint 22.3 and a cmake build elsewhere."""
-
-    when: Selector = Field(default_factory=Selector)
-    install: InstallMethod
-    build_depends: list[str] = Field(
-        default_factory=list,
-        description="apt packages needed to BUILD only. Never reported as installed.",
-    )
-    note: str | None = None
-
-    @model_validator(mode="after")
-    def _check(self) -> InstallBlock:
-        _check_package_names(self.build_depends, "build_depends")
-        return self
-
-
 # ---------------------------------------------------------------------------
-# Outputs: binaries, launchers, service endpoints.
+# Outputs: binaries, launchers, service endpoints.  `Binary` is defined here,
+# ahead of `InstallBlock`, because a block may override the manifest's list.
 # ---------------------------------------------------------------------------
 
 
@@ -805,6 +790,82 @@ class Binary(Strict):
     (AIS-catcher's rule installs `AIS-catcher`, whatever the manifest says),
     because the post-run effect check looks for `<prefix>/bin/<install_as>`."""
     install_as: str = Field(description="Final name in the install prefix.")
+
+
+class InstallBlock(Strict):
+    """One (selector -> method) pair. The method itself varies, not just its
+    argument — js8call is apt on Linux Mint 22.3 and a cmake build elsewhere."""
+
+    when: Selector = Field(default_factory=Selector)
+    install: InstallMethod
+    build_depends: list[str] = Field(
+        default_factory=list,
+        description="apt packages needed to BUILD only. Never reported as installed.",
+    )
+    binaries: list[Binary] | None = Field(
+        default=None,
+        description=(
+            "This block's own build outputs, replacing the manifest's "
+            "`binaries` wherever this block is the one that resolves. A "
+            "prebuilt archive selected by `arch` can carry a different path "
+            "per architecture -- rayhunter's zip has `installer` at the top "
+            "level and one `rayhunter-check` under a per-platform directory -- "
+            "and one manifest-level list cannot describe both. Omit the key to "
+            "use the manifest's list; an empty list is refused, because it "
+            "reads as an override to nothing."
+        ),
+    )
+    note: str | None = None
+
+    @model_validator(mode="after")
+    def _check(self) -> InstallBlock:
+        _check_package_names(self.build_depends, "build_depends")
+        self._check_binaries()
+        return self
+
+    def _check_binaries(self) -> None:
+        """A block's `binaries` is only meaningful where the engine copies files.
+
+        Source, git and non-deb binary blocks install each declared binary into
+        the prefix by name. apt and a vendor `.deb` place their own contents,
+        and a venv, node or data block installs something that is not a build
+        output at all -- a list there would be read by nothing, which is the
+        silent-no-op shape D-031 exists to refuse.
+        """
+        if self.binaries is None:
+            return
+        where = self._describe()
+        if not self.binaries:
+            raise ManifestError(
+                f"{where}: `binaries` is empty. An empty list overrides the manifest's "
+                f"`binaries` with nothing, so the block would install nothing while "
+                f"reporting success; omit the key to use the manifest's list."
+            )
+        method = self.install
+        installs_binaries = isinstance(method, SourceInstall | GitInstall) or (
+            isinstance(method, BinaryInstall) and method.format != "deb"
+        )
+        if not installs_binaries:
+            raise ManifestError(
+                f"{where}: `binaries` names build outputs the engine copies into the "
+                f"prefix, and a {method.method} block copies none -- apt places the "
+                f"package's own files. Drop the list."
+            )
+        names = [b.install_as for b in self.binaries]
+        dupes = {n for n in names if names.count(n) > 1}
+        if dupes:
+            raise ManifestError(f"{where}: duplicate install_as: {sorted(dupes)}")
+
+    def _describe(self) -> str:
+        """This block, named the way a manifest author sees it in the YAML."""
+        parts = [f"method={self.install.method}"]
+        if self.when.distro:
+            parts.append(f"distro={','.join(self.when.distro)}")
+        if self.when.distro_version:
+            parts.append(f"distro_version={','.join(self.when.distro_version)}")
+        if self.when.arch:
+            parts.append(f"arch={','.join(a.value for a in self.when.arch)}")
+        return f"install block ({', '.join(parts)})"
 
 
 class ServiceEndpoint(Strict):
@@ -1234,7 +1295,9 @@ class PackageManifest(Strict):
         for block in self.install:
             if getattr(block.install, "provides_install_target", True):
                 continue
-            if not self.binaries and not getattr(block.install, "install_tree", False):
+            if not effective_binaries(self, block) and not getattr(
+                block.install, "install_tree", False
+            ):
                 raise ManifestError(
                     f"{self.name}: provides_install_target is false, so nothing would "
                     f"be installed. Declare `binaries` naming what the build emits and "
@@ -1318,6 +1381,20 @@ class PackageManifest(Strict):
         for cfg in self.config_files:
             out |= cfg.station_variables
         return out
+
+
+def effective_binaries(manifest: PackageManifest, block: InstallBlock) -> Sequence[Binary]:
+    """The binaries *this* block installs: its own list, else the manifest's.
+
+    Every reader goes through here -- the three step builders, the post-run
+    effect check, ``already_built``, ``uninstall``'s removal planning and the
+    generated package reference -- because a manifest with per-block lists has
+    two answers to "what does this install" and they must not disagree. One
+    reader left on ``manifest.binaries`` would install the aarch64 block's
+    files and then confirm the x86_64 block's names, which is the D-031 shape
+    the block-level field exists to close (issue #69).
+    """
+    return block.binaries if block.binaries is not None else manifest.binaries
 
 
 # ---------------------------------------------------------------------------

--- a/src/hammunition/plan.py
+++ b/src/hammunition/plan.py
@@ -69,6 +69,7 @@ from hammunition.manifest.schema import (
     ProfileManifest,
     SourceInstall,
     Status,
+    effective_binaries,
 )
 from hammunition.state.log import TransactionLog
 from hammunition.state.uninstall import deb_attributed
@@ -528,7 +529,7 @@ def _check_engine_capability(
             )
         elif (
             block.install.format != "deb"
-            and not manifest.binaries
+            and not effective_binaries(manifest, block)
             and not block.install.install_tree
         ):
             found.append(

--- a/src/hammunition/state/uninstall.py
+++ b/src/hammunition/state/uninstall.py
@@ -64,11 +64,13 @@ from hammunition.manifest.schema import (
     BinaryInstall,
     DataInstall,
     GitInstall,
+    InstallBlock,
     NodeInstall,
     PackageManifest,
     ProfileManifest,
     SourceInstall,
     VenvInstall,
+    effective_binaries,
 )
 
 if TYPE_CHECKING:
@@ -310,9 +312,15 @@ def plan_removal(
                 if Path(path).name in names:
                     add(unit, ArtifactRemoval("apt-repo", Path(path), "log", requires_root=True))
 
-    def plan_binaries(unit: str, manifest: PackageManifest) -> None:
-        """Prefix binaries the engine copied — removable only on log evidence."""
-        for binary in manifest.binaries:
+    def plan_binaries(unit: str, manifest: PackageManifest, block: InstallBlock) -> None:
+        """Prefix binaries the engine copied — removable only on log evidence.
+
+        Read from the resolved block, because the block may name its own
+        (issue #69): removing the manifest-level names on a machine that
+        installed the block's would leave the installed files behind and
+        report the removal done.
+        """
+        for binary in effective_binaries(manifest, block):
             dest = paths.prefix / "bin" / binary.install_as
             if str(dest) in attributed_files:
                 add(unit, ArtifactRemoval("binary", dest, "log", requires_root=True))
@@ -396,7 +404,7 @@ def plan_removal(
                 else:
                     already_absent.setdefault(unit, []).append(deb_pkg)
             else:
-                plan_binaries(unit, manifest)
+                plan_binaries(unit, manifest, block)
                 if install.install_tree:
                     add(
                         unit,
@@ -431,7 +439,7 @@ def plan_removal(
                 )
                 continue
             if not install.provides_install_target:
-                plan_binaries(unit, manifest)
+                plan_binaries(unit, manifest, block)
             if install.install_tree:
                 add(
                     unit,

--- a/tests/test_binary_backend.py
+++ b/tests/test_binary_backend.py
@@ -146,8 +146,8 @@ def test_an_appimage_is_refused_by_name(tmp_path: Path) -> None:
         "appimage",
         binaries=[{"produced": "x", "install_as": "x"}],
     )
-    block = manifest.install[0].install
-    assert isinstance(block, BinaryInstall)
+    block = manifest.install[0]
+    assert isinstance(block.install, BinaryInstall)
     with pytest.raises(BackendError, match="appimage"):
         _backend(tmp_path).steps(manifest, block)
 
@@ -155,8 +155,8 @@ def test_an_appimage_is_refused_by_name(tmp_path: Path) -> None:
 def test_an_archive_naming_no_binaries_is_refused(tmp_path: Path) -> None:
     """Unpacking it would leave a directory in a cache and install nothing."""
     manifest = _manifest("https://example.invalid/x.zip", "0" * 64, "zip", binaries=[])
-    block = manifest.install[0].install
-    assert isinstance(block, BinaryInstall)
+    block = manifest.install[0]
+    assert isinstance(block.install, BinaryInstall)
     with pytest.raises(BackendError, match="names no `binaries`"):
         _backend(tmp_path).steps(manifest, block)
 
@@ -168,8 +168,8 @@ def test_a_single_executable_needs_exactly_one_name(tmp_path: Path) -> None:
         "executable",
         binaries=[{"produced": "a", "install_as": "a"}, {"produced": "b", "install_as": "b"}],
     )
-    block = manifest.install[0].install
-    assert isinstance(block, BinaryInstall)
+    block = manifest.install[0]
+    assert isinstance(block.install, BinaryInstall)
     with pytest.raises(BackendError, match="exactly one"):
         _backend(tmp_path).steps(manifest, block)
 
@@ -189,8 +189,8 @@ def test_a_deb_goes_through_apt_and_not_dpkg(tmp_path: Path) -> None:
         "deb",
         binaries=[],
     )
-    block = manifest.install[0].install
-    assert isinstance(block, BinaryInstall)
+    block = manifest.install[0]
+    assert isinstance(block.install, BinaryInstall)
     runner = RecordingRunner()
     backend = _backend(tmp_path, runner)
     steps = backend.steps(manifest, block)
@@ -232,9 +232,9 @@ def test_a_deb_is_simulated_with_the_apt_step_after_its_fetch_and_before_apt_ins
     assert labels == ["fetch", "apt-get", "apt-get", "install-deb"]
     simulate = steps[1]
     assert isinstance(simulate, Command)
-    block = manifest.install[0].install
-    assert isinstance(block, BinaryInstall)
-    deb = str(backend.fetcher.path_for(block.artifact))
+    block = manifest.install[0]
+    assert isinstance(block.install, BinaryInstall)
+    deb = str(backend.fetcher.path_for(block.install.artifact))
     assert simulate.argv == (
         "apt-get",
         "install",
@@ -284,8 +284,8 @@ def test_a_prebuilt_archive_is_fetched_verified_unpacked_and_installed(
     manifest = _manifest(
         url, digest, "zip", binaries=[{"produced": "bin/prebuilt", "install_as": "prebuilt"}]
     )
-    block = manifest.install[0].install
-    assert isinstance(block, BinaryInstall)
+    block = manifest.install[0]
+    assert isinstance(block.install, BinaryInstall)
     backend = _backend(tmp_path)
     plan = InstallPlan(
         target=TARGET,
@@ -311,8 +311,8 @@ def test_a_tampered_artifact_installs_nothing(tmp_path: Path, served_zip: tuple[
     manifest = _manifest(
         url, wrong, "zip", binaries=[{"produced": "bin/prebuilt", "install_as": "prebuilt"}]
     )
-    block = manifest.install[0].install
-    assert isinstance(block, BinaryInstall)
+    block = manifest.install[0]
+    assert isinstance(block.install, BinaryInstall)
     backend = _backend(tmp_path)
     plan = InstallPlan(
         target=TARGET,
@@ -384,8 +384,8 @@ def test_the_binary_backend_passes_the_operator_to_the_tree_install(tmp_path: Pa
             },
         }
     )
-    block = manifest.install[0].install
-    assert isinstance(block, BinaryInstall)
+    block = manifest.install[0]
+    assert isinstance(block.install, BinaryInstall)
     last = backend.steps(manifest, block)[-1]
     assert isinstance(last, Command)
     assert last.argv[:5] == ("chown", "-R", "-h", "--", "alice:")

--- a/tests/test_block_binaries.py
+++ b/tests/test_block_binaries.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Per-block `binaries`, and the one list every reader must agree on (issue #69).
+
+`PackageManifest.binaries` is one list for the whole manifest. A prebuilt
+archive whose blocks select by `arch` can emit a different path per block:
+Rayhunter's release zip carries `installer` at the top level and one
+`rayhunter-check` under a per-platform directory, so an aarch64 block reading
+the manifest-level list would install the x64 executable and the post-run
+effect check would confirm it. That is the D-031 shape — a run that reports
+success having installed the wrong file — so the block's own list, when it
+declares one, is what the backends install, what `verify_effects` reads back,
+what `already_built` counts and what `uninstall` plans to remove.
+
+Every test here was watched red before `InstallBlock.binaries` and
+`effective_binaries` existed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from hammunition.backends import BinaryBackend, Command, RecordingRunner  # noqa: E402
+from hammunition.distro import Target  # noqa: E402
+from hammunition.execute import verify_effects  # noqa: E402
+from hammunition.fetch import Fetcher  # noqa: E402
+from hammunition.manifest.load import load_catalog  # noqa: E402
+from hammunition.manifest.schema import (  # noqa: E402
+    BinaryInstall,
+    ManifestError,
+    PackageManifest,
+    effective_binaries,
+)
+from hammunition.plan import InstallPlan, PlannedPackage  # noqa: E402
+
+CATALOG = REPO_ROOT / "catalog" / "packages"
+SHA = "b" * 64
+
+DOCS = {
+    "what_it_does": "Stands in for a prebuilt archive whose layout differs per arch.",
+    "why_you_want_it": "To prove the block's own `binaries` is the list that is used.",
+    "upstream_url": "https://example.invalid/",
+}
+
+
+def _two_arch_manifest(**overrides: Any) -> PackageManifest:
+    """Rayhunter's shape: one zip per arch, the payload path carrying the arch."""
+    data: dict[str, Any] = {
+        "name": "perarch",
+        "version": "1.0",
+        "summary": "A prebuilt archive laid out differently on each architecture",
+        "categories": ["rf-security"],
+        "install": [
+            {
+                "when": {"arch": ["x86_64"]},
+                "install": {
+                    "method": "binary",
+                    "artifact": {"url": "https://example.invalid/x64.zip", "sha256": SHA},
+                    "format": "zip",
+                },
+                "binaries": [
+                    {"produced": "installer", "install_as": "perarch-installer"},
+                    {"produced": "check-linux-x64/check", "install_as": "perarch-check"},
+                ],
+            },
+            {
+                "when": {"arch": ["aarch64"]},
+                "install": {
+                    "method": "binary",
+                    "artifact": {"url": "https://example.invalid/arm64.zip", "sha256": SHA},
+                    "format": "zip",
+                },
+                "binaries": [
+                    {"produced": "installer", "install_as": "perarch-installer"},
+                    {"produced": "check-linux-aarch64/check", "install_as": "perarch-check"},
+                ],
+            },
+        ],
+        "update": {"probe": {"method": "none"}},
+        "documentation": DOCS,
+    }
+    data.update(overrides)
+    return PackageManifest.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Schema: what it accepts and what it refuses
+# ---------------------------------------------------------------------------
+
+
+def test_a_block_may_declare_its_own_binaries() -> None:
+    manifest = _two_arch_manifest()
+    assert manifest.binaries == []
+    x64, arm = manifest.install
+    assert x64.binaries is not None and arm.binaries is not None
+    assert [b.produced for b in x64.binaries] == ["installer", "check-linux-x64/check"]
+    assert [b.produced for b in arm.binaries] == ["installer", "check-linux-aarch64/check"]
+
+
+def test_block_binaries_are_refused_on_a_method_that_installs_none() -> None:
+    """apt places a package's files; naming build outputs there means nothing,
+    and a list nothing reads is a claim the engine would never honour."""
+    with pytest.raises((ValidationError, ManifestError)) as caught:
+        PackageManifest.model_validate(
+            {
+                "name": "aptish",
+                "version": "1.0",
+                "summary": "An apt block that names binaries",
+                "categories": ["rf-security"],
+                "install": [
+                    {
+                        "when": {"arch": ["x86_64"]},
+                        "install": {"method": "apt", "packages": ["aptish"]},
+                        "binaries": [{"produced": "aptish", "install_as": "aptish"}],
+                    }
+                ],
+                "update": {"probe": {"method": "none"}},
+                "documentation": DOCS,
+            }
+        )
+    message = str(caught.value)
+    assert "apt" in message and "binaries" in message
+
+
+def test_block_binaries_are_refused_on_a_deb() -> None:
+    """apt places a .deb's contents; the engine copies nothing to name."""
+    with pytest.raises((ValidationError, ManifestError)) as caught:
+        PackageManifest.model_validate(
+            {
+                "name": "debbish",
+                "version": "1.0",
+                "summary": "A vendor .deb block that names binaries",
+                "categories": ["rf-security"],
+                "install": [
+                    {
+                        "install": {
+                            "method": "binary",
+                            "artifact": {"url": "https://example.invalid/x.deb", "sha256": SHA},
+                            "format": "deb",
+                            "deb_package": "debbish",
+                        },
+                        "binaries": [{"produced": "debbish", "install_as": "debbish"}],
+                    }
+                ],
+                "update": {"probe": {"method": "none"}},
+                "documentation": DOCS,
+            }
+        )
+    assert "binaries" in str(caught.value)
+
+
+def test_an_empty_block_binaries_list_is_refused() -> None:
+    """`binaries: []` reads as an override to nothing, which would silently
+    install nothing where the manifest's list installs something. Omit the key."""
+    with pytest.raises((ValidationError, ManifestError)) as caught:
+        _two_arch_manifest(
+            install=[
+                {
+                    "when": {"arch": ["x86_64"]},
+                    "install": {
+                        "method": "binary",
+                        "artifact": {"url": "https://example.invalid/x64.zip", "sha256": SHA},
+                        "format": "zip",
+                    },
+                    "binaries": [],
+                }
+            ],
+            binaries=[{"produced": "installer", "install_as": "perarch-installer"}],
+        )
+    assert "empty" in str(caught.value)
+
+
+# ---------------------------------------------------------------------------
+# The helper every reader goes through
+# ---------------------------------------------------------------------------
+
+
+def test_effective_binaries_prefers_the_block() -> None:
+    manifest = _two_arch_manifest(
+        binaries=[{"produced": "installer", "install_as": "manifest-level"}]
+    )
+    arm = manifest.install[1]
+    assert [b.install_as for b in effective_binaries(manifest, arm)] == [
+        "perarch-installer",
+        "perarch-check",
+    ]
+    assert [b.produced for b in effective_binaries(manifest, arm)] == [
+        "installer",
+        "check-linux-aarch64/check",
+    ]
+
+
+def test_effective_binaries_falls_back_to_the_manifest() -> None:
+    manifest = PackageManifest.model_validate(
+        {
+            "name": "shared",
+            "version": "1.0",
+            "summary": "One layout on every architecture",
+            "categories": ["rf-security"],
+            "install": [
+                {
+                    "install": {
+                        "method": "binary",
+                        "artifact": {"url": "https://example.invalid/any.zip", "sha256": SHA},
+                        "format": "zip",
+                    }
+                }
+            ],
+            "binaries": [{"produced": "shared", "install_as": "shared"}],
+            "update": {"probe": {"method": "none"}},
+            "documentation": DOCS,
+        }
+    )
+    assert [b.install_as for b in effective_binaries(manifest, manifest.install[0])] == ["shared"]
+
+
+# ---------------------------------------------------------------------------
+# The block's list is what gets installed, and what gets checked
+# ---------------------------------------------------------------------------
+
+
+def test_the_binary_backend_installs_the_blocks_own_binaries(tmp_path: Path) -> None:
+    """The aarch64 block's `produced` path is what the install command copies.
+    Reading the manifest-level list here is how the x64 executable would land
+    on an aarch64 machine with the run reporting success."""
+    manifest = _two_arch_manifest(
+        binaries=[{"produced": "check-linux-x64/check", "install_as": "perarch-check"}]
+    )
+    backend = BinaryBackend(
+        fetcher=Fetcher(tmp_path / "cache"),
+        runner=RecordingRunner(),
+        build_root=tmp_path / "build",
+        prefix=tmp_path / "prefix",
+    )
+    rendered = " ".join(
+        " ".join(step.argv)
+        for step in backend.steps(manifest, manifest.install[1])
+        if isinstance(step, Command)
+    )
+    assert "check-linux-aarch64/check" in rendered
+    assert "check-linux-x64/check" not in rendered
+
+
+def test_verify_effects_reads_back_the_blocks_own_binaries(tmp_path: Path) -> None:
+    """The post-run check must ask about the file the block installed. Asking
+    about the manifest-level name is D-031 exactly: a check that passes on the
+    wrong artefact is worse than no check."""
+    manifest = _two_arch_manifest(binaries=[{"produced": "installer", "install_as": "wrong-name"}])
+    prefix = tmp_path / "prefix"
+    (prefix / "bin").mkdir(parents=True)
+    for name in ("perarch-installer", "perarch-check"):
+        path = prefix / "bin" / name
+        path.write_text("#!/bin/sh\n")
+        path.chmod(0o755)
+    # The manifest-level name is deliberately absent from the prefix.
+    plan = InstallPlan(
+        target=Target(distro="debian", version="13", arch="aarch64"),
+        packages=(PlannedPackage(manifest=manifest, block=manifest.install[1], apt_packages=()),),
+    )
+    report = verify_effects(plan, None, prefix=prefix)
+    subjects = {check.subject: check.confirmed for check in report.checks}
+    assert subjects["perarch:perarch-installer"] is True
+    assert subjects["perarch:perarch-check"] is True
+    assert "perarch:wrong-name" not in subjects
+
+
+# ---------------------------------------------------------------------------
+# The catalog entry this was written for
+# ---------------------------------------------------------------------------
+
+
+def test_rayhunter_resolves_per_arch_with_its_own_binaries() -> None:
+    """The maintainer's uConsole is aarch64 (docs/reference/hardware-gaps.md),
+    and until issue #69 the manifest had no block for it at all."""
+    rayhunter = load_catalog(CATALOG)["rayhunter"]
+    wanted = {
+        "x86_64": "rayhunter-check-linux-x64/rayhunter-check",
+        "aarch64": "rayhunter-check-linux-aarch64/rayhunter-check",
+        "armv7l": "rayhunter-check-linux-armv7/rayhunter-check",
+    }
+    for arch, produced in wanted.items():
+        block = rayhunter.resolve("debian", "13", arch)
+        assert block is not None, f"rayhunter does not resolve on {arch}"
+        install = block.install
+        assert isinstance(install, BinaryInstall)
+        assert f"linux-{'x64' if arch == 'x86_64' else arch.rstrip('l')}" in install.artifact.url
+        names = effective_binaries(rayhunter, block)
+        assert [b.produced for b in names] == ["installer", produced]
+        assert [b.install_as for b in names] == ["rayhunter-installer", "rayhunter-check"]

--- a/tests/test_git_backend.py
+++ b/tests/test_git_backend.py
@@ -157,7 +157,7 @@ def test_the_pin_is_checked_after_the_checkout_and_before_the_build(tmp_path: Pa
     revision that had already been installed."""
     manifest = _manifest()
     backend = _backend(_HeadRunner(SHA), tmp_path)
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
 
     labels = [s.kind if isinstance(s, Action) else " ".join(s.argv[:2]) for s in steps]
     assert labels.index("verify-pin") > labels.index("git -C"), "the pin was checked too early"
@@ -170,7 +170,7 @@ def test_the_fetch_is_shallow_and_by_ref(tmp_path: Path) -> None:
     """A pinned commit should cost one object walk, not a project's history."""
     manifest = _manifest()
     backend = _backend(_HeadRunner(SHA), tmp_path)
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
 
     fetch = next(s for s in steps if isinstance(s, Command) and "fetch" in s.argv)
     assert "--depth" in fetch.argv and "1" in fetch.argv
@@ -180,7 +180,7 @@ def test_the_fetch_is_shallow_and_by_ref(tmp_path: Path) -> None:
 def test_only_the_install_step_is_privileged(tmp_path: Path) -> None:
     manifest = _manifest()
     backend = _backend(_HeadRunner(SHA), tmp_path)
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
 
     privileged = [s for s in steps if s.requires_root]
     assert len(privileged) == 1
@@ -237,7 +237,7 @@ def test_the_git_backend_passes_the_operator_to_the_tree_install(tmp_path: Path)
         owner="alice",
     )
     manifest = _manifest(install_tree=True, tree_marker="thing")
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
     last = steps[-1]
     assert isinstance(last, Command)
     assert last.argv[:5] == ("chown", "-R", "-h", "--", "alice:")

--- a/tests/test_source_backend.py
+++ b/tests/test_source_backend.py
@@ -241,7 +241,7 @@ def test_extraction_leaves_no_staging_directory(tmp_path: Path) -> None:
 def test_the_steps_run_in_the_order_a_build_needs(tmp_path: Path) -> None:
     backend = _backend(tmp_path)
     manifest = _manifest("autotools")
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
 
     kinds = [s.kind if isinstance(s, Action) else s.argv[0] for s in steps]
     assert kinds == ["fetch", "extract", "./configure", "make", "make"]
@@ -252,7 +252,7 @@ def test_only_the_install_step_is_privileged(tmp_path: Path) -> None:
     root leaves a tree of root-owned objects in the operator's cache."""
     backend = _backend(tmp_path)
     manifest = _manifest("cmake")
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
 
     privileged = [s for s in steps if s.requires_root]
     assert len(privileged) == 1
@@ -265,7 +265,7 @@ def test_the_plan_can_print_every_path_before_anything_is_fetched(tmp_path: Path
     renders real paths rather than describing them."""
     backend = _backend(tmp_path)
     manifest = _manifest("cmake")
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
 
     assert not (tmp_path / "build").exists()
     assert not (tmp_path / "cache").exists()
@@ -280,7 +280,7 @@ def test_compiler_flags_reach_the_compiler(tmp_path: Path) -> None:
     string-mangling; declaring them makes them reviewable catalog data."""
     manifest = _manifest("autotools", compiler_flags=["-Wno-incompatible-pointer-types"])
     backend = _backend(tmp_path)
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
 
     configure = next(s for s in steps if isinstance(s, Command) and s.argv[0] == "./configure")
     assert configure.env["CFLAGS"] == "-Wno-incompatible-pointer-types"
@@ -292,7 +292,7 @@ def test_the_qmake_project_file_is_passed_when_declared(tmp_path: Path) -> None:
     exists at all."""
     manifest = _manifest("qmake", project_file="MSHV_64.pro")
     backend = _backend(tmp_path)
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
 
     qmake = next(s for s in steps if isinstance(s, Command) and s.argv[0] == "qmake")
     assert "MSHV_64.pro" in qmake.argv
@@ -301,7 +301,7 @@ def test_the_qmake_project_file_is_passed_when_declared(tmp_path: Path) -> None:
 def test_the_install_prefix_is_usr_local(tmp_path: Path) -> None:
     manifest = _manifest("autotools")
     backend = _backend(tmp_path)
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
     configure = next(s for s in steps if isinstance(s, Command) and s.argv[0] == "./configure")
     assert f"--prefix={DEFAULT_PREFIX}" in configure.argv
 
@@ -311,7 +311,7 @@ def test_build_commands_carry_a_working_directory(tmp_path: Path) -> None:
     manifest = _manifest("autotools")
     backend = _backend(tmp_path)
     layout = backend.layout(manifest, manifest.install[0].install)  # type: ignore[arg-type]
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
 
     configure = next(s for s in steps if isinstance(s, Command) and s.argv[0] == "./configure")
     assert configure.cwd == layout.src
@@ -327,7 +327,7 @@ def test_a_custom_build_system_is_refused_by_name(tmp_path: Path) -> None:
     manifest = _manifest("custom")
     backend = _backend(tmp_path)
     with pytest.raises(BackendError, match="custom"):
-        backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+        backend.steps(manifest, manifest.install[0])
 
 
 def test_patches_are_refused_by_name(tmp_path: Path) -> None:
@@ -339,7 +339,7 @@ def test_patches_are_refused_by_name(tmp_path: Path) -> None:
     )
     backend = _backend(tmp_path)
     with pytest.raises(BackendError, match="patch"):
-        backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+        backend.steps(manifest, manifest.install[0])
 
 
 # ---------------------------------------------------------------------------
@@ -381,7 +381,7 @@ def test_the_install_step_stays_privileged_even_when_run_as_root(tmp_path: Path)
         prefix=DEFAULT_PREFIX,
         jobs=2,
     )
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
     install = next(
         s for s in steps if isinstance(s, Command) and s.argv[:2] == ("cmake", "--install")
     )
@@ -429,9 +429,12 @@ def test_a_project_with_no_install_rule_installs_its_declared_binaries(tmp_path:
     backend = SourceBackend(
         Fetcher(tmp_path / "cache"), build_root=tmp_path / "b", prefix=tmp_path / "p", jobs=2
     )
-    block = manifest.install[0].install
+    install_block = manifest.install[0]
+    block = install_block.install
     assert isinstance(block, SourceInstall)
-    commands = backend._build_commands(manifest, block, backend.layout(manifest, block))
+    commands = backend._build_commands(
+        manifest, install_block, block, backend.layout(manifest, block)
+    )
 
     argvs = [c.argv for c in commands]
     assert ("make", "install") not in argvs, "the failing install step is still there"
@@ -474,9 +477,12 @@ def test_a_cmake_project_with_no_install_rule_copies_from_its_build_dir(tmp_path
     backend = SourceBackend(
         Fetcher(tmp_path / "cache"), build_root=tmp_path / "b", prefix=tmp_path / "p", jobs=2
     )
-    block = manifest.install[0].install
+    install_block = manifest.install[0]
+    block = install_block.install
     assert isinstance(block, SourceInstall)
-    commands = backend._build_commands(manifest, block, backend.layout(manifest, block))
+    commands = backend._build_commands(
+        manifest, install_block, block, backend.layout(manifest, block)
+    )
 
     assert not any("--install" in c.argv for c in commands), "cmake --install would install nothing"
     last = commands[-1]
@@ -550,9 +556,12 @@ def test_the_default_still_runs_the_build_systems_own_install(tmp_path: Path) ->
     backend = SourceBackend(
         Fetcher(tmp_path / "cache"), build_root=tmp_path / "b", prefix=tmp_path / "p", jobs=2
     )
-    block = manifest.install[0].install
+    install_block = manifest.install[0]
+    block = install_block.install
     assert isinstance(block, SourceInstall)
-    commands = backend._build_commands(manifest, block, backend.layout(manifest, block))
+    commands = backend._build_commands(
+        manifest, install_block, block, backend.layout(manifest, block)
+    )
     assert commands[-1].argv == ("make", "install")
 
 
@@ -701,7 +710,7 @@ def test_the_source_backend_passes_the_operator_to_the_tree_install(tmp_path: Pa
 
     backend = _backend(tmp_path, prefix=P("/usr/local"), owner="alice")
     manifest = _manifest("qmake", install_tree=True, tree_marker="thing")
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
     last = steps[-1]
     assert isinstance(last, Command)
     assert last.argv[:5] == ("chown", "-R", "-h", "--", "alice:")

--- a/tests/test_source_build_end_to_end.py
+++ b/tests/test_source_build_end_to_end.py
@@ -146,7 +146,7 @@ def test_a_source_package_is_fetched_verified_built_and_installed(
     assert not needs_root_for(prefix), "a writable prefix must not ask for root"
 
     manifest = _manifest(url, digest)
-    block = manifest.install[0].install
+    block = manifest.install[0]
     backend = SourceBackend(
         Fetcher(tmp_path / "cache"),
         build_root=tmp_path / "build",
@@ -157,7 +157,7 @@ def test_a_source_package_is_fetched_verified_built_and_installed(
         target=TARGET,
         packages=(PlannedPackage(manifest=manifest, block=manifest.install[0], apt_packages=()),),
     )
-    steps = backend.steps(manifest, block)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, block)
     log = TransactionLog(tmp_path / "log.jsonl")
 
     report = execute(steps, SubprocessRunner(), log=log, plan=plan)
@@ -197,7 +197,7 @@ def test_a_tampered_archive_stops_the_build_before_it_starts(
         target=TARGET,
         packages=(PlannedPackage(manifest=manifest, block=manifest.install[0], apt_packages=()),),
     )
-    steps = backend.steps(manifest, manifest.install[0].install)  # type: ignore[arg-type]
+    steps = backend.steps(manifest, manifest.install[0])
     log = TransactionLog(tmp_path / "log.jsonl")
 
     report = execute(steps, SubprocessRunner(), log=log, plan=plan)


### PR DESCRIPTION
Closes #69's engine half: `binaries` is per-block where a block needs it, and
`catalog/packages/rayhunter.yaml` carries all three Linux architectures.

## The gap

`PackageManifest.binaries` was one list for the whole manifest. Rayhunter's
release zip puts `installer` at the top level and `rayhunter-check` under a
per-platform directory, so the produced path differs per architecture:

```
rayhunter-v0.12.0-linux-aarch64/installer
rayhunter-v0.12.0-linux-aarch64/rayhunter-check-linux-aarch64/rayhunter-check
```

(read out of the downloaded zips, not assumed). An aarch64 block reading the
manifest-level list would have installed the x64 executable, and the post-run
effect check — reading the same list — would have confirmed it. That is the
D-031 shape, so the manifest was x86_64-only and the gap was recorded on #69.
The maintainer's ClockworkPi uConsole is aarch64.

## Schema

`InstallBlock` takes an optional `binaries`, overriding the manifest's list
wherever that block resolves. The validator refuses:

- an empty list — it reads as an override to nothing, so the block would install
  nothing while reporting success;
- a list on a method that copies no build outputs (apt, a `.deb`, venv, node,
  data) — nothing would ever read it;
- duplicate `install_as` inside one block.

Each message names the block by method and selector.

## One reader, not seven

`effective_binaries(manifest, block)` returns the block's list when set, the
manifest's otherwise. Every reader goes through it — the three step builders,
`already_built`, `verify_effects`, `plan_removal`'s binary planning, the
prebuilt-archive blocker in `plan.py`, and the package-reference generator. The
three affected backends' `steps()` now take the whole `InstallBlock` rather than
its install method, because that is the only way they can see the block's list;
each refuses a block whose method is not its own.

## Catalog

aarch64 and armv7l blocks, each with its own artifact, digest and `binaries`.
Both digests were read from upstream's published `.sha256` files and recomputed
against the downloaded zips on 2026-09-12:

```
aarch64  3759e44ef94259009d13967efc6931a076f1dad13aa173b8a83d09468989e9db
armv7    77cd66f99bd32bcd83300e799ebb8611871e7c01dbb957c0b408cf43b76033ee
```

## Tests

`tests/test_block_binaries.py`: schema acceptance, the three refusals, the
helper's precedence in both directions, the binary backend installing the
block's `produced` path, `verify_effects` reading back the block's `install_as`,
and rayhunter resolving on all three architectures with the right zip and the
right `binaries`.

Falsified rather than assumed: the refusals were watched red with the block
validator disabled (they would otherwise have passed on `extra="forbid"` alone),
and the four reader tests were watched red with the helper's precedence removed.

## Verification

- `make check` — exit 0; ruff clean, `mypy --strict` clean on 115 source files,
  1815 passed / 21 skipped, 1965 internal documentation references checked.
- `docs/reference/schema.md`, `docs/packages/rayhunter.md` and
  `docs/reference/capability-matrix.md` regenerated; rayhunter moves from `—`
  to `binary` on debian-13-arm64.
- `hammunition install rayhunter --dry-run --no-refresh` on the dev laptop
  reports `already installed` with no commands, identical to the same command on
  `main` — the two executables are already in `/usr/local/bin` there, so the
  planner's already-built path is what answers. Planned against an empty prefix,
  the x86_64 block renders the x64 fetch and the two `install -D -m 0755` steps
  (`installer` → `rayhunter-installer`, `rayhunter-check-linux-x64/rayhunter-check`
  → `rayhunter-check`), and the aarch64 block renders the aarch64 zip and its own
  two paths.
- No install was run, and nothing was tested against a hotspot or an aarch64
  machine: this is a resolution and planning change, and the aarch64 route is
  not a claim that Rayhunter has been run there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
