### PR TITLE
README: the cryptocurrency icon sits in the same cell as its name and address

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,20 +425,16 @@ Everything is also collected at **[support.chiefgyk3d.com](https://support.chief
 <div align="center">
 <table>
   <tr>
-    <td align="center" width="60"><img src="media/icons/bitcoin.svg" width="28" height="28" alt="Bitcoin"></td>
-    <td><b>₿ Bitcoin</b><br><code>bc1qztdzcy2wyavj2tsuandu4p0tcklzttvdnzalla</code></td>
+    <td><img src="media/icons/bitcoin.svg" width="28" height="28" alt="Bitcoin" align="left">&nbsp;<b>₿ Bitcoin</b><br><code>bc1qztdzcy2wyavj2tsuandu4p0tcklzttvdnzalla</code></td>
   </tr>
   <tr>
-    <td align="center" width="60"><img src="media/icons/monero.svg" width="28" height="28" alt="Monero"></td>
-    <td><b>ɱ Monero</b><br><code>84Y34QubRwQYK2HNviezeH9r6aRcPvgW<wbr>mKtDkN3EwiuVbp6sNLhm9ffRgs6BA9X1<wbr>n9jY7wEN16ZEpiEngZbecXseUrW8SeQ</code></td>
+    <td><img src="media/icons/monero.svg" width="28" height="28" alt="Monero" align="left">&nbsp;<b>ɱ Monero</b><br><code>84Y34QubRwQYK2HNviezeH9r6aRcPvgWmKtDkN3EwiuVbp6sNLhm9ffRgs6BA9X1n9jY7wEN16ZEpiEngZbecXseUrW8SeQ</code></td>
   </tr>
   <tr>
-    <td align="center" width="60"><img src="media/icons/ethereum.svg" width="28" height="28" alt="Ethereum"></td>
-    <td><b>Ξ Ethereum</b><br><code>0x554f18cfB684889c3A60219BDBE7b050C39335ED</code></td>
+    <td><img src="media/icons/ethereum.svg" width="28" height="28" alt="Ethereum" align="left">&nbsp;<b>Ξ Ethereum</b><br><code>0x554f18cfB684889c3A60219BDBE7b050C39335ED</code></td>
   </tr>
   <tr>
-    <td align="center" width="60"><img src="media/icons/solana.svg" width="28" height="28" alt="Solana"></td>
-    <td><b>◎ Solana</b><br><code>5T8h3HbyvHgLxwXgchRYbHSqRjZyAr8J7uwjLN9Fh8Jh</code></td>
+    <td><img src="media/icons/solana.svg" width="28" height="28" alt="Solana" align="left">&nbsp;<b>◎ Solana</b><br><code>5T8h3HbyvHgLxwXgchRYbHSqRjZyAr8J7uwjLN9Fh8Jh</code></td>
   </tr>
 </table>
 </div>


### PR DESCRIPTION
#110's diagnosis was half right. Measured on the live page through Chromium's debugging protocol after it merged:

| image | loaded | natural size | laid-out size | its cell |
|---|---|---|---|---|
| bitcoin.svg | yes | 24×24 | **0×0** | 27 px, padding only |
| mastodon.svg | yes | 24×24 | 30×30 | 84 px |

The intrinsic size did not matter. GitHub's `max-width: 100%` on an image that is a table cell's only content resolves against a cell that sizes itself from the image, and Chromium collapses it to nothing; the social icons render because the caption text under each gives its cell a width.

The fix is structural: each crypto icon now sits in the same cell as its name and address, whose text sets the cell's width, and the empty first column is gone. The `<wbr>` tags from #110 are removed because GitHub's sanitizer strips them (0 in the live DOM), so the Monero address still runs past the page width on a narrow window; that is its 95 characters, and the table scrolls.

Verification after merge: the same debugging-protocol read, posted in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
