### PR TITLE
v0.9.0, beta: feature-complete for 1.0, verification remains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,18 @@ One entry per release, written from the merged pull requests, each line
 naming the PR and the decision it rests on. Decisions are authoritative in
 `docs/DECISIONS.md`; this file is the map from a version to them.
 
-## Unreleased — the road to 1.0 (since v0.7.0, 2026-09-02)
+## Unreleased
 
-79 pull requests merged between 2026-09-02 and 2026-09-13. What separates
-this from the 1.0 tag is listed with owners in
-`docs/reference/release-1.0-checklist.md`.
+Nothing yet.
+
+## v0.9.0 — 2026-09-13 — beta: feature-complete for 1.0, verification remains
+
+79 pull requests merged between 2026-09-02 and 2026-09-13. Every 1.0 stage
+of SCOPE.md is in the catalog, the seven backends are written and reversed
+by `uninstall`, M5 is met on six VMs, and the whole catalog installed and
+verified on the field target. What separates this from the 1.0 tag is
+verification and one decision, listed with owners in
+`docs/reference/release-1.0-checklist.md`; that is the 0.1 that is missing.
 
 ### Engine
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ targeting Debian, Ubuntu, Kali, Linux Mint and Raspberry Pi OS.
 
 ---
 
-## ⚠️ Alpha — it installs, configures and removes; the hard 40% is still ahead
+## Beta, v0.9.0 — feature-complete for 1.0; what remains is verification on the bench
 
-**Status: alpha, v0.7.0 — ready to deploy and shake out.** The core cycle —
+**Status: beta, v0.9.0 — every 1.0 stage is in the catalog; the 0.1 that is missing is measured, not written.** The core cycle —
 resolve, disclose, install, configure, verify, remove — runs end to end and is
 **VM-verified on Parrot, Kali, Debian 13, Ubuntu 24.04, Ubuntu 26.04 and
 Pop!_OS 24.04**, with **zero hard install failures across the whole catalog on
@@ -76,14 +76,15 @@ exactly where things stand:
 | Profile companion offers (mail client, serial terminal) | ✅ detect → respect → offer, never silent |
 | Getting-started, profile, troubleshooting docs | ✅ written and generated |
 
-**Much of the catalog is still out of reach.** Of AHRL's 95 units, **57 cannot
-be satisfied by apt at all** — that missing 60% is the hard part and is precisely
-what users cannot install themselves, which is the reason the project exists. The
-source, git, prebuilt-binary, venv and node backends now cover it; what
-remains out of reach is AppImage and a configured Wine prefix, both post-1.0
-and each refused by name. If you want a working ham radio Linux setup today,
-use one of the projects in [Credit](#credit) below — they work now, and this
-project exists because of them, not instead of them.
+**The hard part is covered.** Of AHRL's 95 units, **57 cannot be satisfied
+by apt at all** — that 60% is precisely what users cannot install themselves,
+which is the reason the project exists — and the source, git, prebuilt-binary,
+venv and node backends now cover it, verified on six VMs and on the field
+target. What remains out of reach is AppImage and a configured Wine prefix,
+both post-1.0 and each refused by name. Until the bench ladder has run against
+attached radios ([the checklist](docs/reference/release-1.0-checklist.md)),
+the projects in [Credit](#credit) below are the ones with years of field use
+behind them; this project exists because of them, not instead of them.
 
 What it does do, it does completely: `--dry-run` prints every command and every
 system change before anything happens, resolution finishes before installation
@@ -302,8 +303,8 @@ requirements, not aspirations:
   release key with the dates it was trusted. Check that file against
   `https://api.github.com/users/ChiefGyk3D/ssh_signing_keys` before trusting
   it; [`docs/contributing/releasing.md`](docs/contributing/releasing.md) is
-  the procedure. **No key exists yet**: `v0.7.0` is annotated and unsigned,
-  and the file says so.
+  the procedure. **No key exists yet**: `v0.7.0` and `v0.9.0` are annotated
+  and unsigned, and the file says so; the first signed tag is 1.0.
 
 ---
 
@@ -326,7 +327,7 @@ catalog and the measurements, so they cannot say what the code does not.
 | [`docs/reference/bench-verification-5430.md`](docs/reference/bench-verification-5430.md) | What has run on the field target itself, a Dell Latitude 5430 Rugged, and what has not |
 | [`docs/reference/release-1.0-checklist.md`](docs/reference/release-1.0-checklist.md) | What stands between here and a 1.0 tag, each item with its owner and its measurement |
 | [`CHANGELOG.md`](CHANGELOG.md) | One entry per release, from the merged pull requests, each line naming the decision it rests on |
-| [`docs/contributing/releasing.md`](docs/contributing/releasing.md) | How a release is cut and signed, and why v0.7.0 is not |
+| [`docs/contributing/releasing.md`](docs/contributing/releasing.md) | How a release is cut and signed, and why v0.7.0 and v0.9.0 are not |
 
 The user-facing documentation site is *Hacker's Ham Shack*. Its standard: a
 licensed ham with moderate Linux experience should get from a fresh install to a

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -295,7 +295,8 @@ after checking the file against the maintainer's profile as described in
 [More than one key](#more-than-one-key). A `key has expired` or `No
 principal matched` from a tag *older* than the key's `valid-before` is the
 git 2.34 behaviour, not a bad tag; run it on a machine with git 2.35 or
-later. Until a key exists, `v0.7.0` is what there is, and it is unsigned.
+later. Until a key exists, `v0.7.0` and `v0.9.0` are what there is, and they
+are unsigned; the first signed tag is 1.0.
 
 ## Before the tag
 

--- a/docs/reference/release-1.0-checklist.md
+++ b/docs/reference/release-1.0-checklist.md
@@ -36,7 +36,7 @@ them need either the maintainer's hardware or the maintainer's key.
 | 5 | **A signing key.** `releasing.md` documents SSH-signed tags and `.github/allowed_signers`; no key exists | maintainer generates it (nobody else may) | the first signed tag is 1.0 |
 | 6 | **The second full-profile run on the field target**, which attributes the 19 builds D-051 cannot yet decide, then `hammunition update` reads them all up to date | maintainer (sudo) | ladder item 6 on the bench page |
 | 7 | **Real uninstalls on the field target**: `station`, `rf-security`, `packet`, against their dry runs | maintainer (sudo) | ladder item 5 on the bench page |
-| 8 | **Version and tag.** `pyproject.toml` says 0.7.0; the README says alpha | this repository, last | bump, changelog from the merged PRs, annotated and signed tag |
+| 8 | **Version and tag.** 0.9.0 (beta) is the version on `main` from 2026-09-13, with its changelog entry; the 1.0 bump and the first signed tag come last | this repository, last | bump to 1.0.0, changelog entry, annotated and signed tag |
 
 Issues open and not blocking: #96 (a declared capability step for linbpq;
 route 1 shipped in #97), #76 (the wiki, post-1.0), #105 (the mesh and

--- a/docs/why-hammunition.md
+++ b/docs/why-hammunition.md
@@ -2,10 +2,11 @@
 
 *Linux radio tools for people who can't leave well enough alone.*
 
-> **State of the project, September 2026: it installs.** v0.7.0, an alpha,
-> was tagged on 2026-09-02. The catalog holds 244 package manifests, 16
-> profiles, and a 23-device hardware catalog with 297 measured USB
-> identifiers. The engine has seven backends — apt, source tarball, git,
+> **State of the project, September 2026: it installs, and it is beta.**
+> v0.9.0 (2026-09-13) is feature-complete for 1.0; what remains is
+> verification against attached radios on the bench. The catalog holds 249
+> package manifests, 16 profiles, and a 24-device hardware catalog with 297
+> measured USB identifiers. The engine has seven backends — apt, source tarball, git,
 > binary, Python venv, Node, and opt-in third-party apt repositories — and
 > the whole catalog and every profile have been installed from a clean
 > snapshot on Parrot, Debian 13, Kali, Ubuntu 24.04, Ubuntu 26.04 and
@@ -281,8 +282,8 @@ Nearly every project in this space depends on one person. That's not a criticism
 debt to those individuals. But it's fragile, and we'd rather build something that
 survives its founder. Multiple maintainers with merge rights, a documented
 decision process, a real pull-request path, and signed releases — the first
-three from the start, the last as soon as a signing key exists (v0.7.0 is an
-annotated tag, unsigned, and says so).
+three from the start, the last as soon as a signing key exists (v0.7.0 and
+v0.9.0 are annotated tags, unsigned, and say so; 1.0 will be signed).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hammunition"
-version = "0.7.0"
+version = "0.9.0"
 description = "Turn a Debian-family install into an amateur radio, SDR and RF workstation"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -257,7 +257,7 @@ def test_campaign_prepare_refreshes_apt_lists_and_keeps_its_failure_text(
             subprocess.CompletedProcess(
                 [], 1, stdout="", stderr="ERROR: Could not fetch URL https://pypi.org/simple/"
             ),
-            subprocess.CompletedProcess([], 0, stdout="hammunition 0.7.0\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="hammunition 0.9.0\n", stderr=""),
         ]
     )
 


### PR DESCRIPTION
The milestone number for where the project measurably is. Every 1.0 stage of SCOPE.md is in the catalog, the seven backends are written and reversed by `uninstall`, M5 is met on six VMs, and the whole catalog installed and verified on the field target. What separates this from 1.0 is verification and one decision (`docs/reference/release-1.0-checklist.md`). That is 0.9.0, and it is beta, not alpha.

## Changes

- `pyproject.toml`: 0.7.0 → 0.9.0; `hammunition --version` prints `hammunition 0.9.0`.
- `CHANGELOG.md`: the Unreleased entry becomes **v0.9.0 — 2026-09-13**, with the one-paragraph statement of what it is and what the missing 0.1 is; a fresh empty Unreleased above it.
- README: the header no longer says "Alpha — the hard 40% is still ahead" (the backends cover that 60%, verified); the status line says beta, v0.9.0; the "much of the catalog is still out of reach" paragraph now says what is true; the signing lines name v0.9.0 as annotated and unsigned like v0.7.0, with 1.0 the first signed tag.
- `docs/why-hammunition.md`: the state-of-the-project block says beta, v0.9.0, and carries today's counts (249 manifests, 24 devices, 297 identifiers).
- `docs/contributing/releasing.md`: the same two-tags-unsigned statement.
- The checklist's item 8 becomes the 1.0 bump and signed tag.
- `tests/test_launchers.py`: the fixture that fakes `--version` output follows the number.

Historical mentions of v0.7.0 (its date, that it was cut from a direct push) are left as history. `make check` green: 1899 passed, 21 skipped.

## After merge, the tag is the maintainer's

```
git checkout main && git pull
git tag -a v0.9.0 -m "v0.9.0 — beta: feature-complete for 1.0, verification remains"
git push origin v0.9.0
```

Annotated and unsigned, as `releasing.md` says every tag before the key is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
