### PR TITLE
installed_files: a build's install rule declares what it leaves, so a library can be checked and decided

### DIFF
--- a/catalog/packages/fl-moxgen.yaml
+++ b/catalog/packages/fl-moxgen.yaml
@@ -42,6 +42,13 @@ install:
       `SHAREDIR=/usr/local/share/fl_moxgen` rather than reading PREFIX. That
       matches our default prefix and would silently ignore any other.
 
+# The Makefile's install rule puts `fl_moxgen` in the prefix's bin (measured
+# on the field laptop, 2026-09-13, mode 0755). Declared so the effect is
+# checked after the run and the build can be decided as already installed.
+binaries:
+  - produced: fl_moxgen
+    install_as: fl_moxgen
+
 update:
   probe:
     method: none

--- a/catalog/packages/libacars.yaml
+++ b/catalog/packages/libacars.yaml
@@ -38,6 +38,17 @@ install:
       visible, so it is worth checking the summary rather than the exit status
       (D-031).
 
+# What cmake's install rule leaves under the prefix, read from the field
+# laptop after the build (2026-09-13): the versioned library, its unversioned
+# symlink and the pkg-config file the three decoders' builds look for. A
+# library has no executable to declare in `binaries`, so without these the
+# engine had no effect to check (D-031), could never decide it as already
+# installed (D-051), and `update` reported it as unknown.
+installed_files:
+  - lib/libacars-2.so.2
+  - lib/libacars-2.so
+  - lib/pkgconfig/libacars-2.pc
+
 update:
   probe:
     method: github_tags

--- a/docs/packages/fl-moxgen.md
+++ b/docs/packages/fl-moxgen.md
@@ -26,6 +26,10 @@ A desktop session and a frequency. Nothing else -- the design work happens befor
   - build dependencies: `build-essential`, `pkg-config`, `libfltk1.3-dev`, `libhpdf-dev`
   - Built in a Debian 13 container on 2026-08-28 with the two overrides above: make exits 0, `fl_moxgen` is produced, and running it headless gets as far as "Can't open display", which is a GUI binary working. AHRL bundles 1.01; SourceForge offers only **1.00** and no 1.01 exists there, so this pins what upstream actually publishes. Its `install` target copies to a hardcoded `BINDIR=/usr/local/bin` and `SHAREDIR=/usr/local/share/fl_moxgen` rather than reading PREFIX. That matches our default prefix and would silently ignore any other.
 
+Binaries this produces:
+
+- `fl_moxgen`
+
 ## Known problems
 
 **Check that you got the PDF-capable build.** Without libharu found at build time the Makefile quietly builds `fl_moxgen_no_pdf` instead, which is the same program with the printing gone and no message saying so. The build arguments above prevent it, and it is worth knowing because printing to scale is most of the point. As with any modelled antenna, the numbers assume the thing is in free space; a Moxon two metres off the ground behaves differently and the null in particular will not be where the model says.

--- a/docs/packages/libacars.md
+++ b/docs/packages/libacars.md
@@ -26,6 +26,12 @@ None beyond a compiler and CMake. It is a library with no radio hardware require
   - build dependencies: `build-essential`, `cmake`, `zlib1g-dev`, `libxml2-dev`, `libjansson-dev`
   - Upstream's configuration summary prints which of the three were detected. If a target ever drops one, the build still succeeds and the library quietly loses a capability — the failure mode this project exists to make visible, so it is worth checking the summary rather than the exit status (D-031).
 
+Files its install rule leaves under the prefix, checked after the run and never copied or removed by the engine:
+
+- `lib/libacars-2.so.2`
+- `lib/libacars-2.so`
+- `lib/pkgconfig/libacars-2.pc`
+
 ## Known problems
 
 zlib, libxml2 and jansson are each optional at build time and each silently disables a feature when missing: no zlib means compressed MIAM and OHMA messages are left undecoded, no libxml2 means XML is not formatted, no jansson means OHMA JSON is not decoded at all. The build prints a configuration summary saying which were found; a decoder that appears to be receiving nothing useful is worth checking against that summary before blaming the antenna. All three are listed as build dependencies here so the question does not arise.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -23,6 +23,7 @@ A manifest is **strict**: an unknown field is an error, not ignored. That is del
 | `after` | `list[str]` | no | Ordering, not dependency. |
 | `requires_kernel` | `list[Literal[ax25]]` | no | Kernel subsystems the software cannot work without, checked against the running kernel at plan time. A machine whose kernel lacks one defers the unit in a profile and refuses it by name. Linux 7.1 removed AX.25 (merge 64edfa65, 2026-04-24); `hammunition.kernel` reads the module tree. The vocabulary is what has been measured. |
 | `binaries` | `list[Binary]` | no |  |
+| `installed_files` | `list[str]` | no | Files the build's own install rule puts under the prefix, as paths relative to it (`lib/libacars-2.so.2`, `lib/pkgconfig/libacars-2.pc`). Declared effects only: they are checked after the run (D-031) and are what lets a build with no executable be decided as already installed (D-051) or compared by `update`; the engine never copies or removes them. An executable belongs in `binaries`, not here. |
 | `launchers` | `list[Launcher]` | no |  |
 | `service_endpoints` | `list[ServiceEndpoint]` | no |  |
 | `apt_repos` | `list[AptRepo]` | no |  |

--- a/scripts/gen_package_reference.py
+++ b/scripts/gen_package_reference.py
@@ -206,6 +206,15 @@ def page(m: PackageManifest) -> str:
             out.append(f"- {_binary_line(b)}")
         out.append("")
 
+    if m.installed_files:
+        out.append(
+            "Files its install rule leaves under the prefix, checked after the run "
+            "and never copied or removed by the engine:\n"
+        )
+        for declared in m.installed_files:
+            out.append(f"- `{declared}`")
+        out.append("")
+
     if m.conflicts_with_repo_package:
         out.append(
             "This displaces the distribution's own "

--- a/src/hammunition/execute.py
+++ b/src/hammunition/execute.py
@@ -307,6 +307,9 @@ def build_effects_present(planned: PlannedPackage, *, prefix: Path) -> bool | No
     marker = _tree_marker(planned.block)
     if marker is not None:
         present.append((tree_destination(prefix, planned.name) / marker).exists())
+    if _declares_installed_binaries(planned.block):
+        for declared_file in planned.manifest.installed_files:
+            present.append((prefix / declared_file).exists())
     if not present:
         return None
     return all(present)
@@ -790,6 +793,28 @@ def verify_effects(
                                 f"the install step exited 0 but there is no executable at "
                                 f"{path} -- the build has no install rule for it, or installs "
                                 f"it under another name"
+                            )
+                        ),
+                    )
+                )
+
+        for planned in plan.packages:
+            if not _declares_installed_binaries(planned.block):
+                continue
+            for declared_file in planned.manifest.installed_files:
+                path = prefix / declared_file
+                present = path.exists()
+                checks.append(
+                    EffectCheck(
+                        kind="file",
+                        subject=f"{planned.name}:{declared_file}",
+                        confirmed=present,
+                        detail=(
+                            f"installed file present at {path}"
+                            if present
+                            else (
+                                f"the install step exited 0 but {path} does not exist -- the "
+                                f"build's install rule put it elsewhere, or installed nothing"
                             )
                         ),
                     )

--- a/src/hammunition/manifest/schema.py
+++ b/src/hammunition/manifest/schema.py
@@ -1203,6 +1203,17 @@ class PackageManifest(Strict):
     )
 
     binaries: list[Binary] = Field(default_factory=list)
+    installed_files: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Files the build's own install rule puts under the prefix, as paths "
+            "relative to it (`lib/libacars-2.so.2`, `lib/pkgconfig/libacars-2.pc`). "
+            "Declared effects only: they are checked after the run (D-031) and "
+            "are what lets a build with no executable be decided as already "
+            "installed (D-051) or compared by `update`; the engine never copies "
+            "or removes them. An executable belongs in `binaries`, not here."
+        ),
+    )
     launchers: list[Launcher] = Field(default_factory=list)
     service_endpoints: list[ServiceEndpoint] = Field(default_factory=list)
 
@@ -1250,6 +1261,30 @@ class PackageManifest(Strict):
     documentation: Documentation
 
     # -- validators ---------------------------------------------------------
+
+    @model_validator(mode="after")
+    def _installed_files_are_relative_effects(self) -> PackageManifest:
+        for declared in self.installed_files:
+            path = PurePosixPath(declared)
+            if path.is_absolute() or ".." in path.parts or not declared.strip():
+                raise ManifestError(
+                    f"installed_files entry {declared!r} must be a relative path under "
+                    f"the prefix with no `..`"
+                )
+            if path.parts[0] == "bin":
+                raise ManifestError(
+                    f"installed_files entry {declared!r} is under bin/; an executable is "
+                    f"declared in `binaries`, which checks it the same way"
+                )
+        if self.installed_files and not any(
+            isinstance(block.install, SourceInstall | GitInstall) for block in self.install
+        ):
+            raise ManifestError(
+                "installed_files declared but no source or git block installs anything "
+                "by its own rule; the field names what `make install` (or equivalent) "
+                "leaves under the prefix"
+            )
+        return self
 
     @model_validator(mode="after")
     def _name_is_slug(self) -> PackageManifest:

--- a/tests/test_installed_files.py
+++ b/tests/test_installed_files.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""`installed_files`: declared effects of a build's own install rule.
+
+libacars is a library: its cmake install rule leaves a `.so`, a symlink and
+a pkg-config file under the prefix and no executable. With nothing to
+declare in `binaries` the engine had no effect to check (D-031), could
+never decide the build as already installed (D-051), and `update` called it
+unknown. The field names what the install rule leaves; the engine checks
+it, and never copies or removes it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from hammunition.backends.apt import AptPackageState  # noqa: E402
+from hammunition.distro import Target  # noqa: E402
+from hammunition.execute import build_effects_present, verify_effects  # noqa: E402
+from hammunition.manifest.load import load_catalog  # noqa: E402
+from hammunition.manifest.schema import ManifestError, PackageManifest  # noqa: E402
+from hammunition.plan import InstallPlan, PlannedPackage  # noqa: E402
+from hammunition.update import BEHIND_PIN, UNKNOWN, report  # noqa: E402
+
+TARGET = Target(distro="debian", version="13", arch="x86_64")
+DOCS = {
+    "what_it_does": "Stands in for a library with no executable.",
+    "why_you_want_it": "To prove a declared file is read back.",
+    "upstream_url": "https://example.invalid/",
+}
+
+
+def _lib(**overrides: Any) -> PackageManifest:
+    data: dict[str, Any] = {
+        "name": "libthing",
+        "version": "2.2.1",
+        "summary": "A shared library",
+        "categories": ["listening"],
+        "install": [
+            {
+                "install": {
+                    "method": "git",
+                    "repo": "https://example.invalid/libthing",
+                    "ref": "v2.2.1",
+                    "build_system": "cmake",
+                }
+            }
+        ],
+        "installed_files": ["lib/libthing-2.so.2", "lib/pkgconfig/libthing-2.pc"],
+        "update": {"probe": {"method": "none"}, "strategy": "rebuild"},
+        "documentation": DOCS,
+    }
+    data.update(overrides)
+    return PackageManifest.model_validate(data)
+
+
+def _plan(manifest: PackageManifest) -> InstallPlan:
+    return InstallPlan(
+        target=TARGET,
+        packages=(PlannedPackage(manifest=manifest, block=manifest.install[0], apt_packages=()),),
+    )
+
+
+# --- the schema refuses what cannot be an effect under the prefix -----------
+
+
+@pytest.mark.parametrize("bad", ["/usr/local/lib/x.so", "lib/../etc/x", "bin/x", ""])
+def test_a_path_that_is_not_a_relative_effect_under_the_prefix_is_refused(bad: str) -> None:
+    with pytest.raises((ValidationError, ManifestError), match="installed_files"):
+        _lib(installed_files=[bad])
+
+
+def test_installed_files_on_a_unit_with_no_build_of_its_own_is_refused() -> None:
+    with pytest.raises((ValidationError, ManifestError), match="installed_files"):
+        _lib(install=[{"install": {"method": "apt", "packages": ["libthing2"]}}])
+
+
+# --- the effect check reads them back ---------------------------------------
+
+
+def test_verify_effects_confirms_each_declared_file_and_names_a_missing_one(
+    tmp_path: Path,
+) -> None:
+    prefix = tmp_path / "prefix"
+    (prefix / "lib" / "pkgconfig").mkdir(parents=True)
+    (prefix / "lib" / "libthing-2.so.2").write_bytes(b"\x7fELF")
+    verification = verify_effects(_plan(_lib()), None, prefix=prefix)
+    files = {c.subject: c for c in verification.checks if c.kind == "file"}
+    assert files["libthing:lib/libthing-2.so.2"].confirmed
+    assert not files["libthing:lib/pkgconfig/libthing-2.pc"].confirmed
+    assert "does not exist" in files["libthing:lib/pkgconfig/libthing-2.pc"].detail
+
+
+# --- D-051 and update can now decide a unit with no executable ---------------
+
+
+def test_a_library_is_decidable_once_its_files_are_declared(tmp_path: Path) -> None:
+    prefix = tmp_path / "prefix"
+    planned = _plan(_lib()).packages[0]
+    assert build_effects_present(planned, prefix=prefix) is False
+    (prefix / "lib" / "pkgconfig").mkdir(parents=True)
+    (prefix / "lib" / "libthing-2.so.2").write_bytes(b"\x7fELF")
+    (prefix / "lib" / "pkgconfig" / "libthing-2.pc").write_text("Name: libthing\n")
+    assert build_effects_present(planned, prefix=prefix) is True
+
+
+def test_without_the_declaration_the_same_unit_is_undecidable() -> None:
+    planned = _plan(_lib(installed_files=[])).packages[0]
+    assert build_effects_present(planned, prefix=Path("/nonexistent")) is None
+
+
+def test_update_reports_the_library_by_its_pin_instead_of_unknown() -> None:
+    states: dict[str, AptPackageState] = {}
+    undeclared = report(
+        _plan(_lib(installed_files=[])), apt_states=states, present={"libthing": None}, built=()
+    )
+    assert undeclared.rows[0].state == UNKNOWN
+    declared = report(_plan(_lib()), apt_states=states, present={"libthing": True}, built=())
+    assert declared.rows[0].state == BEHIND_PIN
+    assert "ref v2.2.1" in declared.rows[0].detail
+
+
+# --- the catalog's own case ---------------------------------------------------
+
+
+def test_libacars_declares_what_its_install_rule_leaves() -> None:
+    catalog = load_catalog(REPO_ROOT / "catalog" / "packages")
+    assert catalog["libacars"].installed_files == [
+        "lib/libacars-2.so.2",
+        "lib/libacars-2.so",
+        "lib/pkgconfig/libacars-2.pc",
+    ]
+    assert [b.install_as for b in catalog["fl-moxgen"].binaries] == ["fl_moxgen"]


### PR DESCRIPTION
Stacked on #91 (`update`), which it needs for `build_effects_present`. Retarget to `main` once #91 merges.

## The gap

`libacars` is a library: cmake's install rule leaves `lib/libacars-2.so.2`, the unversioned symlink and `lib/pkgconfig/libacars-2.pc` under the prefix, and no executable. With nothing to declare in `binaries`:

- the effect check (D-031) had nothing to read back, so its transactions ended `verified: true` with no check of it;
- the already-built rule (D-051) could never decide it, so every profile run rebuilds it;
- `update` (#91) reported it as **unknown**.

## Change

- `PackageManifest.installed_files: list[str]` — paths relative to the prefix that the build's own install rule leaves. Declared effects only: checked after the run as a `file` check, counted by `build_effects_present` (so D-051 and `update` can decide the unit), rendered on the package page. The engine never copies or removes them.
- The schema refuses an absolute path, a `..` segment, an empty entry, anything under `bin/` (an executable belongs in `binaries`), and the field on a unit with no source or git block.
- `catalog/packages/libacars.yaml` declares its three files; `catalog/packages/fl-moxgen.yaml` declares `fl_moxgen` in `binaries` (its Makefile installs it). Both read off the field laptop's disk, not assumed.
- `docs/reference/schema.md` and the two package pages regenerated.

## Measured on the field laptop

Before, from #91's report: `libacars` and `fl-moxgen` were the two **unknown** rows. From this branch:

```
$ hammunition update libacars fl-moxgen
  fl-moxgen  behind the pin  on disk, but not attributed at sha256 547b5ba7e9fa…: … `install fl-moxgen` rebuilds
  libacars   behind the pin  on disk, but not attributed at ref v2.2.1: … `install libacars` rebuilds
```

That is the correct reading: both were built in transactions that could not confirm a check the old manifests never declared. They build once more under these manifests, are attributed, and are never rebuilt again while the pin stands.

## Tests

`tests/test_installed_files.py`, 10 tests: the four refusals, the effect check confirming one file and naming the missing one, D-051's half going from undecidable to decidable with the declaration, `update` going from unknown to behind-the-pin, and the catalog's own two manifests. `make check` green locally: 1859 passed, 21 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
