### PR TITLE
Docs: the road to 1.0 measured, README and CLAUDE.md brought current, mesh track recorded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,7 +474,7 @@ catalog/
     classes/       # device families with shared Linux needs ✅ 5
     devices/       # one YAML per device                     ✅ 24
 src/hammunition/
-  cli/             # argparse entry points; install/list/status/show ✅
+  cli/             # install/uninstall/update/list/status/show/doctor/hardware/menus/station ✅
   manifest/        # schema, loader, validation              ✅
     hardware.py    # device catalog schema (D-020)           ✅
   consent/         # affirmative consent gates (D-021)       ✅
@@ -486,22 +486,21 @@ src/hammunition/
   fetch.py         # verified download, mandatory sha256          ✅
   paths.py         # owner-aware XDG dirs (log, cache, build)     ✅
   distro/          # /etc/os-release detection               ✅
-  hardware/        # USB/serial detection, udev generation   ✅ written; not hardware-verified
+  hardware/        # USB/serial detection, udev generation   ✅ rules applied on the field laptop; attached-device ladder not yet run
 docs/              # "Hacker's Ham Shack" — guides and labs (section title, not a brand)
   contributing/    # how to contribute; hardware.md is the live ask   ✅
   reference/cli.md # the CLI reference                       ✅
 tests/
 ```
 
-Ticks mark what exists. **M1's walking skeleton runs** — detect, resolve, print,
-install, log — and **M3 has begun**: the verified fetcher and the
-source-from-tarball and source-from-git backends are written, so `source` and
-`git` manifests now plan and build end to end, and binary, venv and node
-followed. What it cannot do it still refuses by name: pipx and templated config
-files are measured, named and absent. Do not let this read as a
-working installer: **57 of AHRL's 95 units cannot be satisfied by apt**, and
-while source-from-tarball is the largest single slice of that 57 (35 units), the
-rest of the 60% is still the hard part (**D-004**).
+Ticks mark what exists. Every backend 1.0 needs is written and VM-verified,
+`uninstall` reverses all of them, and the whole catalog installed on the field
+laptop with every effect confirmed (2026-09-12). What is still refused by name
+is refused on purpose: AppImage and a Wine prefix are post-1.0 (SCOPE.md), and
+pipx and CPAN were measured at zero users. **57 of AHRL's 95 units cannot be
+satisfied by apt** (D-004); that 60% is what the seven backends exist for, and
+they cover it. What separates this from a 1.0 tag is verification and one
+decision, listed with owners in `docs/reference/release-1.0-checklist.md`.
 
 ## Closed questions
 
@@ -582,10 +581,9 @@ exists, document the gap rather than carry a fork we cannot sustain.
 VARA and HAMRS are post-1.0. Novel capability (RF security, mesh) layers on top,
 never substitutes.
 
-**M1 — walking skeleton. ✅ It runs.** `hammunition install <profile> --dry-run`
+**M1 — walking skeleton. ✅ Complete.** `hammunition install <profile> --dry-run`
 resolves the whole transaction and prints every command; without `--dry-run` it
-installs. Remaining M1 gap is the starter profile's name and contents, which
-`docs/reference/profile-sizing.md` still has awaiting the maintainer.
+installs. The starter profile question closed as `station` (16 profiles ship).
 - Manifest schema + validator ✅
 - apt backend ✅ — with real resolution: `depends` goes through
   `apt-cache policy`, which is what D-016's four suspected-stale AHRL
@@ -593,11 +591,6 @@ installs. Remaining M1 gap is the starter profile's name and contents, which
   in M3; see below
 - `/etc/os-release` detection ✅ — shared with `scripts/capability_matrix.py`
   rather than duplicated, so `--check` verifies the parser the engine uses
-- the starter profile is the last M1 item and is **awaiting the maintainer**:
-  named `ham-core` when M1 was written, `docs/reference/profile-sizing.md`
-  proposes **`station`** instead and a four-way split. The catalog it would
-  draw on is no longer the constraint — 247 manifests exist where M1 planned
-  about twenty
 - `install`, `list`, `status`, `show`, `--dry-run` ✅
 - Container test harness for Parrot and Debian ✅
 
@@ -671,14 +664,17 @@ prefix are **post-1.0**, required by HAMRS and VARA respectively. `snap` appears
 11 times and is an **anti-dependency** — every occurrence is removal — so it
 belongs in `system_modifications`, never as a backend.
 
-**M4 — profiles and hardware.** Full profile set. udev rules, group membership,
-firmware. Persistent device symlinks.
+**M4 — profiles and hardware. ✅ Profiles complete; hardware applied, not yet
+exercised.** All 12 profiles of the 1.0 set plus 4 post-1.0 ship, every member
+installable and asserted by test. udev rules and group membership are generated
+from the hardware catalog and were applied on the field laptop, byte-identical to
+the catalog's set; the ladder against attached devices is the open item, and
+D-029 says what the hardware role actually is.
 
-**M5 — parity verified.** Every unit either **installs successfully on at least
-one supported distro**, or carries a `broken`/`retired` status **verified by us**
-— never inherited from an AHRL shell comment. Re-attempt `ardop`,
-`radiosonde_auto_rx`, and the compiler-flag-fragile set before accepting any
-verdict, and record what was tested: date, version, distro, actual failure.
+**M5 — parity verified. ✅ Met on six VMs** (`docs/reference/m5-parity-verified.md`):
+every unit either installs on at least one supported distro or carries a verdict
+tested here, never inherited, with zero hard install failures across the whole
+catalog on Parrot, Kali, Debian 13, Ubuntu 24.04, Ubuntu 26.04 and Pop!_OS 24.04.
 
 **Exit criterion: our install-success fraction must be at least as good as
 AHRL's own.** AHRL ships 95 units with 9 disabled. Shipping 95 manifests with 40

--- a/README.md
+++ b/README.md
@@ -24,13 +24,20 @@ installs the engine in one command; `hammunition doctor` reports what is ready;
 `hammunition hardware` detects your radios and applies the udev rules and
 group membership they need; `hammunition update` reports what is installed
 against the catalog and, with `--upstream`, the catalog against what
-upstream publishes; launchers and curated desktop menus generate for
-Xfce and GNOME. What remains for 1.0: the Pop!_OS declaration decision now
-that its VM has run, COSMIC menus, real-hardware checks on the bench (the
-field target is a Dell Latitude 5430 Rugged; [its first session](docs/reference/bench-verification-5430.md)
-ran the read-only ladder and then the whole catalog: 164 units, verified, on 2026-09-12 — the attached-hardware ladder is what remains there), what a
-packet station means on a kernel without AX.25 (D-041), and release
-engineering — the first signed tag waits on a key that does not exist yet.
+upstream publishes; launchers and a curated desktop menu generate from the
+catalog — eight activity groups, 55 submenus named for the thing a person
+looks for, a toolkit nested as one line, every generated entry titled by
+what it does (D-050, D-054, D-055) — measured on the field laptop's KDE
+Plasma, written for Xfce through the menu spec and for GNOME through its
+app-folders, and not yet looked at on either of those desktops since the
+rebuild. **What remains for 1.0** is listed with owners in
+[the 1.0 checklist](docs/reference/release-1.0-checklist.md): the Pop!_OS
+declaration decision, the rebuilt menu seen on GNOME, Xfce and COSMIC,
+the attached-hardware ladder on the bench (the field target is a Dell
+Latitude 5430 Rugged; [nine sessions](docs/reference/bench-verification-5430.md)
+have run there, the whole catalog installed and verified, the radios not
+yet plugged in), and a signing key — the first signed tag waits on one
+that does not exist yet.
 
 Being honest about this up front matters more than looking finished, so here is
 exactly where things stand:
@@ -54,7 +61,7 @@ exactly where things stand:
 | Builds from a pinned git revision, with the pin verified after checkout | ✅ working |
 | Prebuilt binaries: `.deb`, tarball, zip, executable | ✅ working — `.deb` through apt, never `dpkg -i` |
 | Per-user venv installs, hash-pinned end to end (`--require-hashes`) | ✅ working — not1mm and NanoVNASaver run from them |
-| Launcher + desktop-entry generation from manifests (D-036) | ✅ working — 24 units carry launchers; terminal launchers hold their window; a wrapper never shadows its own tool (found and fixed 2026-09-12) |
+| Launcher + desktop-entry generation from manifests (D-036) | ✅ working — 26 units carry launchers; terminal launchers hold their window; a wrapper never shadows its own tool (found and fixed 2026-09-12) |
 | Idempotent re-runs for builds (D-051) | ✅ a source, git or prebuilt unit already installed at its pin is skipped; measured on the field laptop: 143 of 165 units plan nothing on a re-run |
 | AppImage backend | ❌ post-1.0 (SCOPE.md) — refused by name |
 | pipx / CPAN backends | ⚪ re-measured to **zero users** and dropped from 1.0 (D-014 amendment) |
@@ -64,7 +71,8 @@ exactly where things stand:
 | `uninstall` | ✅ working — reverses apt, venv, binary, .deb, trees and launchers; marker-verified, VM-proven; a real `make install` is refused by name |
 | End-to-end VM verification (install / configure / remove) | ✅ Parrot, Kali, Debian 13, Ubuntu 24.04, Ubuntu 26.04, and [Pop!_OS 24.04](docs/reference/vm-campaign-pop.md) as an undeclared target |
 | M5 install-success across the full catalog, six targets | ✅ **zero hard failures**; every unit installs on ≥1 target or is refused with a reason |
-| Curated desktop menus (Xfce/KDE menu-spec + GNOME app-folders) | ✅ Parrot's shape (D-050): *Hammunition*, seven ordered groups (Workstation hidden — git and VS Code are not radio), one submenu per category, and a generated entry for every installed radio unit that ships none; measured on the field laptop's Plasma 2026-09-12; GNOME's per-group folders written and awaiting the Debian VM; Xfce awaiting a Kali re-run; COSMIC unmeasured — the Pop VM exists now, its desktop has not been looked at |
+| Curated desktop menus (Xfce/KDE menu-spec + GNOME app-folders) | ✅ *Hammunition*, eight activity groups in a newcomer's reading order, 55 submenus named for the thing a person looks for, a toolkit unit nested as one line (GNU Radio's 21 entries), a titled entry for every installed unit that ships none, and a source build's own entry placed from the local prefix (D-050, D-054, D-055); measured on the field laptop's Plasma 2026-09-13: 108 entries placed, largest submenu 11; GNOME's eight folders written and read back from gsettings on the same machine; Xfce and COSMIC not yet looked at since the rebuild |
+| `update` and `update --upstream` (D-053) | ✅ installed against the catalog offline, the catalog against upstream on request; measured on the field laptop: 171 units in 0.7 s, 25 upstream probes in 7.5 s, three pins found behind and re-pinned the same night |
 | Profile companion offers (mail client, serial terminal) | ✅ detect → respect → offer, never silent |
 | Getting-started, profile, troubleshooting docs | ✅ written and generated |
 
@@ -316,6 +324,7 @@ catalog and the measurements, so they cannot say what the code does not.
 | [`docs/reference/device-naming.md`](docs/reference/device-naming.md) | What `/dev/serial/by-id/` already covers, and the 19 of 23 devices where it does not |
 | [`docs/contributing/hardware.md`](docs/contributing/hardware.md) | How to send one, and what we do and don't store |
 | [`docs/reference/bench-verification-5430.md`](docs/reference/bench-verification-5430.md) | What has run on the field target itself, a Dell Latitude 5430 Rugged, and what has not |
+| [`docs/reference/release-1.0-checklist.md`](docs/reference/release-1.0-checklist.md) | What stands between here and a 1.0 tag, each item with its owner and its measurement |
 | [`docs/contributing/releasing.md`](docs/contributing/releasing.md) | How a release is cut and signed, and why v0.7.0 is not |
 
 The user-facing documentation site is *Hacker's Ham Shack*. Its standard: a

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -256,6 +256,8 @@ Ordered by coverage-per-effort, not by source.
 9. **Trunked and digital-voice listening** — post-1.0, receive-only; see below
 10. **Repeater and hotspot** — post-1.0, transmit infrastructure; waits on
     station config; see below
+11. **Mesh and Reticulum** — post-1.0; a vibrant, varied ecosystem is the
+    goal, not two clients; see below
 
 **1.0 = stages 1 through 6.** That is already more coverage than any single
 existing project, and it is achievable. Stages 7 through 10 are where "one stop
@@ -394,3 +396,34 @@ already ships, profiles that already exist, and no dependency on station
 config. Track B's SvxLink sub-stack is one `config_files` block away once
 D-004's station config lands; ASL3 is a D-040 manifest; the G4KLX suite is
 last, because it needs the pin decision and hardware nobody here owns yet.
+
+### Track C — mesh and Reticulum (stage 11)
+
+Asked for by the maintainer on 2026-09-13: "Reticulum, Meshtastic, MeshCore
+and the rest aren't included; we want an extremely vibrant and varied
+Reticulum ecosystem and apps available to get people diving in." Today the
+catalog carries two Meshtastic units (`python3-meshtastic`,
+`gtk-meshtastic-client`) under the `mesh` tag and nothing of Reticulum or
+MeshCore; `reticulum-meshchat` is dispositioned ADD (post-1.0) and waits on
+the AppImage backend. The track is receive-and-mesh, not repeater
+infrastructure, so it does not wait on station config; it waits on
+measurement, and on 1.0 shipping first.
+
+What a vibrant ecosystem means here, each a unit with a measured pin:
+
+- **Reticulum** — the stack (`rns`) and its daemon, LXMF, Nomad Network,
+  Sideband, MeshChat, the RNode firmware flasher, and the transports that
+  make it interesting on radio: LoRa through RNode, packet through a KISS
+  TNC, and the interfaces that ride on the rest of this catalog.
+- **Meshtastic** — `meshtasticd` for a Linux node with a LoRa HAT (never
+  in Debian; the openSUSE OBS repository is the D-040 case with a
+  fingerprint to pin), the web client, the flashers, and the existing CLI
+  and GTK client.
+- **MeshCore** — the companion clients, the web flasher's firmware pins,
+  and whatever the board definitions the LoRa sweep already reads turn out
+  to need (`docs/reference/lora-inventory.md`: 107 boards, 26 identifiers).
+
+Every one of these is installable per-user (venv, node, AppImage post-1.0)
+or through a pinned repository, which is why the track can be cheap; what it
+must not do is arrive as a list of names. A `mesh` profile ships when its
+units have run against a node on the bench, and the tracking issue is #105.

--- a/docs/reference/release-1.0-checklist.md
+++ b/docs/reference/release-1.0-checklist.md
@@ -1,0 +1,63 @@
+<!--
+SPDX-FileCopyrightText: Copyright (C) 2026 Renegade Penguin LLC
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+# The 1.0 checklist
+
+**Written:** 2026-09-13, from measurements, after the maintainer asked how
+close 1.0 is. SCOPE.md defines 1.0 as stages 1 through 6, and every one of
+them is in the catalog; M5's exit criterion is met on six VMs. What is left is
+verification and one decision. Each item names its owner, because most of
+them need either the maintainer's hardware or the maintainer's key.
+
+## Done, and where the evidence is
+
+| Gate | Evidence |
+|---|---|
+| Stages 1–6 in the catalog | 249 manifests; Blend 152 of 152; parity 106 of the 124 units that owe a manifest, every gap with a recorded reason (`parity-coverage.md`) |
+| Every backend 1.0 needs, with `uninstall` for each | apt, source, git, binary, venv, node, apt_repo, data — `m5-parity-verified.md`, `vm-campaign-*.md` |
+| M5: install-success at least AHRL's 90.5% | zero hard failures on six targets (`m5-parity-verified.md`) |
+| The whole catalog on the field target | 164 units installed and verified, 33 effect checks (`bench-verification-5430.md`, session 6) |
+| Idempotent re-runs for builds | D-051, measured: 143 of 165 plan nothing on a re-run |
+| `update` and `update --upstream` | D-053, measured: 171 units in 0.7 s; 25 probes in 7.5 s; three pins re-pinned (#97) |
+| The menu, on KDE Plasma | D-050/D-054/D-055, measured on the field laptop: 8 groups, 54 submenus, 108 entries placed, largest submenu 11 |
+| GNOME app-folders | written by `menus apply --gnome` and read back from gsettings on the field laptop, 2026-09-13: 8 folders, each carrying its group's categories and app list |
+| Open questions | none (`QUESTIONS.md`) |
+
+## Open, with owners
+
+| # | Item | Owner | How it closes |
+|---|---|---|---|
+| 1 | **The attached-hardware ladder** on the field target: HackRF Pro, Proxmark3, a Meshtastic node, the C5 Wardriver, one at a time; `hardware list` recognises each, permits it, symlinks it as `device-naming.md` says | maintainer, on the bench | session 10 in `bench-verification-5430.md`; the README's "not yet exercised against an attached device" line comes out |
+| 2 | **The rebuilt menu seen on GNOME and Xfce.** The data is written correctly on both paths (gsettings read back here; the menu-spec file parses into the right 8-group, 54-submenu structure with the freedesktop parser); what has not happened is a person opening the launcher on either desktop since D-055 | the VM host session, or the maintainer on a Debian GNOME VM and the Kali Xfce VM | one screenshot-level check each, recorded on the VM page |
+| 3 | **COSMIC menus.** No mechanism has been measured (D-036); the Pop!_OS 24.04 VM exists | maintainer's decision: measure now, or declare COSMIC post-1.0 in SCOPE.md | either a measured mechanism or one line in SCOPE.md |
+| 4 | **Pop!_OS as a declared target.** Its VM campaign passed; it is carried as undeclared | maintainer's decision | `containers/targets.yaml` and the capability matrix, or a line saying why not |
+| 5 | **A signing key.** `releasing.md` documents SSH-signed tags and `.github/allowed_signers`; no key exists | maintainer generates it (nobody else may) | the first signed tag is 1.0 |
+| 6 | **The second full-profile run on the field target**, which attributes the 19 builds D-051 cannot yet decide, then `hammunition update` reads them all up to date | maintainer (sudo) | ladder item 6 on the bench page |
+| 7 | **Real uninstalls on the field target**: `station`, `rf-security`, `packet`, against their dry runs | maintainer (sudo) | ladder item 5 on the bench page |
+| 8 | **Version and tag.** `pyproject.toml` says 0.7.0; the README says alpha | this repository, last | bump, changelog from the merged PRs, annotated and signed tag |
+
+Issues open and not blocking: #96 (a declared capability step for linbpq;
+route 1 shipped in #97), #76 (the wiki, post-1.0), #105 (the mesh and
+Reticulum track, SCOPE.md stage 11, post-1.0).
+
+## The bench ladder for the hardware session
+
+Every step is `sudo`-free until it says otherwise, and every one is recorded
+in `bench-verification-5430.md` afterwards.
+
+```
+hammunition doctor                       # 11 ok expected, as in session 8
+hammunition hardware list                # before anything is plugged in: the baseline
+# plug in one device, wait two seconds
+hammunition hardware list                # the device recognised, its class named, its permission state
+ls -l /dev/serial/by-id/ /dev/hammunition* 2>/dev/null   # the symlink device-naming.md promises, if any
+hammunition hardware apply --dry-run     # nothing to change is the expected answer; anything else is a finding
+# unplug, next device
+```
+
+Then, with the RTL-SDR or the HackRF attached: open *Hammunition → SDR &
+Listening → SDR Receivers & Transceivers → Gqrx* from the menu, select the
+device, confirm audio. That one click is the first GUI-against-radio
+measurement on this machine, and it closes ladder item 3.


### PR DESCRIPTION
Asked on 2026-09-13: how close is 1.0, and is the documentation current? Measured answer: every 1.0 stage is in the catalog and M5 is met; what remains is verification and one decision. This PR makes the docs say that, with numbers measured tonight rather than typed.

## README

- "What remains for 1.0" no longer names the AX.25-kernel question (D-045 settled it) or a menu that predates the rebuild; it points at the new checklist and names the four real gates.
- The menus row describes the tree you actually have (D-050, D-054, D-055): 8 activity groups, 55 submenus, GNU Radio nested, titled entries, source builds' own entries placed; measured on the field laptop's Plasma (108 placed, largest submenu 11). GNOME's eight folders were written and read back from gsettings on the same machine; Xfce and COSMIC are stated as not yet looked at since the rebuild.
- New row for `update` and `--upstream` (D-053) with its measurements; launcher count 24 → 26; the docs table gains the checklist.

## CLAUDE.md

- The repo-layout narrative no longer says "M1 runs, M3 has begun, do not let this read as a working installer"; it states the seven backends, the field-laptop full install, and what is refused on purpose.
- The `cli/` line lists every verb; the `hardware/` line says rules applied on the bench, ladder not yet run.
- M1 marked complete (the starter-profile question closed as `station`); M4 marked profiles complete and hardware applied-not-exercised; M5 marked met on six VMs with the page linked.

## `docs/reference/release-1.0-checklist.md` (new)

What is done with evidence, and eight open items each with an owner and how it closes: the attached-hardware ladder (maintainer, Monday), the rebuilt menu seen on GNOME and Xfce (data verified both ways here; a person has not opened either launcher), COSMIC (measure or declare post-1.0), Pop!_OS declaration, a signing key, the second full-profile run, real uninstalls, version and tag. The bench ladder for the hardware session is written command by command.

## SCOPE.md stage 11, Track C

Mesh and Reticulum, post-1.0, from the maintainer's ask the same day: Reticulum (rns, LXMF, Nomad Network, Sideband, MeshChat, RNode), Meshtastic (`meshtasticd` from the OBS repository as a D-040 case, web client, flashers) and MeshCore, each needing a measured pin and a run against a node. Tracking issue #105.

Doc-link check passes; `make check` green: 1899 passed, 21 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
