### PR TITLE
ci: the udev citation job imports its parser again; the orphan test stops reading too early

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,9 +243,9 @@ jobs:
           python-version: "3.11"
       - run: pip install -e ".[dev]"
       - name: Sweep every udev rule in the archive
-        run: |
-          mkdir -p reference/probes
-          podman run --rm -v "$PWD/scripts/udev-sweep.sh":/sweep.sh:ro debian:13 \
-            bash /sweep.sh > reference/probes/udev-debian-13.tsv
-          wc -l reference/probes/udev-debian-13.tsv
+        # The same runner a developer uses, so the mounts the sweep needs
+        # (the script and its parser module) live in one place. A hand-written
+        # podman line here fell behind when the parser became a module and the
+        # job died on import, unnoticed because only the schedule runs it.
+        run: scripts/run-udev-sweep.sh debian-13
       - run: python scripts/check_rule_citations.py

--- a/tests/test_gui_smoke.py
+++ b/tests/test_gui_smoke.py
@@ -142,12 +142,29 @@ def _orphan_holding_the_pipe(prefix: str = "") -> list[str]:
 
 def _alive(pid: int) -> bool:
     # A killed orphan is a zombie until PID 1 reaps it, and kill(pid, 0) still
-    # succeeds on a zombie; read the state rather than race the reaper.
+    # succeeds on a zombie; read the state rather than race the reaper. X is
+    # the state between zombie and gone.
     try:
         state = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
     except OSError:
         return False
-    return state != "Z"
+    return state not in ("Z", "X")
+
+
+def _dies_within(pid: int, grace: float) -> bool:
+    # The lane returns on EOF, and the kernel closes a dying process's files
+    # before it marks the process a zombie, so the instant the pipe closes the
+    # orphan can still read as R. Measured on the field laptop under a
+    # twelve-thread load, 2026-09-12: 30 of 60 runs saw R for up to 6 ms
+    # after run_bounded returned, every one a zombie or gone within 7 ms;
+    # reading once lost 21 of 40 runs (#81). A bounded poll is the honest
+    # assertion: the orphan must die because of the deadline, not by it.
+    end = time.monotonic() + grace
+    while time.monotonic() < end:
+        if not _alive(pid):
+            return True
+        time.sleep(0.005)
+    return not _alive(pid)
 
 
 def test_a_grandchild_holding_the_pipe_does_not_stall_the_lane(smoke: ModuleType) -> None:
@@ -158,7 +175,7 @@ def test_a_grandchild_holding_the_pipe_does_not_stall_the_lane(smoke: ModuleType
     try:
         assert rc == 0
         assert elapsed < 10, f"lane waited {elapsed:.0f}s on an orphan's pipe"
-        assert not _alive(orphan), "the orphan survived the lane's deadline"
+        assert _dies_within(orphan, 2.0), "the orphan survived the lane's deadline"
     finally:
         with contextlib.suppress(ProcessLookupError):
             os.kill(orphan, signal.SIGKILL)

--- a/tests/test_udev_rule_pairs.py
+++ b/tests/test_udev_rule_pairs.py
@@ -69,4 +69,10 @@ def test_the_sweep_script_imports_this_module_rather_than_inlining_it() -> None:
     runner = (REPO_ROOT / "scripts" / "run-udev-sweep.sh").read_text()
     assert "from udev_rule_pairs import find_pair" in sweep
     assert 'udev_rule_pairs.py":/udev_rule_pairs.py:ro' in runner
+    # CI must go through the runner rather than restate its podman line: the
+    # restated line mounted only the sweep script, so the weekly citation job
+    # died on `import udev_rule_pairs` from the day the parser became a module.
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    assert "run: scripts/run-udev-sweep.sh debian-13" in ci
+    assert "udev-sweep.sh\":/sweep.sh" not in ci
     assert "PAIR = re.compile" not in sweep, "the inline copy is back; it cannot be tested there"

--- a/tests/test_udev_rule_pairs.py
+++ b/tests/test_udev_rule_pairs.py
@@ -74,5 +74,5 @@ def test_the_sweep_script_imports_this_module_rather_than_inlining_it() -> None:
     # died on `import udev_rule_pairs` from the day the parser became a module.
     ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     assert "run: scripts/run-udev-sweep.sh debian-13" in ci
-    assert "udev-sweep.sh\":/sweep.sh" not in ci
+    assert 'udev-sweep.sh":/sweep.sh' not in ci
     assert "PAIR = re.compile" not in sweep, "the inline copy is back; it cannot be tested there"


### PR DESCRIPTION
Two CI fixes, each measured rather than guessed.

## 1. The weekly `udev rule citations` job could not import its parser

The job restated `scripts/run-udev-sweep.sh`'s podman line by hand and mounted only the sweep script. When the pair parser moved into `scripts/udev_rule_pairs.py` (D-047, PR #57), the runner gained a second mount and the CI line did not, so the job dies at `ModuleNotFoundError: No module named 'udev_rule_pairs'`. Unnoticed because the job runs only on `schedule` and `workflow_dispatch`: the last scheduled run (2026-09-07) predates the split, and a dispatched run on `block-binaries` (34725601481) is the first evidence. Tomorrow's Sunday run would have been the first scheduled failure.

Fix: the job calls `scripts/run-udev-sweep.sh debian-13`, the same runner a developer uses, so the mounts live in one place. `tests/test_udev_rule_pairs.py` pins that CI goes through the runner. A `workflow_dispatch` of `ci.yml` on this branch is the proof, linked in a comment below.

## 2. `test_a_grandchild_holding_the_pipe_does_not_stall_the_lane` read too early (closes #81)

The test read the orphan's `/proc` state the instant `run_bounded` returned. The lane returns on pipe EOF, and the kernel closes a dying process's files before it marks the process a zombie, so under load the orphan still reads as `R` for a few milliseconds.

Measured on the field laptop with twelve busy threads (`yes > /dev/null` ×12):

| | result |
|---|---|
| orphan state at the instant the lane returned, 60 runs | Z ×10, gone ×19, X ×1, **R ×30** |
| longest time from that instant to zombie or gone | 6.37 ms |
| single read, 40 runs | **21 failed** |
| bounded 2 s poll, 40 runs | 0 failed |

The lane was never at fault, and re-running was hiding a test that read too early. `_alive` now also treats `X` as dead, and the assertion polls for up to 2 s. The fixture's own falsification still stands: the orphan must die because of the deadline, and a lane that lost its `killpg` would fail the poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
