### PR TITLE
catalog: menu_title for 47 units that generate a terminal entry

### DIFF
--- a/catalog/packages/aircrack-ng.yaml
+++ b/catalog/packages/aircrack-ng.yaml
@@ -4,6 +4,7 @@
 name: aircrack-ng
 version: "1.7"
 summary: Wi-Fi security auditing suite — capture, analysis and key recovery
+menu_title: Wi-Fi capture and cracking suite (aircrack-ng)
 categories: [rf-security]
 
 install:

--- a/catalog/packages/aldo.yaml
+++ b/catalog/packages/aldo.yaml
@@ -4,6 +4,7 @@
 name: aldo
 version: "0.7.8"
 summary: Morse trainer with four teaching methods, including Koch
+menu_title: Morse code trainer (aldo)
 categories: [cw, training]
 
 install:

--- a/catalog/packages/atlc.yaml
+++ b/catalog/packages/atlc.yaml
@@ -4,6 +4,7 @@
 name: atlc
 version: "4.6.1"
 summary: Computes impedance of a transmission line of any cross-section, from a picture of it
+menu_title: Transmission line impedance calculator (atlc)
 categories: [antenna, electronics]
 
 install:

--- a/catalog/packages/avrdude.yaml
+++ b/catalog/packages/avrdude.yaml
@@ -4,6 +4,7 @@
 name: avrdude
 version: "7.1"
 summary: Reads and writes AVR microcontroller memories through almost any programmer
+menu_title: AVR microcontroller programmer (avrdude)
 categories: [electronics, programmer]
 
 install:

--- a/catalog/packages/ax25-xtools.yaml
+++ b/catalog/packages/ax25-xtools.yaml
@@ -4,6 +4,7 @@
 name: ax25-xtools
 version: "0.0.10"
 summary: X11 versions of the AX.25 monitoring tools
+menu_title: Packet soundmodem tuning scope (smdiag)
 categories: [packet]
 requires_kernel: [ax25]
 

--- a/catalog/packages/canadian-ham-exam.yaml
+++ b/catalog/packages/canadian-ham-exam.yaml
@@ -4,6 +4,7 @@
 name: canadian-ham-exam
 version: "1.0.1"
 summary: Practice tests for the Canadian amateur radio qualification exams
+menu_title: Canadian ham exam practice tests (canadian-ham-exam)
 categories: [training]
 
 install:

--- a/catalog/packages/cassbeam.yaml
+++ b/catalog/packages/cassbeam.yaml
@@ -4,6 +4,7 @@
 name: cassbeam
 version: "1.1"
 summary: Models Cassegrain dish antennas — the microwave and radio-astronomy case
+menu_title: Cassegrain dish antenna modeller (cassbeam)
 categories: [antenna]
 
 install:

--- a/catalog/packages/cw.yaml
+++ b/catalog/packages/cw.yaml
@@ -4,6 +4,7 @@
 name: cw
 version: "3.6.1"
 summary: Sounds text as Morse from the command line — the unixcw core tool
+menu_title: Morse code sender (cw)
 categories: [cw, training]
 
 install:

--- a/catalog/packages/cwcp.yaml
+++ b/catalog/packages/cwcp.yaml
@@ -4,6 +4,7 @@
 name: cwcp
 version: "3.6.1"
 summary: Curses Morse tutor — unixcw with a menu instead of a command line
+menu_title: Morse code tutor (cwcp)
 categories: [cw, training]
 
 install:

--- a/catalog/packages/dablin.yaml
+++ b/catalog/packages/dablin.yaml
@@ -4,6 +4,7 @@
 name: dablin
 version: "1.16.0"
 summary: Lightweight DAB receiver for the command line or a small window
+menu_title: DAB radio receiver (dablin)
 categories: [listening, sdr]
 
 install:

--- a/catalog/packages/dsdcc.yaml
+++ b/catalog/packages/dsdcc.yaml
@@ -4,6 +4,7 @@
 name: dsdcc
 version: "1.9.3"
 summary: Decodes digital voice protocols from demodulated audio
+menu_title: Digital voice decoder (dsdccx)
 categories: [listening, sdr]
 
 install:

--- a/catalog/packages/ebook2cw.yaml
+++ b/catalog/packages/ebook2cw.yaml
@@ -4,6 +4,7 @@
 name: ebook2cw
 version: "0.8.5"
 summary: Converts a text file or ebook into Morse code audio at a chosen speed
+menu_title: Text-to-Morse audio converter (ebook2cw)
 categories: [cw, training]
 
 install:

--- a/catalog/packages/esptool.yaml
+++ b/catalog/packages/esptool.yaml
@@ -4,6 +4,7 @@
 name: esptool
 version: "4.7.0"
 summary: Flash and inspect ESP8266 and ESP32 chips over their serial bootloader
+menu_title: ESP8266 and ESP32 flasher (esptool)
 categories: [workstation, hardware, rf-security]
 
 # D-026, worked example. This copies bytes to a serial port. Some of the images

--- a/catalog/packages/gnss-sdr.yaml
+++ b/catalog/packages/gnss-sdr.yaml
@@ -4,6 +4,7 @@
 name: gnss-sdr
 version: "0.0.20"
 summary: A complete GPS and GNSS receiver built entirely in software
+menu_title: Software-defined GNSS receiver (gnss-sdr)
 categories: [sdr, timing, station]
 
 install:

--- a/catalog/packages/gnuais.yaml
+++ b/catalog/packages/gnuais.yaml
@@ -4,6 +4,7 @@
 name: gnuais
 version: "0.3.3"
 summary: Decodes AIS from the discriminator output of a VHF receiver
+menu_title: AIS ship decoder (gnuais)
 categories: [tracking, listening]
 
 install:

--- a/catalog/packages/gnuaisgui.yaml
+++ b/catalog/packages/gnuaisgui.yaml
@@ -4,6 +4,7 @@
 name: gnuaisgui
 version: "0.3.3"
 summary: Puts the vessels gnuais has heard on an OpenStreetMap display
+menu_title: AIS ship map (gnuaisgui)
 categories: [tracking, listening]
 
 depends: [gnuais]

--- a/catalog/packages/gpsbabel.yaml
+++ b/catalog/packages/gpsbabel.yaml
@@ -4,6 +4,7 @@
 name: gpsbabel
 version: "1.10.0"
 summary: Converts between GPS file formats and talks to the receiver
+menu_title: GPS format converter (gpsbabel)
 categories: [station, tracking, timing]
 
 # SUPERSEDE, per docs/reference/dispositions.md #7: AHRL carries `gpsman`, a

--- a/catalog/packages/gr-air-modes.yaml
+++ b/catalog/packages/gr-air-modes.yaml
@@ -4,6 +4,7 @@
 name: gr-air-modes
 version: "0.0.20210211"
 summary: Decodes aircraft transponder replies with GNU Radio
+menu_title: Aircraft ADS-B decoder (modes_rx)
 categories: [tracking, sdr, listening]
 
 depends: [gnuradio]

--- a/catalog/packages/hacktv.yaml
+++ b/catalog/packages/hacktv.yaml
@@ -4,6 +4,7 @@
 name: hacktv
 version: "0+git20250218"
 summary: Generates and transmits analogue television — a HackRF as a TV station
+menu_title: Analogue TV transmitter (hacktv)
 categories: [sdr, rf-security]
 
 # Not a default install anywhere. It reaches an operator through a profile

--- a/catalog/packages/hcxdumptool.yaml
+++ b/catalog/packages/hcxdumptool.yaml
@@ -4,6 +4,7 @@
 name: hcxdumptool
 version: "6.3.5"
 summary: Wi-Fi frame capture aimed at producing hash files for offline analysis
+menu_title: Wi-Fi handshake capture tool (hcxdumptool)
 categories: [rf-security]
 
 install:

--- a/catalog/packages/inspectrum.yaml
+++ b/catalog/packages/inspectrum.yaml
@@ -4,6 +4,7 @@
 name: inspectrum
 version: "0.3.1"
 summary: Offline visualiser for captured radio signals — read a waveform by eye
+menu_title: Captured signal viewer (inspectrum)
 categories: [rf-security, sdr]
 
 install:

--- a/catalog/packages/linpac.yaml
+++ b/catalog/packages/linpac.yaml
@@ -4,6 +4,7 @@
 name: linpac
 version: "0.28"
 summary: Terminal for AX.25 packet with a built-in mail client and macros
+menu_title: AX.25 packet terminal (linpac)
 categories: [packet, emcomm]
 requires_kernel: [ax25]
 

--- a/catalog/packages/m2kcli.yaml
+++ b/catalog/packages/m2kcli.yaml
@@ -4,6 +4,7 @@
 name: m2kcli
 version: "0.9.0"
 summary: Command-line control of the ADALM2000 lab instrument
+menu_title: ADALM2000 instrument control (m2kcli)
 categories: [electronics, hardware]
 
 install:

--- a/catalog/packages/mfcuk.yaml
+++ b/catalog/packages/mfcuk.yaml
@@ -4,6 +4,7 @@
 name: mfcuk
 version: "0.3.8"
 summary: MIFARE Classic key recovery with no known key — the slow path
+menu_title: MIFARE Classic key recovery, no key needed (mfcuk)
 categories: [rfid]
 
 install:

--- a/catalog/packages/mfoc.yaml
+++ b/catalog/packages/mfoc.yaml
@@ -4,6 +4,7 @@
 name: mfoc
 version: "0.10.7"
 summary: Key recovery for MIFARE Classic cards with at least one known key
+menu_title: MIFARE Classic key recovery, needs one key (mfoc)
 categories: [rfid]
 
 install:

--- a/catalog/packages/minimodem.yaml
+++ b/catalog/packages/minimodem.yaml
@@ -4,6 +4,7 @@
 name: minimodem
 version: "0.24"
 summary: General-purpose audio FSK modem — Bell 103, RTTY, AX.25 and anything else
+menu_title: Audio FSK modem (minimodem)
 categories: [digital-modes, packet, listening]
 
 install:

--- a/catalog/packages/mlat-client-adsbfi.yaml
+++ b/catalog/packages/mlat-client-adsbfi.yaml
@@ -4,6 +4,7 @@
 name: mlat-client-adsbfi
 version: "0.4.2"
 summary: Contributes ADS-B timing data so a network can locate aircraft by multilateration
+menu_title: ADS-B multilateration feeder (mlat-client-adsbfi)
 categories: [tracking, sdr]
 
 install:

--- a/catalog/packages/morse2ascii.yaml
+++ b/catalog/packages/morse2ascii.yaml
@@ -4,6 +4,7 @@
 name: morse2ascii
 version: "0.2.1"
 summary: Decodes Morse out of a recorded WAV file
+menu_title: Morse decoder for WAV files (morse2ascii)
 categories: [cw, listening]
 
 install:

--- a/catalog/packages/multimon-ng.yaml
+++ b/catalog/packages/multimon-ng.yaml
@@ -4,6 +4,7 @@
 name: multimon-ng
 version: "1.3.1"
 summary: Decoder for POCSAG, FLEX, AFSK, DTMF and other audio-band digital modes
+menu_title: Pager and audio mode decoder (multimon-ng)
 categories: [listening, tracking]
 
 install:

--- a/catalog/packages/multimon.yaml
+++ b/catalog/packages/multimon.yaml
@@ -4,6 +4,7 @@
 name: multimon
 version: "1.0"
 summary: The original multimon decoder, kept for the modes its successor dropped
+menu_title: Legacy audio mode decoder (multimon)
 categories: [listening, tracking]
 
 install:

--- a/catalog/packages/openfpgaloader.yaml
+++ b/catalog/packages/openfpgaloader.yaml
@@ -4,6 +4,7 @@
 name: openfpgaloader
 version: "0.13.1"
 summary: Universal bitstream loader for FPGAs, over JTAG and SPI
+menu_title: FPGA bitstream loader (openFPGALoader)
 categories: [electronics, programmer]
 
 install:

--- a/catalog/packages/openocd.yaml
+++ b/catalog/packages/openocd.yaml
@@ -4,6 +4,7 @@
 name: openocd
 version: "0.12.0"
 summary: On-chip debugging and in-system programming over JTAG and SWD
+menu_title: On-chip JTAG and SWD debugger (openocd)
 categories: [electronics, programmer]
 
 install:

--- a/catalog/packages/pat.yaml
+++ b/catalog/packages/pat.yaml
@@ -4,6 +4,7 @@
 name: pat
 version: "0.16.0"
 summary: Winlink client — radio email that works when the internet does not
+menu_title: Winlink radio email client (pat-winlink)
 categories: [packet, emcomm]
 
 install:

--- a/catalog/packages/pipx.yaml
+++ b/catalog/packages/pipx.yaml
@@ -4,6 +4,7 @@
 name: pipx
 version: "1.7.1"
 summary: Installs Python applications in their own environments, on the PATH
+menu_title: Python application installer (pipx)
 categories: [workstation, station]
 
 install:

--- a/catalog/packages/readsb.yaml
+++ b/catalog/packages/readsb.yaml
@@ -4,6 +4,7 @@
 name: readsb
 version: "3.14.1630"
 summary: Efficient Mode S and ADS-B decoder — the maintained dump1090 successor
+menu_title: ADS-B and Mode S decoder (readsb)
 categories: [tracking, sdr, listening]
 
 # SUPERSEDE, per docs/reference/dispositions.md #4 and the dump1090 entry in

--- a/catalog/packages/rtl-433.yaml
+++ b/catalog/packages/rtl-433.yaml
@@ -4,6 +4,7 @@
 name: rtl-433
 version: "25.02"
 summary: Decoder for the unlicensed ISM bands — weather stations, sensors, tyre monitors
+menu_title: ISM-band sensor decoder (rtl_433)
 categories: [rf-security, sdr, tracking]
 
 install:

--- a/catalog/packages/rtl-ais.yaml
+++ b/catalog/packages/rtl-ais.yaml
@@ -4,6 +4,7 @@
 name: rtl-ais
 version: "0.3"
 summary: Receives both AIS channels at once from one cheap dongle
+menu_title: Dual-channel AIS receiver (rtl_ais)
 categories: [tracking, listening, sdr]
 
 install:

--- a/catalog/packages/soapyremote-server.yaml
+++ b/catalog/packages/soapyremote-server.yaml
@@ -4,6 +4,7 @@
 name: soapyremote-server
 version: "0.5.2"
 summary: Serves a local SDR over the network to software on another machine
+menu_title: Network SDR server (SoapySDRServer)
 categories: [sdr, hardware]
 
 install:

--- a/catalog/packages/soapysdr-tools.yaml
+++ b/catalog/packages/soapysdr-tools.yaml
@@ -4,6 +4,7 @@
 name: soapysdr-tools
 version: "0.8.1"
 summary: Command-line tools for the SoapySDR hardware abstraction layer
+menu_title: SoapySDR device probe (SoapySDRUtil)
 categories: [sdr, hardware]
 
 install:

--- a/catalog/packages/splat.yaml
+++ b/catalog/packages/splat.yaml
@@ -4,6 +4,7 @@
 name: splat
 version: "1.4.2"
 summary: Terrain-aware path analysis for VHF and above, from real elevation data
+menu_title: RF path and coverage modeller (splat)
 categories: [hf-propagation, antenna]
 
 install:

--- a/catalog/packages/tcpdump.yaml
+++ b/catalog/packages/tcpdump.yaml
@@ -4,6 +4,7 @@
 name: tcpdump
 version: "4.99.5"
 summary: Command-line packet capture — the tool that works when nothing else does
+menu_title: Command-line packet capture (tcpdump)
 categories: [rf-security, workstation]
 
 install:

--- a/catalog/packages/tio.yaml
+++ b/catalog/packages/tio.yaml
@@ -4,6 +4,7 @@
 name: tio
 version: "3.9"
 summary: Serial device terminal — the modern replacement for screen on a TTY
+menu_title: Serial terminal (tio)
 categories: [workstation, hardware]
 
 install:

--- a/catalog/packages/tlf.yaml
+++ b/catalog/packages/tlf.yaml
@@ -4,6 +4,7 @@
 name: tlf
 version: "1.4.1"
 summary: Console contest logger built for speed, driven from the keyboard
+menu_title: Contest logger (tlf)
 categories: [contest, logging, cw]
 
 install:

--- a/catalog/packages/tmd710-tncsetup.yaml
+++ b/catalog/packages/tmd710-tncsetup.yaml
@@ -4,6 +4,7 @@
 name: tmd710-tncsetup
 version: "1.13.1"
 summary: Configures the built-in TNC on Kenwood TM-D710 and TH-D72 radios
+menu_title: Kenwood TM-D710 TNC setup (tmd710_tncsetup)
 categories: [packet, tracking, radio-programming]
 
 install:

--- a/catalog/packages/tzwatch.yaml
+++ b/catalog/packages/tzwatch.yaml
@@ -4,6 +4,7 @@
 name: tzwatch
 version: "1.4.4"
 summary: Prints the time in several time zones at once, in a terminal
+menu_title: Multi-timezone clock (tzwatch)
 categories: [station, timing]
 
 install:

--- a/catalog/packages/voacapl.yaml
+++ b/catalog/packages/voacapl.yaml
@@ -4,6 +4,7 @@
 name: voacapl
 version: "0.7.6"
 summary: The VOACAP HF propagation prediction engine, ported to Linux
+menu_title: HF propagation predictor (voacapl)
 categories: [hf-propagation]
 
 install:

--- a/catalog/packages/wwl.yaml
+++ b/catalog/packages/wwl.yaml
@@ -4,6 +4,7 @@
 name: wwl
 version: "1.3"
 summary: Distance and bearing between two Maidenhead locators, from the command line
+menu_title: Grid square and distance calculator (wwl)
 categories: [hf-propagation, antenna]
 
 install:


### PR DESCRIPTION
The desktop menu (D-050/D-054) generates a terminal entry for every installed
unit that ships no desktop entry of its own, named after the unit. On the field
laptop that produces menu entries called `tlf`, `wwl`, `splat`, `tio`, `atlc`,
`m2kcli` — names a newcomer cannot read.

This populates the branch's optional `menu_title` field on exactly the 47 units
whose generated entry is named after the unit. Each title follows the fixed
convention: **what it does, then the command in parentheses**, sentence case,
short. The command in the parentheses is the executable the generated entry
actually runs, which is not always the unit's name — verified with
`dpkg -L <package> | grep bin/` on the field laptop and against `menus.cli_entries`
(so `dsdccx`, `modes_rx`, `pat-winlink`, `rtl_433`, `rtl_ais`, `SoapySDRServer`,
`SoapySDRUtil`, `tmd710_tncsetup`, `openFPGALoader`, and `smdiag` — ax25-xtools
ships only `smdiag` under `/usr/bin`, the rest in `/usr/sbin`).

No schema change: the `menu_title` field already exists on this branch. Docs are
unchanged: `gen_package_reference.py` does not render the field. `make check`
passes.

| Unit | menu_title |
|---|---|
| aircrack-ng | Wi-Fi capture and cracking suite (aircrack-ng) |
| aldo | Morse code trainer (aldo) |
| atlc | Transmission line impedance calculator (atlc) |
| avrdude | AVR microcontroller programmer (avrdude) |
| ax25-xtools | Packet soundmodem tuning scope (smdiag) |
| canadian-ham-exam | Canadian ham exam practice tests (canadian-ham-exam) |
| cassbeam | Cassegrain dish antenna modeller (cassbeam) |
| cw | Morse code sender (cw) |
| cwcp | Morse code tutor (cwcp) |
| dablin | DAB radio receiver (dablin) |
| dsdcc | Digital voice decoder (dsdccx) |
| ebook2cw | Text-to-Morse audio converter (ebook2cw) |
| esptool | ESP8266 and ESP32 flasher (esptool) |
| gnss-sdr | Software-defined GNSS receiver (gnss-sdr) |
| gnuais | AIS ship decoder (gnuais) |
| gnuaisgui | AIS ship map (gnuaisgui) |
| gpsbabel | GPS format converter (gpsbabel) |
| gr-air-modes | Aircraft ADS-B decoder (modes_rx) |
| hacktv | Analogue TV transmitter (hacktv) |
| hcxdumptool | Wi-Fi handshake capture tool (hcxdumptool) |
| inspectrum | Captured signal viewer (inspectrum) |
| linpac | AX.25 packet terminal (linpac) |
| m2kcli | ADALM2000 instrument control (m2kcli) |
| mfcuk | MIFARE Classic key recovery, no key needed (mfcuk) |
| mfoc | MIFARE Classic key recovery, needs one key (mfoc) |
| minimodem | Audio FSK modem (minimodem) |
| mlat-client-adsbfi | ADS-B multilateration feeder (mlat-client-adsbfi) |
| morse2ascii | Morse decoder for WAV files (morse2ascii) |
| multimon | Legacy audio mode decoder (multimon) |
| multimon-ng | Pager and audio mode decoder (multimon-ng) |
| openfpgaloader | FPGA bitstream loader (openFPGALoader) |
| openocd | On-chip JTAG and SWD debugger (openocd) |
| pat | Winlink radio email client (pat-winlink) |
| pipx | Python application installer (pipx) |
| readsb | ADS-B and Mode S decoder (readsb) |
| rtl-433 | ISM-band sensor decoder (rtl_433) |
| rtl-ais | Dual-channel AIS receiver (rtl_ais) |
| soapyremote-server | Network SDR server (SoapySDRServer) |
| soapysdr-tools | SoapySDR device probe (SoapySDRUtil) |
| splat | RF path and coverage modeller (splat) |
| tcpdump | Command-line packet capture (tcpdump) |
| tio | Serial terminal (tio) |
| tlf | Contest logger (tlf) |
| tmd710-tncsetup | Kenwood TM-D710 TNC setup (tmd710_tncsetup) |
| tzwatch | Multi-timezone clock (tzwatch) |
| voacapl | HF propagation predictor (voacapl) |
| wwl | Grid square and distance calculator (wwl) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
