### PR TITLE
README: the currency symbol text goes; the icon carries it

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,16 +425,16 @@ Everything is also collected at **[support.chiefgyk3d.com](https://support.chief
 <div align="center">
 <table>
   <tr>
-    <td><img src="media/icons/bitcoin.svg" width="28" height="28" alt="Bitcoin">&nbsp;<b>₿ Bitcoin</b><br><code>bc1qztdzcy2wyavj2tsuandu4p0tcklzttvdnzalla</code></td>
+    <td><img src="media/icons/bitcoin.svg" width="28" height="28" alt="Bitcoin">&nbsp;<b>Bitcoin</b><br><code>bc1qztdzcy2wyavj2tsuandu4p0tcklzttvdnzalla</code></td>
   </tr>
   <tr>
-    <td><img src="media/icons/monero.svg" width="28" height="28" alt="Monero">&nbsp;<b>ɱ Monero</b><br><code>84Y34QubRwQYK2HNviezeH9r6aRcPvgWmKtDkN3EwiuVbp6sNLhm9ffRgs6BA9X1n9jY7wEN16ZEpiEngZbecXseUrW8SeQ</code></td>
+    <td><img src="media/icons/monero.svg" width="28" height="28" alt="Monero">&nbsp;<b>Monero</b><br><code>84Y34QubRwQYK2HNviezeH9r6aRcPvgWmKtDkN3EwiuVbp6sNLhm9ffRgs6BA9X1n9jY7wEN16ZEpiEngZbecXseUrW8SeQ</code></td>
   </tr>
   <tr>
-    <td><img src="media/icons/ethereum.svg" width="28" height="28" alt="Ethereum">&nbsp;<b>Ξ Ethereum</b><br><code>0x554f18cfB684889c3A60219BDBE7b050C39335ED</code></td>
+    <td><img src="media/icons/ethereum.svg" width="28" height="28" alt="Ethereum">&nbsp;<b>Ethereum</b><br><code>0x554f18cfB684889c3A60219BDBE7b050C39335ED</code></td>
   </tr>
   <tr>
-    <td><img src="media/icons/solana.svg" width="28" height="28" alt="Solana">&nbsp;<b>◎ Solana</b><br><code>5T8h3HbyvHgLxwXgchRYbHSqRjZyAr8J7uwjLN9Fh8Jh</code></td>
+    <td><img src="media/icons/solana.svg" width="28" height="28" alt="Solana">&nbsp;<b>Solana</b><br><code>5T8h3HbyvHgLxwXgchRYbHSqRjZyAr8J7uwjLN9Fh8Jh</code></td>
   </tr>
 </table>
 </div>


### PR DESCRIPTION
Removes the ₿ ɱ Ξ ◎ text added in #109 beside each cryptocurrency name; with the icons rendering since #111 it read doubled. Maintainer's call, 2026-09-13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)