### PR TITLE
containers: retry the target image's apt steps when the mirror is mid-sync

### DIFF
--- a/containers/Dockerfile.target
+++ b/containers/Dockerfile.target
@@ -36,17 +36,39 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1
 
+# `apt_step` runs `apt-get update` and one install, and retries the pair up
+# to three times a minute apart. The retry is for one measured failure and
+# nothing else: deb.parrot.sh served a Packages index naming python3.13
+# builds its pool no longer had, so update succeeded and install 404'd --
+# four times in two hours on 2026-09-12/13 (runs 34725601481, 34726708880,
+# 34727268076, 34728009036), every one green on a plain re-run minutes
+# later. A mirror mid-sync is a transient; a package that really is missing
+# still fails three times and the build still fails. The lists are removed
+# between attempts so the next update fetches the resynced index rather
+# than trusting the stale one.
+RUN printf '%s\n' \
+      '#!/bin/sh' \
+      'set -eu' \
+      'attempt=1' \
+      'while :; do' \
+      '  if apt-get -o APT::Sandbox::User="${APT_SANDBOX_USER:-_apt}" update \' \
+      '     && apt-get -o APT::Sandbox::User="${APT_SANDBOX_USER:-_apt}" install -y "$@"; then' \
+      '    rm -rf /var/lib/apt/lists/*; exit 0' \
+      '  fi' \
+      '  rm -rf /var/lib/apt/lists/*' \
+      '  if [ "$attempt" -ge 3 ]; then echo "apt_step: failed $attempt times" >&2; exit 1; fi' \
+      '  echo "apt_step: attempt $attempt failed; the mirror may be mid-sync, retrying in 60s" >&2' \
+      '  attempt=$((attempt + 1)); sleep 60' \
+      'done' > /usr/local/bin/apt_step \
+ && chmod 0755 /usr/local/bin/apt_step
+
 RUN if [ -n "${IDENTITY_PACKAGE}" ]; then \
-      apt-get -o APT::Sandbox::User=${APT_SANDBOX_USER} update \
-   && apt-get -o APT::Sandbox::User=${APT_SANDBOX_USER} install -y --allow-downgrades "${IDENTITY_PACKAGE}" \
-   && rm -rf /var/lib/apt/lists/*; \
+      apt_step --allow-downgrades "${IDENTITY_PACKAGE}"; \
     fi
 
 # python3-venv gives us a vendored virtualenv; we never touch system site-packages.
-RUN apt-get -o APT::Sandbox::User=${APT_SANDBOX_USER} update \
- && apt-get -o APT::Sandbox::User=${APT_SANDBOX_USER} install -y --no-install-recommends \
-      python3 python3-venv python3-pip ca-certificates apt-utils \
- && rm -rf /var/lib/apt/lists/*
+RUN apt_step --no-install-recommends \
+      python3 python3-venv python3-pip ca-certificates apt-utils
 
 # Vendored virtualenv, exactly as the shipped .deb will do (DESIGN.md §5).
 RUN python3 -m venv /opt/hammunition-venv


### PR DESCRIPTION
Four `parrot` job failures in two hours on 2026-09-12/13 (runs 34725601481, 34726708880, 34727268076, 34728009036), every one the same shape and every one green on a plain re-run minutes later:

```
apt-get update  && apt-get install -y --no-install-recommends python3 python3-venv python3-pip ca-certificates apt-utils
  404  Not Found [IP: 23.19.10.58 443]     (python3.13 3.13.5-2+deb13u4 named by the index, gone from the pool)
```

The update succeeded and the install 404'd: deb.parrot.sh was serving a Packages index naming builds its pool no longer had, which is a mirror mid-sync, not a missing package. Every PR tonight needed a manual re-run for it.

## Change

`containers/Dockerfile.target` gains `apt_step`, a twelve-line `/bin/sh` script written by the Dockerfile itself, and both apt steps (the optional identity package, and the python3 set) go through it. It retries the update-and-install pair up to three times a minute apart, removing `/var/lib/apt/lists/*` between attempts so the next update fetches the resynced index rather than trusting the stale one. A package that really is missing still fails three times and the build still fails, with `apt_step: failed 3 times` on stderr.

Nothing else in the image changes: the same `APT::Sandbox::User` option (falling back to `_apt`), the same flags, the same list cleanup on success.

## Driven locally

The script was extracted from the Dockerfile and run under `sh` with a fake `apt-get` on PATH:

| fake apt-get | result |
|---|---|
| install fails twice, succeeds on the third call | exit 0, two "retrying in 60s" lines |
| install always fails | exit 1, `apt_step: failed 3 times` |

This PR's own `parrot` job is the first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
