### PR TITLE
Launchers carry a title for the menu; the wrapper keeps its name

### DIFF
--- a/catalog/packages/ais-catcher.yaml
+++ b/catalog/packages/ais-catcher.yaml
@@ -59,6 +59,7 @@ service_endpoints:
 launchers:
   - name: ais-catcher-web
     exec: (sleep 2; x-www-browser {endpoint:webmap}) & exec AIS-catcher -N 8100
+    title: AIS-catcher web map (ais-catcher-web)
     terminal: false
 
 update:

--- a/catalog/packages/ax25-apps.yaml
+++ b/catalog/packages/ax25-apps.yaml
@@ -22,6 +22,7 @@ install:
 launchers:
   - name: axlisten
     exec: axlisten -a
+    title: AX.25 channel monitor (axlisten)
     terminal: true
     # What is on the air: raw AX.25 frames on every configured port, outgoing as well as incoming
 

--- a/catalog/packages/ax25-tools.yaml
+++ b/catalog/packages/ax25-tools.yaml
@@ -18,6 +18,7 @@ install:
 launchers:
   - name: mheard
     exec: mheard
+    title: AX.25 stations heard (mheard)
     terminal: true
     # Who has been heard: the stations mheardd logged on each port. The rest of the unit is per-port configuration (kissattach, axparms, sethdlc) typed at a shell, not opened from a menu
 

--- a/catalog/packages/bladerf.yaml
+++ b/catalog/packages/bladerf.yaml
@@ -17,6 +17,7 @@ install:
 launchers:
   - name: bladeRF-cli
     exec: bladeRF-cli -i
+    title: bladeRF interactive shell (bladeRF-cli)
     terminal: true
     # The bladeRF at the keyboard: an interactive session; `probe` and `info` inside it answer whether the board is seen before any FPGA is loaded
 

--- a/catalog/packages/gpsd-tools.yaml
+++ b/catalog/packages/gpsd-tools.yaml
@@ -20,6 +20,7 @@ install:
 launchers:
   - name: cgps
     exec: cgps
+    title: GPS fix monitor (cgps)
     terminal: true
     # The GPS fix, live, from the running gpsd
 

--- a/catalog/packages/gpsd.yaml
+++ b/catalog/packages/gpsd.yaml
@@ -17,6 +17,7 @@ install:
 launchers:
   - name: gpsctl
     exec: gpsctl
+    title: GPS receiver control (gpsctl)
     terminal: true
     # Which receiver gpsd owns: with no arguments gpsctl asks the running daemon and names the device, or reports that none is connected. The live fix itself is cgps, gpsd-tools' launcher
 

--- a/catalog/packages/gr-gsm.yaml
+++ b/catalog/packages/gr-gsm.yaml
@@ -24,6 +24,7 @@ depends: [gnuradio]
 launchers:
   - name: grgsm_livemon
     exec: grgsm_livemon
+    title: GSM live monitor (grgsm_livemon)
     terminal: true
     # The live GSM monitor: grgsm_livemon's own window, tuned from its controls; the terminal behind it keeps the GNU Radio log, where a missing device or an unlocked RTL-SDR is reported
 

--- a/catalog/packages/gr-osmosdr.yaml
+++ b/catalog/packages/gr-osmosdr.yaml
@@ -19,6 +19,7 @@ install:
 launchers:
   - name: osmocom_fft
     exec: osmocom_fft
+    title: SDR spectrum display (osmocom_fft)
     terminal: true
     # A spectrum from whatever SDR is attached: the osmocom source's own FFT display, and the first proof that a device string opens
 

--- a/catalog/packages/gr-satellites.yaml
+++ b/catalog/packages/gr-satellites.yaml
@@ -19,6 +19,7 @@ install:
 launchers:
   - name: gr_satellites
     exec: gr_satellites --list_satellites
+    title: gr-satellites decoder list (gr_satellites)
     terminal: true
     # Which satellites it decodes: the supported list with each downlink. Every other invocation needs a satellite name and a recording or a live source, so this is the representative entry rather than a decoder session
 

--- a/catalog/packages/hackrf.yaml
+++ b/catalog/packages/hackrf.yaml
@@ -18,6 +18,7 @@ install:
 launchers:
   - name: hackrf_info
     exec: hackrf_info
+    title: HackRF board info (hackrf_info)
     terminal: true
     # Is the HackRF there: firmware, serial and board revision of every attached unit
 

--- a/catalog/packages/hammunition-hill.yaml
+++ b/catalog/packages/hammunition-hill.yaml
@@ -57,6 +57,7 @@ service_endpoints:
 launchers:
   - name: hammunition-hill
     exec: x-www-browser {endpoint:dashboard}
+    title: Hammunition Hill dashboard
     terminal: false
 
 update:

--- a/catalog/packages/libhamlib-utils.yaml
+++ b/catalog/packages/libhamlib-utils.yaml
@@ -18,6 +18,7 @@ install:
 launchers:
   - name: rigctl
     exec: rigctl -m 1
+    title: Rig control shell (rigctl)
     terminal: true
     # Rig control at the keyboard: an interactive rigctl session against the dummy rig (model 1); `rigctl -l` lists the real ones
 

--- a/catalog/packages/libnfc-bin.yaml
+++ b/catalog/packages/libnfc-bin.yaml
@@ -18,6 +18,7 @@ install:
 launchers:
   - name: nfc-list
     exec: nfc-list
+    title: NFC reader and tag check (nfc-list)
     terminal: true
     # What the NFC reader sees: lists the reader and any tag in its field
 

--- a/catalog/packages/rtl-sdr.yaml
+++ b/catalog/packages/rtl-sdr.yaml
@@ -18,6 +18,7 @@ install:
 launchers:
   - name: rtl_test
     exec: rtl_test -t
+    title: RTL-SDR device test (rtl_test)
     terminal: true
     # Is the dongle working: rtl_test probes the attached RTL-SDR and reports its tuner and gain range
 

--- a/catalog/packages/stlink-tools.yaml
+++ b/catalog/packages/stlink-tools.yaml
@@ -17,6 +17,7 @@ install:
 launchers:
   - name: st-info
     exec: st-info --probe
+    title: ST-Link probe (st-info)
     terminal: true
     # Is the probe there: identifies the ST-Link and the target behind it -- the first thing to run before blaming the board (known_problems below)
 

--- a/catalog/packages/ubertooth.yaml
+++ b/catalog/packages/ubertooth.yaml
@@ -18,6 +18,7 @@ install:
 launchers:
   - name: ubertooth-util
     exec: ubertooth-util -v
+    title: Ubertooth board check (ubertooth-util)
     terminal: true
     # Is the Ubertooth there: firmware revision of the attached unit
 

--- a/catalog/packages/yagiuda.yaml
+++ b/catalog/packages/yagiuda.yaml
@@ -17,6 +17,7 @@ install:
 launchers:
   - name: input
     exec: input
+    title: Yagi-Uda design input (input)
     terminal: true
     # Where a design starts: input is the unit's interactive program, asking for element positions and the frequency span and writing the file yagi, output and optimise then read
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -253,8 +253,9 @@ A generated wrapper script. 14 AHRL units need one.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `name` | `str` | **yes** |  |
+| `name` | `str` | **yes** | The wrapper's filename under <prefix>/bin, so the launcher is also what a shell finds by that name. |
 | `exec` | `str` | **yes** | Command template. May reference {endpoint:NAME}. |
+| `title` | `str \| None` | no | What the desktop menu shows for this launcher. Defaults to `name`, which is fine when the name is the tool's known name (rigctl, hackrf_info) and not when it is a bare word (yagiuda's `input`). The convention is what it does, then the command in parentheses. |
 | `working_directory` | `str \| None` | no |  |
 | `terminal` | `bool` | no (default `False`) |  |
 

--- a/src/hammunition/launchers.py
+++ b/src/hammunition/launchers.py
@@ -175,7 +175,7 @@ def desktop_entry(manifest: PackageManifest, launcher: Launcher, wrapper: Path) 
     return (
         "[Desktop Entry]\n"
         "Type=Application\n"
-        f"Name={launcher.name}\n"
+        f"Name={launcher.display_name}\n"
         f"Comment={manifest.summary}\n"
         f"Exec={wrapper}\n"
         f"Terminal={'true' if launcher.terminal else 'false'}\n"

--- a/src/hammunition/manifest/schema.py
+++ b/src/hammunition/manifest/schema.py
@@ -903,12 +903,39 @@ class ServiceEndpoint(Strict):
 class Launcher(Strict):
     """A generated wrapper script. 14 AHRL units need one."""
 
-    name: str
+    name: str = Field(
+        description=(
+            "The wrapper's filename under <prefix>/bin, so the launcher is also "
+            "what a shell finds by that name."
+        ),
+    )
     exec: str = Field(
         description="Command template. May reference {endpoint:NAME}.",
     )
+    title: str | None = Field(
+        default=None,
+        description=(
+            "What the desktop menu shows for this launcher. Defaults to `name`, "
+            "which is fine when the name is the tool's known name (rigctl, "
+            "hackrf_info) and not when it is a bare word (yagiuda's `input`). "
+            "The convention is what it does, then the command in parentheses."
+        ),
+    )
     working_directory: str | None = None
     terminal: bool = False
+
+    @property
+    def display_name(self) -> str:
+        return self.title if self.title is not None else self.name
+
+    @model_validator(mode="after")
+    def _title_is_not_blank(self) -> Launcher:
+        if self.title is not None and not self.title.strip():
+            raise ManifestError(
+                f"launcher {self.name!r} has a blank title; omit `title` to show the "
+                f"name, or give the entry a title someone can read"
+            )
+        return self
 
     @model_validator(mode="after")
     def _terminal_launchers_keep_their_shell(self) -> Launcher:

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 from hammunition.launchers import desktop_entry, launcher_steps, wrapper_body
-from hammunition.manifest.schema import PackageManifest
+from hammunition.manifest.schema import ManifestError, PackageManifest
 
 
 def manifest(**overrides: Any) -> PackageManifest:
@@ -64,6 +64,33 @@ def test_desktop_entry_carries_mapped_categories_and_the_marker(tmp_path: Path) 
         assert category in entry, entry
     assert "X-Hammunition-Package=launchable" in entry
     assert "Terminal=false" in entry
+
+
+def test_desktop_entry_name_is_the_title_when_one_is_given(tmp_path: Path) -> None:
+    # yagiuda's interactive program is called `input`; a menu entry called
+    # "input" tells nobody what it is. The title is what the menu shows and
+    # the name stays the wrapper's filename, so `type input` still finds it.
+    m = manifest(
+        launchers=[
+            {"name": "input", "exec": "input", "terminal": True, "title": "Yagi-Uda design (input)"}
+        ]
+    )
+    entry = desktop_entry(m, m.launchers[0], tmp_path / "bin" / "input")
+    assert "Name=Yagi-Uda design (input)\n" in entry
+    assert "Exec=" + str(tmp_path / "bin" / "input") in entry
+
+
+def test_desktop_entry_name_falls_back_to_the_launcher_name(tmp_path: Path) -> None:
+    m = manifest()
+    entry = desktop_entry(m, m.launchers[0], tmp_path / "bin" / "launchable")
+    assert "Name=launchable\n" in entry
+
+
+def test_a_blank_title_is_refused_rather_than_rendering_an_unnamed_entry() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises((ValidationError, ManifestError), match="title"):
+        manifest(launchers=[{"name": "l", "exec": "l", "title": "  "}])
 
 
 def test_steps_write_both_artifacts_and_they_are_real(tmp_path: Path) -> None:


### PR DESCRIPTION
Found while reading the field laptop's transaction log after the launcher agent's nine units landed: yagiuda's launcher put an entry called **"input"** in the Hammunition menu, with a comment about Yagi-Uda arrays. `input` is the unit's interactive design program, and the name is right for the wrapper (a shell finds it by that name) and wrong for a menu.

## Change

- `Launcher.title: str | None` — what the desktop entry's `Name=` shows. Defaults to `name`; a blank title is refused with the launcher named.
- The wrapper's filename is still `name`, so the PATH strip for a wrapper named like its tool (#82) is unaffected and `type input` still resolves.
- Seventeen catalog launchers gain a title in one shape, *what it does, then the command in parentheses*: `AX.25 channel monitor (axlisten)`, `GPS fix monitor (cgps)`, `HackRF board info (hackrf_info)`, `Rig control shell (rigctl)`, `Yagi-Uda design input (input)`, and so on. Launchers whose name is the software's own name (artemis, gpa, yaac, mshv, supersdr, js8spotter, hamclock-next, openhamclock, radiosonde-auto-rx) are left alone; `hammunition-hill` becomes "Hammunition Hill dashboard".
- `docs/reference/schema.md` regenerated.

## Tests

Three new in `tests/test_launchers.py`, watched red first: the title renders as `Name=`, the fallback is the name, a blank title is refused.

## Measured on the field laptop

`install yagiuda --yes --no-refresh` from this branch: two unprivileged steps, the entry rewritten, `Name=Yagi-Uda design input (input)` on disk, wrapper unchanged, menu re-applied.

`make check` green locally: 1828 passed, 21 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
