### PR TITLE
Put morse-classic back into the morse profile

### DIFF
--- a/catalog/packages/morse-classic.yaml
+++ b/catalog/packages/morse-classic.yaml
@@ -18,8 +18,9 @@ categories: [cw, training]
 # On a PipeWire desktop apt resolves that by removing pipewire-alsa (measured:
 # `apt-get install -s morse` on Parrot 7.3 + KDE, 2026-09-12, #61). Declared
 # so the plan names this unit as the reason rather than the whole
-# transaction; the engine never removes it (D-022). Not a member of the
-# `morse` profile for the same reason.
+# transaction; the engine never removes it (D-022). With Recommends off
+# (below, D-052) the conflict never arises in practice, and the unit is a
+# member of the `morse` profile again.
 conflicts_with_repo_package: [pipewire-alsa]
 
 install:

--- a/catalog/profiles/morse.yaml
+++ b/catalog/profiles/morse.yaml
@@ -11,11 +11,12 @@ packages:
   - cwcp
   - xcwcp
   - qrq
-  # morse-classic is deliberately not a member: Debian's `morse` Recommends
-  # pulseaudio, which Conflicts with pipewire-alsa, so apt would remove a
-  # PipeWire desktop's audio routing to install it and the engine refuses the
-  # whole transaction (field laptop, Parrot 7.3 + KDE, 2026-09-12, #61). It
-  # stays installable by name; the dry run discloses the conflict.
+  # morse-classic left the profile on 2026-09-12 because Debian's `morse`
+  # Recommends pulseaudio, which Conflicts with pipewire-alsa, and apt would
+  # have removed a PipeWire desktop's audio routing to install it (#61). It is
+  # back since D-052: its manifest sets `install_recommends: false`, so it
+  # installs without pulling pulseaudio and the profile no longer refuses.
+  - morse-classic
   - ebook2cw
   - ebook2cwgui
   - cwwav
@@ -30,8 +31,9 @@ packages:
 
 documentation:
   what_it_installs: >-
-    Four ways to learn — Koch method training, high-speed callsign drilling,
-    the three unixcw front ends, and a converter that turns any text you were
+    Five ways to learn — Koch method training, high-speed callsign drilling,
+    the three unixcw front ends, the long-lived Unix `morse` sounder that
+    drills you on random groups, and a converter that turns any text you were
     going to read into Morse audio at a speed you choose. Two decoders, one
     live from a receiver and one offline from a recording. Two ways to send: a
     daemon that keys a transmitter for a logging program, and a control panel
@@ -48,12 +50,8 @@ documentation:
   deliberately_excludes: >-
     fldigi, which decodes CW among twenty other modes and belongs in
     `digital-modes`. Contest loggers, which key CW through `cwdaemon` and live
-    in `logging`. morse-classic, the long-lived Unix `morse` sounder: Debian's
-    package Recommends pulseaudio, which cannot coexist with pipewire-alsa, so
-    on a PipeWire desktop apt would remove your audio routing to install it
-    and the engine refuses the whole profile (#61). Install it by name if you
-    want it and are not on PipeWire. Nothing here needs a radio: every trainer
-    generates its own audio, which is the point.
+    in `logging`. Nothing here needs a radio: every trainer generates its own
+    audio, which is the point.
   manual_configuration: >-
     **`cwdaemon` needs a keying interface and a group you are not in.** Serial
     keying needs `dialout`, parallel needs `lp`, and this profile adds neither

--- a/docs/profiles/index.md
+++ b/docs/profiles/index.md
@@ -12,7 +12,7 @@ Named bundles of software that belong together. Flat tags with overlap, never ne
 | [electronics](electronics.md) | 1.0 | 11 | Bench electronics, instruments and device programmers |
 | [listening](listening.md) | 1.0 | 24 | Shortwave, utility and aeronautical listening — no licence, no transmitter |
 | [logging](logging.md) | 1.0 | 11 | Station logs, contest logging and award tracking |
-| [morse](morse.md) | 1.0 | 16 | Morse code — sending, decoding, learning, and licence exam practice |
+| [morse](morse.md) | 1.0 | 17 | Morse code — sending, decoding, learning, and licence exam practice |
 | [packet](packet.md) | 1.0 | 22 | AX.25, APRS, Winlink and the EMCOMM stack |
 | [propagation](propagation.md) | 1.0 | 12 | Band conditions, grey line, beacons and DX spotting |
 | [rf-research](rf-research.md) 🔒 | post-1.0 | 2 | Transmit-capable and interception-capable RF tooling — affirmative opt-in required |

--- a/docs/profiles/morse.md
+++ b/docs/profiles/morse.md
@@ -8,7 +8,7 @@
 
 ## What it installs
 
-Four ways to learn — Koch method training, high-speed callsign drilling, the three unixcw front ends, and a converter that turns any text you were going to read into Morse audio at a speed you choose. Two decoders, one live from a receiver and one offline from a recording. Two ways to send: a daemon that keys a transmitter for a logging program, and a control panel for a Winkeyer. A beacon monitor. And practice tests for the US and Canadian licence exams.
+Five ways to learn — Koch method training, high-speed callsign drilling, the three unixcw front ends, the long-lived Unix `morse` sounder that drills you on random groups, and a converter that turns any text you were going to read into Morse audio at a speed you choose. Two decoders, one live from a receiver and one offline from a recording. Two ways to send: a daemon that keys a transmitter for a logging program, and a control panel for a Winkeyer. A beacon monitor. And practice tests for the US and Canadian licence exams.
 
 **Disk footprint:** Under 100 MB. Everything here is small; the largest single item is the wxWidgets front end for ebook2cw.
 
@@ -16,13 +16,13 @@ Four ways to learn — Koch method training, high-speed callsign drilling, the t
 
 Morse is a skill before it is a mode, and everything here is either practice, sending or copying. The licence exam tools are here because the Debian Hamradio Blend groups its `morse` and `training` tasks together and the same person wants both at the same stage — this is the profile someone installs while they are still learning. If the exam tools look out of place in something called `morse`, that is a fair reading and they are three packages you can remove.
 
-## Packages (16)
+## Packages (17)
 
-[`aldo`](../packages/aldo.md), [`cw`](../packages/cw.md), [`cwcp`](../packages/cwcp.md), [`xcwcp`](../packages/xcwcp.md), [`qrq`](../packages/qrq.md), [`ebook2cw`](../packages/ebook2cw.md), [`ebook2cwgui`](../packages/ebook2cwgui.md), [`cwwav`](../packages/cwwav.md), [`cwdaemon`](../packages/cwdaemon.md), [`flwkey`](../packages/flwkey.md), [`morse2ascii`](../packages/morse2ascii.md), [`xdemorse`](../packages/xdemorse.md), [`ibp`](../packages/ibp.md), [`hamexam`](../packages/hamexam.md), [`canadian-ham-exam`](../packages/canadian-ham-exam.md), [`fccexam`](../packages/fccexam.md)
+[`aldo`](../packages/aldo.md), [`cw`](../packages/cw.md), [`cwcp`](../packages/cwcp.md), [`xcwcp`](../packages/xcwcp.md), [`qrq`](../packages/qrq.md), [`morse-classic`](../packages/morse-classic.md), [`ebook2cw`](../packages/ebook2cw.md), [`ebook2cwgui`](../packages/ebook2cwgui.md), [`cwwav`](../packages/cwwav.md), [`cwdaemon`](../packages/cwdaemon.md), [`flwkey`](../packages/flwkey.md), [`morse2ascii`](../packages/morse2ascii.md), [`xdemorse`](../packages/xdemorse.md), [`ibp`](../packages/ibp.md), [`hamexam`](../packages/hamexam.md), [`canadian-ham-exam`](../packages/canadian-ham-exam.md), [`fccexam`](../packages/fccexam.md)
 
 ## What it deliberately excludes
 
-fldigi, which decodes CW among twenty other modes and belongs in `digital-modes`. Contest loggers, which key CW through `cwdaemon` and live in `logging`. morse-classic, the long-lived Unix `morse` sounder: Debian's package Recommends pulseaudio, which cannot coexist with pipewire-alsa, so on a PipeWire desktop apt would remove your audio routing to install it and the engine refuses the whole profile (#61). Install it by name if you want it and are not on PipeWire. Nothing here needs a radio: every trainer generates its own audio, which is the point.
+fldigi, which decodes CW among twenty other modes and belongs in `digital-modes`. Contest loggers, which key CW through `cwdaemon` and live in `logging`. Nothing here needs a radio: every trainer generates its own audio, which is the point.
 
 ## What you configure by hand afterward
 


### PR DESCRIPTION
Follows #85 (D-052). `morse-classic` was pulled from the `morse` profile on 2026-09-12 because Debian's `morse` Recommends pulseaudio, which evicts pipewire-alsa, and the engine refused the whole profile on a PipeWire desktop (#61). With the manifest's `install_recommends: false` the conflict never arises, so the unit is a member again.

Measured on the field laptop (Parrot 7.3 + KDE, PipeWire) from this branch:

- `install morse --dry-run`: 20 commands, `morse` alone in a second `apt-get install ... --no-install-recommends`, every other apt package on apt's defaults, no removal planned.
- The plan's D-052 section names `morse-classic` as the unit that asked for the flag.

Prose changes: the profile's `deliberately_excludes` no longer lists it, `what_it_installs` counts it, and the manifest comment says why it is back. `docs/profiles/*` regenerated. `make check` green locally (1814 passed, 21 skipped).

The `conflicts_with_repo_package: [pipewire-alsa]` declaration stays on the manifest: it is still true of Debian's Recommends, and the D-022 disclosure it produces ("pipewire-alsa stays installed") is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
